### PR TITLE
Fix invalid YAML in pr-review-policy.yml

### DIFF
--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -138,15 +138,11 @@ jobs:
 
           FORMATTED_REASONS=$(echo "$REASONS" | sed 's/%0A/\n/g')
 
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
-**External Review Required**
+          COMMENT_BODY=$(printf '%s\n\n%s\n\n%s\n\n%s\n\n%s' \
+            '**External Review Required**' \
+            'This PR has been labeled `needs-external-review` based on .github/review-policy.yml:' \
+            "$FORMATTED_REASONS" \
+            'Per REVIEW_POLICY.md, the authoring agent must post a handoff message and alert the human. The human will coordinate external review by a different agent.' \
+            '> Automated check per .github/review-policy.yml')
 
-This PR has been labeled \`needs-external-review\` based on .github/review-policy.yml:
-
-$FORMATTED_REASONS
-
-Per REVIEW_POLICY.md, the authoring agent must post a handoff message and alert the human. The human will coordinate external review by a different agent.
-
-> Automated check per .github/review-policy.yml
-EOF
-          )"
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$COMMENT_BODY"


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Fix YAML parse error in `pr-review-policy.yml` caused by bare `**` (markdown bold) inside a `run: |` block being interpreted as a YAML alias token
- Replace shell heredoc with `printf` to construct the PR comment body without YAML-hostile characters
- This was the root cause of **Self-Review Required** and **Label Gate** status checks never reporting on PRs

## Self-Review
- **Correctness**: The `printf` approach produces identical comment output without triggering YAML parsing issues. Validated with `yaml.safe_load()`.
- **Regression risk**: Low — only changes how a PR comment body is constructed in the external-review labeling step. No logic changes.
- **Style/conventions**: Follows existing workflow patterns in the repo.
- **Test coverage**: YAML validity confirmed locally. The workflow will be tested by this PR itself (the status checks should now fire).
- **Security/dependency hygiene**: No new dependencies. No credential changes.