### PR TITLE
Include website in publicShares for share page logos

### DIFF
--- a/src/lib/share.js
+++ b/src/lib/share.js
@@ -99,6 +99,7 @@ function computeMemberSummaryForShare(familyMembers, bills, memberId) {
                 billId: bill.id,
                 name: bill.name,
                 logo: sanitizeImageSrc(bill.logo),
+                website: bill.website || '',
                 monthlyAmount: getBillMonthlyAmount(bill),
                 billingFrequency: bill.billingFrequency || 'monthly',
                 canonicalAmount: bill.amount,


### PR DESCRIPTION
## Summary

Authoring-Agent: claude

Adds `website` field to bill data in `computeMemberSummaryForShare()` so the share page CompanyLogo component can resolve logos via Logo.dev domain lookup. One-line addition.

Closes #74

## Self-Review

- **Correctness**: Adds `website: bill.website || ''` to the bill payload. Same pattern as `logo` field on the line above.
- **Regression risk**: None — additive field. Existing share pages without this field will continue to work (CompanyLogo falls back to name lookup then initials).
- **Note**: Existing publicShares documents won't have this field until regenerated. New share links will include it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)