### PR TITLE
Replace monospace font in Text Invoice textarea with system UI font

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1649,8 +1649,8 @@ img, svg { display: block; max-width: 100%; }
 
 .invoice-body-textarea {
     min-height: 100px;
-    font-family: monospace;
-    font-size: 0.82rem;
+    font-family: inherit;
+    font-size: 0.875rem;
     line-height: 1.5;
     resize: vertical;
 }


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Replaced `font-family: monospace` with `font-family: inherit` on `.invoice-body-textarea`
- Bumped `font-size` from `0.82rem` to `0.875rem` to match the app's standard input size
- The textarea now uses the app's system UI font stack, eliminating the dated monospace appearance

Closes #93

## Self-Review
- **Correctness:** Two CSS property changes; inherits the body's system font stack
- **Regression risk:** Minimal — only affects the Text Invoice Message textarea appearance
- **Style:** Consistent with how other textareas in the app inherit the system font
- **Test coverage:** CSS-only change; no test impact
- **Security/dependency hygiene:** No dependencies or security surface changes

## Test plan
- [ ] Open Dashboard → click "Text Invoice" on any member → verify the message textarea uses the modern system font
- [ ] Verify the textarea text is readable and well-sized

🤖 Generated with [Claude Code](https://claude.com/claude-code)