### PR TITLE
Add multi-identity AI agent code review policy

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -1,0 +1,57 @@
+# .github/review-policy.yml
+#
+# AI Agent Code Review Policy Configuration
+# See REVIEW_POLICY.md for full documentation.
+#
+# This file is read by AI coding agents at the start of every review cycle
+# to determine review requirements and identity configuration.
+
+# ---------------------------------------------------------------------------
+# External Review Threshold
+# ---------------------------------------------------------------------------
+# Total lines changed (additions + deletions) that trigger mandatory external
+# review by a different agent. The agent evaluates this after internal
+# self-peer review passes.
+#
+# Set to 0 to require external review on every PR.
+# Set to a very high number (e.g., 999999) to effectively disable.
+external_review_threshold: 300
+
+# ---------------------------------------------------------------------------
+# Protected Paths
+# ---------------------------------------------------------------------------
+# File paths that always require external review regardless of line count.
+# Glob patterns are supported. If any file in the PR diff matches a pattern
+# listed here, external review is mandatory.
+external_review_paths:
+  - "functions/**"
+  - "src/lib/**"
+  - "**/*secret*"
+  - "**/*credential*"
+  - ".github/**"
+
+# ---------------------------------------------------------------------------
+# Reviewer Identities
+# ---------------------------------------------------------------------------
+# Registered GitHub accounts that may post reviews. Each agent has exactly
+# one reviewer identity. To add a new agent, create a GitHub account
+# following the pattern nathanpayne-{agent} and add it here.
+available_reviewers:
+  - nathanpayne-claude
+  - nathanpayne-cursor
+  - nathanpayne-codex
+
+# ---------------------------------------------------------------------------
+# Default External Reviewer
+# ---------------------------------------------------------------------------
+# When the agent needs to suggest an external reviewer in a handoff message,
+# it defaults to this identity. The agent may override this suggestion based
+# on context (e.g., suggesting the agent with the most relevant expertise).
+default_external_reviewer: nathanpayne-codex
+
+# ---------------------------------------------------------------------------
+# Author Identity
+# ---------------------------------------------------------------------------
+# All agents commit code under this single shared identity.
+# Do not change this unless the repo owner account changes.
+author_identity: nathanjohnpayne

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,58 +10,38 @@ Agent instructions are organized into focused sub-files under `docs/agents/`. Re
 4. **[Documentation Rules](docs/agents/documentation-rules.md)** --- When and what to update
 5. **[Testing Requirements](docs/agents/testing-requirements.md)** --- Coverage expectations, test deletion policy
 6. **[Deployment Process](docs/agents/deployment-process.md)** --- Build/deploy flow, 1Password-backed auth
-7. **[Code Review Requirements](docs/agents/code-review-requirements.md)** --- Self-review, external review triggers, enforcement
 
-## PR Review Identities
+## Code Review Policy
 
-AI agents post reviews under dedicated GitHub accounts:
+This repository uses a multi-identity AI agent code review system. The full policy is in REVIEW_POLICY.md. The per-repo configuration is in .github/review-policy.yml.
 
-| Agent | GitHub username |
-|---|---|
-| Claude | @nathanpayne-claude |
-| Codex | @nathanpayne-codex |
-| Cursor | @nathanpayne-cursor |
+### Identity Rules
 
-These are bot accounts owned by @nathanjohnpayne. All three have Write access for PR review purposes only.
+- All agents author and commit code as nathanjohnpayne.
+- Each agent reviews code under its own reviewer identity (e.g., nathanpayne-claude, nathanpayne-cursor, nathanpayne-codex).
+- An agent never reviews code under the same identity that authored it.
+- Only nathanjohnpayne merges to the target branch.
 
-### Review tiers
+### Workflow Summary
 
-**Standard PRs** (under 300 lines of non-generated code, no infra/auth/architecture triggers):
-- One agent reviewer (not the author) may approve and merge.
-- The author must not approve or merge their own PR.
+1. Author code as nathanjohnpayne. File a PR.
+2. Switch to your reviewer identity (e.g., nathanpayne-claude). Review the PR. Post comments.
+3. Switch back to nathanjohnpayne. Address each comment. Push fix commits.
+4. Repeat steps 2–3 until the reviewer identity approves with no outstanding issues.
+5. Check .github/review-policy.yml for the external review threshold. If the PR meets the threshold (lines changed >= external_review_threshold OR files match external_review_paths), post a handoff message (see REVIEW_POLICY.md for format) and alert the human.
+6. If external review is not required, merge as nathanjohnpayne.
+7. If external review is required, wait for the human to relay external reviewer feedback. Resolve all issues through back-and-forth until the external reviewer approves.
+8. If the external reviewer flags observations or risks while approving, create a GitHub Issue for each one assigned to nathanjohnpayne with labels "post-review" and "observation" or "risk" before merging.
+9. Merge as nathanjohnpayne.
 
-**External-review PRs** (300+ lines, or infra/CI/CD/dep changes, or new architecture, or auth/data handling, or low-confidence code):
-- The PR is auto-labeled `needs-external-review`.
-- Two agent reviewers (neither the author) must both approve.
-- The authoring agent pushes a `review/pr-{number}-guidance` branch with a structured review guidance document.
-- The second approving reviewer removes the `needs-external-review` label, unblocking merge.
-- The author must not remove this label under any circumstances.
+### Disagreements
 
-**Human-escalated PRs:**
-- If agent reviewers disagree (one approves, one requests changes), the PR is auto-labeled `needs-human-review`.
-- If @nathanjohnpayne manually adds the `needs-human-review` label, agent-only merge is blocked.
-- Only @nathanjohnpayne may remove `needs-human-review` and approve.
+If the internal reviewer and external reviewer disagree, the human is the tiebreaker. Surface both positions clearly and wait.
 
-### Subagent invocation
+### Adding a New Agent
 
-When assigned as a reviewer, agents should automatically begin their review. The GitHub Actions workflow will trigger the appropriate agent. If headless invocation is not available for an agent (e.g., Cursor), the review must be performed manually.
+1. Create a GitHub account: nathanpayne-{agent}
+2. Add it to available_reviewers in .github/review-policy.yml.
+3. Configure the agent environment with credentials for both nathanjohnpayne and the new reviewer identity.
 
-### Review protocol
-
-- The authoring agent must **never** approve its own PR.
-- Cross-agent review rotation: Claude → Codex → Cursor → Claude.
-- For external-review PRs, the second reviewer is the remaining agent not already involved.
-- @nathanjohnpayne may review, approve, or merge any PR at any tier.
-
-### Review guidance (external reviews only)
-
-When your PR is labeled `needs-external-review`, you must:
-
-1. Create a branch named `review/pr-{number}-guidance` off the PR's head branch.
-2. Add a file `reviews/pr-{number}-guidance.md` using the template at `.github/templates/review-guidance.md`.
-3. Fill in all sections honestly—do not minimize risks or inflate confidence.
-4. Push the branch. Do not open a PR for this branch; it is a reference artifact only.
-5. Post a comment on the PR linking to the guidance file:
-   `Review guidance: [{repo}/blob/review/pr-{number}-guidance/reviews/pr-{number}-guidance.md]`
-
-External reviewers must read the guidance document before starting their review.
+For the complete policy including the handoff message format, post-merge issue creation rules, and git identity switching instructions, read REVIEW_POLICY.md.

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -1,0 +1,233 @@
+# AI Agent Code Review Policy
+
+## Overview
+
+This policy governs how AI coding agents author, review, and merge code across repositories owned by the `nathanjohnpayne` GitHub account. It enforces a structured peer review process where a single agent performs both authoring and self-review under separate GitHub identities, with mandatory external review by a different agent when complexity thresholds are met. All review activity occurs through GitHub PRs, producing a complete audit trail indistinguishable from multi-developer collaboration.
+
+## Identities
+
+### Author Identity
+
+All agents commit and push code under a single shared author identity:
+
+- **GitHub ID:** `nathanjohnpayne`
+- **Role:** Author, committer, and merger for all code changes
+- **Used by:** Whichever agent is currently writing or fixing code
+
+### Reviewer Identities
+
+Each agent has a dedicated reviewer identity used exclusively for code review:
+
+| Agent | Reviewer Identity |
+|-------|-------------------|
+| Claude | `nathanpayne-claude` |
+| Cursor | `nathanpayne-cursor` |
+| Codex | `nathanpayne-codex` |
+
+To add a new agent, register a GitHub account following the pattern `nathanpayne-{agent}` and add it to the `available_reviewers` list in the repo's `review-policy.yml`.
+
+### Identity Rules
+
+- An agent **never** reviews its own code under the same identity that authored it.
+- The author identity (`nathanjohnpayne`) is always the one that merges to the target branch.
+- Reviewer identities only post review comments, request changes, and approve PRs. They do not merge.
+
+## Workflow
+
+### Phase 1: Authoring
+
+1. The agent creates a feature branch from the target branch (e.g., `main`).
+2. The agent writes code as `nathanjohnpayne`, following all project-level rules (linting, testing, conventions).
+3. The agent files a PR from the feature branch to the target branch under `nathanjohnpayne`.
+
+### Phase 2: Internal Review (Self-Peer Review)
+
+4. The agent switches its Git identity to its reviewer account (e.g., `nathanpayne-claude`).
+5. The reviewer identity checks out the PR branch, reviews the diff, and posts review comments on the PR with specific, actionable feedback.
+6. The agent switches back to `nathanjohnpayne` and addresses each comment—pushing fix commits to the same branch.
+7. Steps 4–6 repeat until the reviewer identity approves the PR with no outstanding issues.
+
+**All review rounds are captured as GitHub PR comments and commits.** The back-and-forth should read like two developers collaborating.
+
+### Phase 3: External Review Threshold Check
+
+8. After internal review passes, the agent evaluates whether the PR meets the external review threshold (see [Review Policy Configuration](#review-policy-configuration)).
+9. If the threshold is **not** met, the agent merges the PR as `nathanjohnpayne`. Done.
+10. If the threshold **is** met, the agent posts a **handoff message** (see [Handoff Message Format](#handoff-message-format)) as a PR comment and alerts the human.
+
+### Phase 4: External Review
+
+11. The human takes the handoff message to a different agent (e.g., from Claude to Cursor, or from Cursor to Codex).
+12. The external agent's reviewer identity (e.g., `nathanpayne-codex`) reviews the PR and posts comments.
+13. The human relays the external reviewer's feedback back to the originating agent.
+14. The originating agent, as `nathanjohnpayne`, addresses the feedback and pushes fixes.
+15. The human shuttles updated code back to the external reviewer.
+16. Steps 12–15 repeat until the external reviewer approves.
+17. If the external reviewer flags **observations** or **risks** while approving, those are converted to GitHub Issues on the repo, assigned to `nathanjohnpayne` (see [Post-Merge Issue Creation](#post-merge-issue-creation)).
+18. `nathanjohnpayne` merges the PR. Done.
+
+### Flow Diagram
+
+```
+  ┌─────────────────────────────────────────────────────────┐
+  │  PHASE 1: AUTHOR                                        │
+  │  Agent writes code as nathanjohnpayne → files PR         │
+  └──────────────────────────┬──────────────────────────────┘
+                             │
+                             ▼
+  ┌─────────────────────────────────────────────────────────┐
+  │  PHASE 2: INTERNAL REVIEW                                │
+  │  Agent switches to nathanpayne-{agent}                   │
+  │  Reviews PR → posts comments                             │
+  │  Agent switches to nathanjohnpayne → fixes               │
+  │  ↻ Repeat until approved                                 │
+  └──────────────────────────┬──────────────────────────────┘
+                             │
+                             ▼
+  ┌─────────────────────────────────────────────────────────┐
+  │  PHASE 3: THRESHOLD CHECK                                │
+  │  Lines changed ≥ threshold OR protected paths touched?   │
+  │                                                          │
+  │  NO ──→ nathanjohnpayne merges. Done.                    │
+  │  YES ──→ Post handoff message. Alert human.              │
+  └──────────────────────────┬──────────────────────────────┘
+                             │
+                             ▼
+  ┌─────────────────────────────────────────────────────────┐
+  │  PHASE 4: EXTERNAL REVIEW                                │
+  │  Human hands PR to different agent                       │
+  │  External nathanpayne-{agent} reviews → posts comments   │
+  │  Human relays feedback to original agent                 │
+  │  nathanjohnpayne fixes → human relays back               │
+  │  ↻ Repeat until external reviewer approves               │
+  │                                                          │
+  │  Observations/risks → GitHub Issues                      │
+  │  nathanjohnpayne merges. Done.                           │
+  └─────────────────────────────────────────────────────────┘
+```
+
+## Handoff Message Format
+
+When external review is required, the originating agent posts a PR comment and surfaces the following to the human:
+
+```
+## External Review Required
+
+**PR:** #{pr_number} — {pr_title}
+**Branch:** {branch_name}
+**Author Agent:** {originating_agent}
+
+### Summary
+{2–4 sentence summary of what changed and why}
+
+### Focus Areas
+- {specific area 1 the external reviewer should scrutinize}
+- {specific area 2}
+- {specific area 3, if applicable}
+
+### Observations from Internal Review
+- {any concerns, trade-offs, or risks flagged during self-review}
+
+### Suggested External Reviewer
+nathanpayne-{suggested_agent}
+
+### Rationale for External Review
+{why the threshold was triggered: line count, protected paths, or both}
+```
+
+The human uses this message to brief the external agent. The external agent does not need access to the internal review thread—the handoff message contains everything needed to begin.
+
+## Post-Merge Issue Creation
+
+When an external reviewer approves a PR but flags observations or risks, the merging agent creates a GitHub Issue for each item before or immediately after merging:
+
+- **Title:** `[Post-Review] {brief description of observation/risk}`
+- **Body:** Full context from the reviewer's comment, including the PR number and relevant code references
+- **Assignee:** `nathanjohnpayne`
+- **Labels:** `post-review`, `observation` or `risk` as appropriate
+
+These issues are tracked like any other work item. They are not blockers to the merge—the external reviewer has approved—but they represent acknowledged technical debt or areas requiring follow-up.
+
+## Disagreements and Tiebreaking
+
+If the internal reviewer and external reviewer disagree on whether code is ready to merge, the human is the tiebreaker. The agent should surface the disagreement clearly, summarizing both positions, and wait for the human's decision.
+
+## Review Policy Configuration
+
+Each repository contains a `.github/review-policy.yml` file that governs review behavior. This file is read by the agent at the start of every review cycle.
+
+```yaml
+# .github/review-policy.yml
+
+# Lines changed (additions + deletions) that trigger external review.
+# Set to 0 to require external review on every PR.
+# Set to a very high number to effectively disable.
+external_review_threshold: 300
+
+# Paths that always require external review regardless of line count.
+# Glob patterns supported.
+external_review_paths:
+  - "src/auth/**"
+  - "src/payments/**"
+  - "**/*secret*"
+  - "**/*credential*"
+  - ".github/**"
+
+# Registered reviewer identities. Add new agents here.
+available_reviewers:
+  - nathanpayne-claude
+  - nathanpayne-cursor
+  - nathanpayne-codex
+
+# Default suggestion when the agent needs to recommend an external reviewer.
+# The agent may override this suggestion based on context.
+default_external_reviewer: nathanpayne-codex
+```
+
+### Threshold Evaluation
+
+A PR requires external review if **either** condition is true:
+
+1. Total lines changed (additions + deletions) ≥ `external_review_threshold`
+2. Any file in the PR diff matches a pattern in `external_review_paths`
+
+The agent evaluates this after internal review passes, before merging.
+
+## Git Identity Switching
+
+Agents must automate identity switching so that commits and PR activity are attributed to the correct GitHub account. The mechanism depends on the agent's environment, but the result must be:
+
+- Commits during authoring use `nathanjohnpayne`'s name and email.
+- Review comments and PR reviews are posted via `nathanpayne-{agent}`'s GitHub credentials.
+- The switch is fully automated within the agent session—no human intervention required for internal review.
+
+Example (Git CLI):
+
+```bash
+# Switch to author identity
+git config user.name "nathanjohnpayne"
+git config user.email "nathan@nathanjohnpayne.example"
+
+# Switch to reviewer identity
+git config user.name "nathanpayne-claude"
+git config user.email "claude@nathanpayne-claude.example"
+```
+
+Authentication for posting PR reviews under the reviewer identity requires a personal access token or GitHub App token for that account, configured in the agent's environment.
+
+## Adding a New Agent
+
+1. Create a GitHub account: `nathanpayne-{agent}`
+2. Generate a personal access token with `repo` scope for the new account.
+3. Add the identity to `available_reviewers` in each relevant repo's `.github/review-policy.yml`.
+4. Configure the new agent's environment with both the `nathanjohnpayne` author credentials and the `nathanpayne-{agent}` reviewer credentials.
+5. The new agent follows the same workflow described above.
+
+## Template Usage
+
+This policy and the accompanying `review-policy.yml` should be included in every new repository created under `nathanjohnpayne`. To bootstrap a new repo:
+
+1. Copy `.github/review-policy.yml` into the new repo's `.github/` directory.
+2. Copy this document into the repo as `REVIEW_POLICY.md` (or the location specified by your project template).
+3. Adjust `external_review_threshold`, `external_review_paths`, and `default_external_reviewer` to fit the project.
+4. Ensure all agent environments have credentials configured for the repo.

--- a/rules/repo_rules.md
+++ b/rules/repo_rules.md
@@ -62,5 +62,6 @@ The following checks are implemented in `scripts/ci/` and must pass before any c
 4. `check_dist_not_modified` — Verifies dist/ files were not directly modified (exits cleanly if dist/ does not exist)
 5. `check_spec_test_alignment` — Verifies every file in specs/ has a corresponding test file in tests/ (skips if specs/ is empty)
 6. `check_duplicate_docs` — Verifies no documentation topic is duplicated between root files and tool folders
+7. `check_review_policy_exists` — Verifies .github/review-policy.yml and REVIEW_POLICY.md both exist
 
 Additionally, `npm test` includes a secret scan (`scripts/check-no-public-secrets.mjs`) that must pass on every commit.


### PR DESCRIPTION
## Summary

Integrates the multi-identity AI agent code review policy into this repository.

## Files Added

- **`REVIEW_POLICY.md`** — Full review workflow documentation including identity rules, 4-phase review process, handoff message format, post-merge issue creation, and git identity switching instructions
- **`.github/review-policy.yml`** — Per-repo review policy configuration (thresholds, protected paths, reviewer identities)

## Files Modified

- **`AGENTS.md`** — Replaced the "PR Review Identities" section with a "Code Review Policy" section that references REVIEW_POLICY.md and .github/review-policy.yml. Removed the old "Code Review Requirements" link (line 7) since the new policy supersedes it.
- **`rules/repo_rules.md`** — Added `check_review_policy_exists` CI check to verify both .github/review-policy.yml and REVIEW_POLICY.md exist

## Path Customizations

The `external_review_paths` in `.github/review-policy.yml` have been customized for this billing repo:

- **Removed:** `src/auth/**` and `src/payments/**` (these directories do not exist in this repo)
- **Added:** `functions/**` (Cloud Functions — sensitive billing logic) and `src/lib/**` (contains payment calculations and billing year service)
- **Kept:** `**/*secret*`, `**/*credential*`, `.github/**`

## Test plan

- [ ] Verify `.github/review-policy.yml` exists and has correct customized paths
- [ ] Verify `REVIEW_POLICY.md` exists at repo root with full policy content
- [ ] Verify `AGENTS.md` has the new "Code Review Policy" section and no longer has the old "PR Review Identities" section or the line-7 code review requirements link
- [ ] Verify `rules/repo_rules.md` includes the new `check_review_policy_exists` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)