### PR TITLE
Fix update toast: add no-cache header for app/version.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -45,6 +45,15 @@
         ]
       },
       {
+        "source": "app/version.json",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
         "source": "share.html",
         "headers": [
           {


### PR DESCRIPTION
## Summary

Authoring-Agent: claude

The CDN was caching `app/version.json` for 1 hour (default `max-age=3600`), preventing the `UpdateToast` component from detecting new deploys. The existing `version.json` header rule only matched the root file, not the React app's copy at `app/version.json`.

## Self-Review

- **Correctness**: Adds matching `Cache-Control: no-cache, no-store, must-revalidate` header for `app/version.json`, consistent with the existing root `version.json` rule.
- **Regression risk**: None — only affects caching behavior of a single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)