### PR TITLE
Fix Self-Review skip for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   self-review-check:
     name: Self-Review Required
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check for Self-Review section


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Change the Dependabot skip condition from `github.actor` to `github.event.pull_request.user.login`
- `github.actor` reflects whoever triggered the workflow run (which changes after `gh pr update-branch`), not the PR author
- This caused the Self-Review Required check to run and fail on Dependabot PRs after branch updates

## Self-Review
- **Correctness**: `github.event.pull_request.user.login` is the stable PR author field that persists across re-runs and branch updates.
- **Regression risk**: None — this only affects the skip condition for Dependabot PRs. Human/agent PRs are unaffected.
- **Style/conventions**: Consistent with GitHub Actions best practices for author-based conditions.
- **Test coverage**: Will be validated by future Dependabot PRs. The condition change is a single-line swap.
- **Security/dependency hygiene**: No new dependencies. No credential changes.