### PR TITLE
Skip self-review requirement for bot PRs

### DIFF
--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   self-review-check:
     name: Self-Review Required
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - name: Check for Self-Review section


### PR DESCRIPTION
## Summary
- exempt bot-authored pull requests from the `Self-Review Required` workflow gate
- keep the self-review requirement in place for human-authored pull requests
- make Dependabot security update PRs eligible to pass required checks without manual body edits

## Testing
- verified the workflow diff is limited to the self-review job condition in `.github/workflows/pr-review-policy.yml`
- confirmed PR #6 is authored by `app/dependabot`, which is currently failing the self-review gate only because the old condition checks a single hard-coded login
- confirmed PR #6 changes only `functions/package-lock.json`, and `npm --prefix functions ci` succeeds on that PR branch

## Self-Review
- this change intentionally keys off `github.event.pull_request.user.type` so future bot-authored PRs are covered beyond a single Dependabot actor string
- the external-review labeling flow remains unchanged, so sensitive human-authored PRs still surface for extra review as before
- residual risk is low because the change only broadens the existing bot exemption; it does not alter the review requirement for user-authored PRs
