### PR TITLE
Render share link as named hyperlink in preview

### DIFF
--- a/src/lib/invoice.js
+++ b/src/lib/invoice.js
@@ -130,11 +130,11 @@ function buildConfiguredInvoiceMessage(ctx, shareUrl, options) {
 
     // In markdown mode, convert bare share URLs (not already inside markdown links)
     // into named hyperlinks: "Name's Year Annual Billing Summary"
+    // Skip URLs already inside [...] (link text) or (...) (link destination)
     if (options && options.markdown && shareUrl) {
         const linkText = ctx.member.name + '\u2019s ' + ctx.currentYear + ' Annual Billing Summary';
         const escaped = shareUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        // Match the URL only when it's NOT inside (url) markdown link syntax
-        result = result.replace(new RegExp('(?<!\\()' + escaped + '(?!\\))', 'g'),
+        result = result.replace(new RegExp('(?<![\\[\\(])' + escaped + '(?![\\]\\)])', 'g'),
             '[' + linkText + '](' + shareUrl + ')');
     }
     return result;


### PR DESCRIPTION
## Summary

Authoring-Agent: claude

In markdown preview mode, `%share_link%` now renders as a named hyperlink — e.g., "[John Payne's 2026 Annual Billing Summary](url)" — instead of a raw URL. Uses the member name and billing year dynamically. Plain text mode (mailto/SMS) still uses the bare URL.

## Self-Review

- **Correctness**: Only applies in `{ markdown: true }` context (preview only). Name uses right single quote (Unicode \u2019) for the possessive. Plain text paths unchanged.
- **Regression risk**: None — markdown mode is only used in the Invoicing preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)