### PR TITLE
Fix Manage tabs stuck on Loading... state

### DIFF
--- a/src/lib/BillingYearService.js
+++ b/src/lib/BillingYearService.js
@@ -85,6 +85,9 @@ export class BillingYearService {
 
     /** Call when auth state changes. Loads data for the user or resets. */
     async setUser(user) {
+        // Skip reload if the same user is already bound
+        if (user?.uid && user.uid === this._user?.uid) return;
+
         this._user = user;
         if (!user) {
             this._setState({


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- `BillingYearService.setUser()` was called on every component mount via `useBillingData()`'s `useEffect`, triggering a full Firestore reload even when the same user was already bound
- Added a UID guard to skip redundant reloads, eliminating the "Loading..." flash when switching between Manage tabs

Closes #86, closes #88, closes #89, closes #90, closes #91

## Self-Review
- **Correctness:** The guard `user?.uid && user.uid === this._user?.uid` correctly skips reload for the same user while still allowing: (a) initial binding when `_user` is null, (b) sign-out when `user` is null, (c) user switching
- **Regression risk:** Low — the only behavioral change is skipping redundant `_loadData()` calls. All 23 existing BillingYearService tests pass
- **Style:** Matches existing codebase patterns (early return guard)
- **Test coverage:** Existing test suite covers setUser behavior; 23/23 tests pass
- **Security/dependency hygiene:** No new dependencies, no security surface changes

## Test plan
- [ ] Navigate Dashboard → Manage → Members: should load instantly without "Loading..." flash
- [ ] Navigate Members → Bills → Invoicing: no loading state between tabs
- [ ] Sign out and sign in: data should still load correctly on first visit
- [ ] Switch billing years: should trigger a proper reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)