### PR TITLE
Fix share page logos and clipboard error in share link generation

### DIFF
--- a/src/app/components/ShareLinkDialog.jsx
+++ b/src/app/components/ShareLinkDialog.jsx
@@ -92,8 +92,8 @@ export default function ShareLinkDialog({ open, memberId, memberName, userId, bi
 
             const url = buildShareUrl(window.location.origin, rawToken);
             setGeneratedUrl(url);
-            await navigator.clipboard.writeText(url);
-            if (showToast) showToast('Share link generated and copied!');
+            try { await navigator.clipboard.writeText(url); } catch (_) { /* clipboard may be blocked */ }
+            if (showToast) showToast('Share link generated!');
         } catch (err) {
             console.error('Failed to generate share link:', err);
             if (showToast) showToast('Failed to generate share link: ' + err.message);

--- a/src/main.js
+++ b/src/main.js
@@ -3789,6 +3789,7 @@ function computeMemberSummaryForShare(targetMemberId) {
                 billId: bill.id,
                 name: bill.name,
                 logo: sanitizeImageSrc(bill.logo),
+                website: bill.website || '',
                 monthlyAmount: getBillMonthlyAmount(bill),
                 billingFrequency: bill.billingFrequency || 'monthly',
                 canonicalAmount: bill.amount,


### PR DESCRIPTION
## Summary

Authoring-Agent: claude

Two fixes:
1. **Legacy `computeMemberSummaryForShare()`** was missing the `website` field — share links generated from the legacy app had no domain data for Logo.dev logo resolution on share pages.
2. **`ShareLinkDialog.jsx`** — `navigator.clipboard.writeText()` wasn't wrapped in try/catch, causing clipboard permission errors to show as "Failed to generate share link" even though the link was generated successfully.

## Self-Review

- **Correctness**: One-line data fix in legacy + one-line try/catch in React. Both match patterns already used elsewhere.
- **Regression risk**: None.
- **Test coverage**: 488 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)