### PR TITLE
Add Authoring-Agent line to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+Authoring-Agent: <!-- claude | codex | cursor -->
+
 ## Summary
 - Describe the change.
 - Call out any user-visible behavior or deployment notes.


### PR DESCRIPTION
Adds the `Authoring-Agent:` line to the PR template so the reviewer assignment workflow can identify the originating agent.