### PR TITLE
Remove decorative purple border-left from bill cards

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -970,7 +970,6 @@ img, svg { display: block; max-width: 100%; }
 .bill-card {
     background: var(--color-surface, #ffffff);
     border: 1px solid var(--color-border, #e0e0e0);
-    border-left: 3px solid var(--color-primary, #4A6FA5);
     border-radius: 12px;
     padding: var(--space-3, 16px);
 }


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Removed the 3px solid primary-color left border from `.bill-card` that served no semantic purpose (not indicating selection, status, or any meaningful state)
- Produces a cleaner, less cluttered Bills tab UI

Closes #92

## Self-Review
- **Correctness:** Single CSS property removal; no functional behavior change
- **Regression risk:** Minimal — purely cosmetic change to one class
- **Style:** Follows existing CSS organization in shell.css
- **Test coverage:** CSS-only change; no test impact
- **Security/dependency hygiene:** No dependencies or security surface changes

## Test plan
- [ ] Navigate to Manage → Bills tab: bill cards should render without the left purple border
- [ ] Verify bill card layout and spacing are otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)