### PR TITLE
Close em dashes per Chicago/APA style

### DIFF
--- a/login.html
+++ b/login.html
@@ -34,12 +34,12 @@
                 </svg>
             </div>
             <h1 id="login-title">Friends &amp; Family Billing</h1>
-            <p class="hero-copy">The easiest way for families and close friends to track, split, and settle shared expenses — all year long, all in one place.</p>
+            <p class="hero-copy">The easiest way for families and close friends to track, split, and settle shared expenses—all year long, all in one place.</p>
 
             <div class="hero-points" aria-label="Product highlights">
                 <div class="hero-point">
                     <span class="hero-point-title">No more spreadsheets</span>
-                    <span class="hero-point-copy">See who owes what — instantly, for the whole year.</span>
+                    <span class="hero-point-copy">See who owes what—instantly, for the whole year.</span>
                 </div>
                 <div class="hero-point">
                     <span class="hero-point-title">One-tap invoicing</span>
@@ -131,7 +131,7 @@
                 <div class="trust-icons">
                     <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/></svg>
                 </div>
-                <p>Secured by Google &amp; Firebase.<br>Your data stays private and encrypted — always.</p>
+                <p>Secured by Google &amp; Firebase.<br>Your data stays private and encrypted—always.</p>
             </div>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- Removes spaces around em dashes in login page copy to match Chicago/APA convention

## Self-Review
- **Correctness:** Whitespace-only change in three lines of marketing copy
- **Regression risk:** None
- **Style/convention:** Matches user's stated style preference
- **Test coverage:** N/A
- **Security:** No changes to logic or inputs

## Test plan
- [ ] Verify login page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)