### PR TITLE
Move Payment Methods management to Settings page

### DIFF
--- a/src/app/components/PaymentMethodsManager.jsx
+++ b/src/app/components/PaymentMethodsManager.jsx
@@ -1,0 +1,269 @@
+/**
+ * PaymentMethodsManager — CRUD for payment methods (venmo, zelle, etc.).
+ * Extracted from InvoicingTab to be reused on the Settings page.
+ */
+import { useState, useRef } from 'react';
+import { PAYMENT_METHOD_TYPES, getPaymentMethodIcon, getPaymentMethodDetail } from '../../lib/formatting.js';
+import { isValidE164 } from '../../lib/validation.js';
+import ActionMenu, { ActionMenuItem } from './ActionMenu.jsx';
+import ConfirmDialog from './ConfirmDialog.jsx';
+
+export default function PaymentMethodsManager({ settings, readOnly, onUpdate }) {
+    const methods = settings.paymentMethods || [];
+    const [editTarget, setEditTarget] = useState(null);
+    const [deleteTarget, setDeleteTarget] = useState(null);
+    const [newType, setNewType] = useState('venmo');
+
+    function addMethod() {
+        const typeDef = PAYMENT_METHOD_TYPES[newType];
+        const method = {
+            id: 'pm_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
+            type: newType,
+            label: typeDef ? typeDef.label : newType,
+            enabled: true,
+            email: '', phone: '', handle: '', url: '', instructions: ''
+        };
+        onUpdate([...methods, method]);
+    }
+
+    function toggleEnabled(methodId) {
+        onUpdate(methods.map(m =>
+            m.id === methodId ? { ...m, enabled: !m.enabled } : m
+        ));
+    }
+
+    function removeMethod() {
+        if (!deleteTarget) return;
+        onUpdate(methods.filter(m => m.id !== deleteTarget.id));
+        setDeleteTarget(null);
+    }
+
+    function saveEdit(updated) {
+        onUpdate(methods.map(m => m.id === updated.id ? updated : m));
+        setEditTarget(null);
+    }
+
+    return (
+        <div className="invoicing-section">
+            <h3>Payment Methods</h3>
+            <p className="invoicing-hint">
+                Configure payment methods shown in invoices and on the share page.
+            </p>
+
+            {methods.length === 0 ? (
+                <p className="invoicing-empty">No payment methods configured yet.</p>
+            ) : (
+                <div className="payment-methods-list">
+                    {methods.map(method => (
+                        <div key={method.id} className={'payment-method-item' + (method.enabled ? '' : ' payment-method-disabled')}>
+                            <div className="payment-method-icon" dangerouslySetInnerHTML={{ __html: getPaymentMethodIcon(method.type) }} />
+                            <div className="payment-method-info">
+                                <strong>{method.label}</strong>
+                                {(method.qrCode || method.hasQrCode) && (
+                                    <span className="pm-qr-badge" title="QR code uploaded">
+                                        <img src="/qr-code.svg" alt="QR" className="pm-qr-icon" />
+                                    </span>
+                                )}
+                                <span className="payment-method-detail">{getPaymentMethodDetail(method)}</span>
+                            </div>
+                            {!readOnly && (
+                                <div className="payment-method-controls">
+                                    <label className="payment-method-toggle">
+                                        <input
+                                            type="checkbox"
+                                            checked={method.enabled}
+                                            onChange={() => toggleEnabled(method.id)}
+                                        />
+                                        <span className="toggle-label">{method.enabled ? 'On' : 'Off'}</span>
+                                    </label>
+                                    <ActionMenu label={'Actions for ' + method.label}>
+                                        <ActionMenuItem onClick={() => setEditTarget({ ...method })}>
+                                            Edit
+                                        </ActionMenuItem>
+                                        <ActionMenuItem onClick={() => setDeleteTarget(method)} danger>
+                                            Remove
+                                        </ActionMenuItem>
+                                    </ActionMenu>
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {!readOnly && (
+                <div className="payment-method-add">
+                    <select
+                        className="composer-input"
+                        value={newType}
+                        onChange={e => setNewType(e.target.value)}
+                    >
+                        {Object.entries(PAYMENT_METHOD_TYPES).map(([key, val]) => (
+                            <option key={key} value={key}>{val.label}</option>
+                        ))}
+                    </select>
+                    <button className="btn btn-sm btn-primary" onClick={addMethod}>
+                        Add Payment Method
+                    </button>
+                </div>
+            )}
+
+            <ConfirmDialog
+                open={deleteTarget !== null}
+                title="Remove Payment Method"
+                message={deleteTarget ? 'Remove ' + deleteTarget.label + '?' : ''}
+                confirmLabel="Remove"
+                destructive
+                onConfirm={removeMethod}
+                onCancel={() => setDeleteTarget(null)}
+            />
+
+            {editTarget && (
+                <PaymentMethodEditDialog
+                    method={editTarget}
+                    onSave={saveEdit}
+                    onCancel={() => setEditTarget(null)}
+                />
+            )}
+        </div>
+    );
+}
+
+// ── Payment Method Edit Dialog ──────────────────────────────────────
+
+function PaymentMethodEditDialog({ method, onSave, onCancel }) {
+    const [fields, setFields] = useState({ ...method });
+    const [error, setError] = useState('');
+    const qrInputRef = useRef(null);
+    const typeDef = PAYMENT_METHOD_TYPES[method.type] || { fields: ['url', 'instructions'] };
+
+    function update(key, value) {
+        setFields(prev => ({ ...prev, [key]: value }));
+        setError('');
+    }
+
+    function handleSave(e) {
+        e.preventDefault();
+        setError('');
+
+        const label = (fields.label || '').trim();
+        const defaultLabel = (PAYMENT_METHOD_TYPES[method.type] || PAYMENT_METHOD_TYPES.other).label;
+        const validated = { ...fields, label: label || defaultLabel };
+
+        const phone = (validated.phone || '').trim();
+        if (phone && !isValidE164(phone)) {
+            setError('Phone must be in E.164 format (e.g., +14155551212)');
+            return;
+        }
+        validated.phone = phone;
+
+        const url = (validated.url || '').trim();
+        if (url && !/^https?:\/\//i.test(url)) {
+            setError('URL must start with http:// or https://');
+            return;
+        }
+        validated.url = url;
+
+        if (validated.email) validated.email = validated.email.trim();
+        if (validated.handle) validated.handle = validated.handle.trim();
+        if (validated.instructions) validated.instructions = validated.instructions.trim();
+
+        onSave(validated);
+    }
+
+    const fieldDefs = {
+        handle: { label: 'Handle / Username', placeholder: '@username' },
+        email: { label: 'Email', placeholder: 'email@example.com', type: 'email' },
+        phone: { label: 'Phone', placeholder: '+14155551212', type: 'tel' },
+        url: { label: 'URL / Link', placeholder: 'https://', type: 'url' },
+        instructions: { label: 'Instructions (optional)', placeholder: 'Additional payment instructions...' }
+    };
+
+    return (
+        <div className="dialog-overlay" onClick={onCancel}>
+            <div className="dialog" onClick={e => e.stopPropagation()}>
+                <div className="dialog-title">Edit {method.label}</div>
+                <form onSubmit={handleSave}>
+                    <div className="payment-dialog-fields">
+                        <div className="payment-field-group">
+                            <label>Display Label</label>
+                            <input
+                                className="composer-input"
+                                value={fields.label}
+                                onChange={e => update('label', e.target.value)}
+                            />
+                        </div>
+                        {typeDef.fields.map(f => {
+                            const def = fieldDefs[f] || { label: f, placeholder: '' };
+                            return (
+                                <div key={f} className="payment-field-group">
+                                    <label>{def.label}</label>
+                                    {f === 'instructions' ? (
+                                        <textarea
+                                            className="composer-input"
+                                            rows={2}
+                                            placeholder={def.placeholder}
+                                            value={fields[f] || ''}
+                                            onChange={e => update(f, e.target.value)}
+                                        />
+                                    ) : (
+                                        <input
+                                            className="composer-input"
+                                            type={def.type || 'text'}
+                                            placeholder={def.placeholder}
+                                            value={fields[f] || ''}
+                                            onChange={e => update(f, e.target.value)}
+                                        />
+                                    )}
+                                </div>
+                            );
+                        })}
+                        <div className="payment-field-group">
+                            <label>QR Code (optional)</label>
+                            {fields.qrCode ? (
+                                <div className="pm-qr-preview">
+                                    <img src={fields.qrCode} alt="QR Code" className="pm-qr-image" />
+                                    <div className="pm-qr-actions">
+                                        <button type="button" className="btn btn-sm btn-secondary" onClick={() => qrInputRef.current && qrInputRef.current.click()}>
+                                            Replace
+                                        </button>
+                                        <button type="button" className="btn btn-sm btn-tertiary" style={{ color: 'var(--color-danger)' }} onClick={() => {
+                                            setFields(prev => ({ ...prev, qrCode: '', hasQrCode: false }));
+                                        }}>
+                                            Remove
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <button type="button" className="btn btn-sm btn-secondary" onClick={() => qrInputRef.current && qrInputRef.current.click()}>
+                                    Upload QR Code
+                                </button>
+                            )}
+                            <input
+                                ref={qrInputRef}
+                                type="file"
+                                accept="image/png,image/jpeg"
+                                style={{ display: 'none' }}
+                                onChange={e => {
+                                    const file = e.target.files && e.target.files[0];
+                                    if (!file) return;
+                                    const reader = new FileReader();
+                                    reader.onload = () => {
+                                        setFields(prev => ({ ...prev, qrCode: reader.result, hasQrCode: true }));
+                                    };
+                                    reader.readAsDataURL(file);
+                                    e.target.value = '';
+                                }}
+                            />
+                        </div>
+                    </div>
+                    {error && <p className="composer-error">{error}</p>}
+                    <div className="dialog-buttons">
+                        <button type="button" className="btn btn-sm btn-header-secondary" onClick={onCancel}>Cancel</button>
+                        <button type="submit" className="btn btn-sm btn-primary">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/src/app/views/Manage/InvoicingTab.jsx
+++ b/src/app/views/Manage/InvoicingTab.jsx
@@ -3,21 +3,19 @@
  * Port of renderEmailSettings() (main.js:2605) and renderPaymentMethodsSettings() (main.js:2696).
  */
 import { useState, useRef, useEffect } from 'react';
-import { doc, setDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '../../../lib/firebase.js';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 import { useBillingData } from '../../hooks/useBillingData.js';
 import { useToast } from '../../contexts/ToastContext.jsx';
-import { isYearReadOnly, isValidE164 } from '../../../lib/validation.js';
+import { isYearReadOnly } from '../../../lib/validation.js';
 import { detectDuplicatePaymentText } from '../../../lib/validation.js';
-import { PAYMENT_METHOD_TYPES, getPaymentMethodIcon, getPaymentMethodDetail } from '../../../lib/formatting.js';
 import { buildInvoiceBody, buildInvoiceSubject, getInvoiceSummaryContext, renderPreviewHTML } from '../../../lib/invoice.js';
 import { escapeHtml } from '../../../lib/formatting.js';
 import { generateRawToken, hashToken } from '../../../lib/validation.js';
 import { buildShareScopes, buildShareTokenDoc, buildShareUrl, buildPublicShareData, computeExpiryDate } from '../../../lib/share.js';
 import ShareLinkDialog from '../../components/ShareLinkDialog.jsx';
 import ActionMenu, { ActionMenuItem } from '../../components/ActionMenu.jsx';
-import ConfirmDialog from '../../components/ConfirmDialog.jsx';
 
 const EMAIL_TEMPLATE_FIELDS = [
     { token: '%billing_year%', label: 'Billing Year' },
@@ -25,36 +23,6 @@ const EMAIL_TEMPLATE_FIELDS = [
     { token: '%payment_methods%', label: 'Payment Methods' },
     { token: '%share_link%', label: 'Share Link' }
 ];
-
-/**
- * Sync QR codes to the publicQrCodes collection (mirrors main.js:3895).
- * Called after payment method updates to keep share pages in sync.
- */
-async function syncPublicQrCodes(userId, methods) {
-    if (!userId) return;
-    const methodsWithQr = (methods || []).filter(m => m.qrCode);
-    // Write/update QR codes for methods that have them
-    for (const m of methodsWithQr) {
-        const docId = userId + '_' + m.id;
-        try {
-            await setDoc(doc(db, 'publicQrCodes', docId), {
-                ownerId: userId,
-                methodId: m.id,
-                qrCode: m.qrCode,
-                updatedAt: serverTimestamp()
-            });
-        } catch (err) {
-            console.error('Error writing public QR code:', err);
-        }
-    }
-    // Delete QR codes for methods that no longer have them
-    const allMethods = methods || [];
-    const withoutQr = allMethods.filter(m => !m.qrCode && m.hasQrCode === false);
-    for (const m of withoutQr) {
-        const docId = userId + '_' + m.id;
-        try { await deleteDoc(doc(db, 'publicQrCodes', docId)); } catch (_) {}
-    }
-}
 
 export default function InvoicingTab() {
     const { familyMembers, bills, payments, activeYear, loading, service } = useBillingData();
@@ -83,15 +51,6 @@ export default function InvoicingTab() {
                 }}
                 onSaveShareUrl={invoiceShareUrl => {
                     service.updateSettings({ invoiceShareUrl });
-                }}
-            />
-            <PaymentMethodsSection
-                settings={settings}
-                readOnly={readOnly}
-                onUpdate={paymentMethods => {
-                    service.updateSettings({ paymentMethods });
-                    syncPublicQrCodes(user ? user.uid : null, paymentMethods);
-                    showToast('Payment methods updated');
                 }}
             />
         </div>
@@ -455,268 +414,3 @@ function placeCaretAtEnd(el) {
     }
 }
 
-// ── Payment Methods Manager ─────────────────────────────────────────
-
-function PaymentMethodsSection({ settings, readOnly, onUpdate }) {
-    const methods = settings.paymentMethods || [];
-    const [editTarget, setEditTarget] = useState(null);
-    const [deleteTarget, setDeleteTarget] = useState(null);
-    const [newType, setNewType] = useState('venmo');
-
-    function addMethod() {
-        const typeDef = PAYMENT_METHOD_TYPES[newType];
-        const method = {
-            id: 'pm_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
-            type: newType,
-            label: typeDef ? typeDef.label : newType,
-            enabled: true,
-            email: '', phone: '', handle: '', url: '', instructions: ''
-        };
-        onUpdate([...methods, method]);
-    }
-
-    function toggleEnabled(methodId) {
-        onUpdate(methods.map(m =>
-            m.id === methodId ? { ...m, enabled: !m.enabled } : m
-        ));
-    }
-
-    function removeMethod() {
-        if (!deleteTarget) return;
-        onUpdate(methods.filter(m => m.id !== deleteTarget.id));
-        setDeleteTarget(null);
-    }
-
-    function saveEdit(updated) {
-        onUpdate(methods.map(m => m.id === updated.id ? updated : m));
-        setEditTarget(null);
-    }
-
-    return (
-        <div className="invoicing-section">
-            <h3>Payment Methods</h3>
-            <p className="invoicing-hint">
-                Configure payment methods shown in invoices and on the share page.
-            </p>
-
-            {methods.length === 0 ? (
-                <p className="invoicing-empty">No payment methods configured yet.</p>
-            ) : (
-                <div className="payment-methods-list">
-                    {methods.map(method => (
-                        <div key={method.id} className={'payment-method-item' + (method.enabled ? '' : ' payment-method-disabled')}>
-                            <div className="payment-method-icon" dangerouslySetInnerHTML={{ __html: getPaymentMethodIcon(method.type) }} />
-                            <div className="payment-method-info">
-                                <strong>{method.label}</strong>
-                                {(method.qrCode || method.hasQrCode) && (
-                                    <span className="pm-qr-badge" title="QR code uploaded">
-                                        <img src="/qr-code.svg" alt="QR" className="pm-qr-icon" />
-                                    </span>
-                                )}
-                                <span className="payment-method-detail">{getPaymentMethodDetail(method)}</span>
-                            </div>
-                            {!readOnly && (
-                                <div className="payment-method-controls">
-                                    <label className="payment-method-toggle">
-                                        <input
-                                            type="checkbox"
-                                            checked={method.enabled}
-                                            onChange={() => toggleEnabled(method.id)}
-                                        />
-                                        <span className="toggle-label">{method.enabled ? 'On' : 'Off'}</span>
-                                    </label>
-                                    <ActionMenu label={'Actions for ' + method.label}>
-                                        <ActionMenuItem onClick={() => setEditTarget({ ...method })}>
-                                            Edit
-                                        </ActionMenuItem>
-                                        <ActionMenuItem onClick={() => setDeleteTarget(method)} danger>
-                                            Remove
-                                        </ActionMenuItem>
-                                    </ActionMenu>
-                                </div>
-                            )}
-                        </div>
-                    ))}
-                </div>
-            )}
-
-            {!readOnly && (
-                <div className="payment-method-add">
-                    <select
-                        className="composer-input"
-                        value={newType}
-                        onChange={e => setNewType(e.target.value)}
-                    >
-                        {Object.entries(PAYMENT_METHOD_TYPES).map(([key, val]) => (
-                            <option key={key} value={key}>{val.label}</option>
-                        ))}
-                    </select>
-                    <button className="btn btn-sm btn-primary" onClick={addMethod}>
-                        Add Payment Method
-                    </button>
-                </div>
-            )}
-
-            <ConfirmDialog
-                open={deleteTarget !== null}
-                title="Remove Payment Method"
-                message={deleteTarget ? 'Remove ' + deleteTarget.label + '?' : ''}
-                confirmLabel="Remove"
-                destructive
-                onConfirm={removeMethod}
-                onCancel={() => setDeleteTarget(null)}
-            />
-
-            {editTarget && (
-                <PaymentMethodEditDialog
-                    method={editTarget}
-                    onSave={saveEdit}
-                    onCancel={() => setEditTarget(null)}
-                />
-            )}
-        </div>
-    );
-}
-
-// ── Payment Method Edit Dialog ──────────────────────────────────────
-
-function PaymentMethodEditDialog({ method, onSave, onCancel }) {
-    const [fields, setFields] = useState({ ...method });
-    const [error, setError] = useState('');
-    const qrInputRef = useRef(null);
-    const typeDef = PAYMENT_METHOD_TYPES[method.type] || { fields: ['url', 'instructions'] };
-
-    function update(key, value) {
-        setFields(prev => ({ ...prev, [key]: value }));
-        setError('');
-    }
-
-    function handleSave(e) {
-        e.preventDefault();
-        setError('');
-
-        // Default blank label to type default (mirrors main.js:2908)
-        const label = (fields.label || '').trim();
-        const defaultLabel = (PAYMENT_METHOD_TYPES[method.type] || PAYMENT_METHOD_TYPES.other).label;
-        const validated = { ...fields, label: label || defaultLabel };
-
-        // Validate phone (E.164, mirrors main.js:2912)
-        const phone = (validated.phone || '').trim();
-        if (phone && !isValidE164(phone)) {
-            setError('Phone must be in E.164 format (e.g., +14155551212)');
-            return;
-        }
-        validated.phone = phone;
-
-        // Validate URL (http(s), mirrors main.js:2921)
-        const url = (validated.url || '').trim();
-        if (url && !/^https?:\/\//i.test(url)) {
-            setError('URL must start with http:// or https://');
-            return;
-        }
-        validated.url = url;
-
-        // Trim all string fields
-        if (validated.email) validated.email = validated.email.trim();
-        if (validated.handle) validated.handle = validated.handle.trim();
-        if (validated.instructions) validated.instructions = validated.instructions.trim();
-
-        onSave(validated);
-    }
-
-    const fieldDefs = {
-        handle: { label: 'Handle / Username', placeholder: '@username' },
-        email: { label: 'Email', placeholder: 'email@example.com', type: 'email' },
-        phone: { label: 'Phone', placeholder: '+14155551212', type: 'tel' },
-        url: { label: 'URL / Link', placeholder: 'https://', type: 'url' },
-        instructions: { label: 'Instructions (optional)', placeholder: 'Additional payment instructions...' }
-    };
-
-    return (
-        <div className="dialog-overlay" onClick={onCancel}>
-            <div className="dialog" onClick={e => e.stopPropagation()}>
-                <div className="dialog-title">Edit {method.label}</div>
-                <form onSubmit={handleSave}>
-                    <div className="payment-dialog-fields">
-                        <div className="payment-field-group">
-                            <label>Display Label</label>
-                            <input
-                                className="composer-input"
-                                value={fields.label}
-                                onChange={e => update('label', e.target.value)}
-                            />
-                        </div>
-                        {typeDef.fields.map(f => {
-                            const def = fieldDefs[f] || { label: f, placeholder: '' };
-                            return (
-                                <div key={f} className="payment-field-group">
-                                    <label>{def.label}</label>
-                                    {f === 'instructions' ? (
-                                        <textarea
-                                            className="composer-input"
-                                            rows={2}
-                                            placeholder={def.placeholder}
-                                            value={fields[f] || ''}
-                                            onChange={e => update(f, e.target.value)}
-                                        />
-                                    ) : (
-                                        <input
-                                            className="composer-input"
-                                            type={def.type || 'text'}
-                                            placeholder={def.placeholder}
-                                            value={fields[f] || ''}
-                                            onChange={e => update(f, e.target.value)}
-                                        />
-                                    )}
-                                </div>
-                            );
-                        })}
-                        <div className="payment-field-group">
-                            <label>QR Code (optional)</label>
-                            {fields.qrCode ? (
-                                <div className="pm-qr-preview">
-                                    <img src={fields.qrCode} alt="QR Code" className="pm-qr-image" />
-                                    <div className="pm-qr-actions">
-                                        <button type="button" className="btn btn-sm btn-secondary" onClick={() => qrInputRef.current && qrInputRef.current.click()}>
-                                            Replace
-                                        </button>
-                                        <button type="button" className="btn btn-sm btn-tertiary" style={{ color: 'var(--color-danger)' }} onClick={() => {
-                                            setFields(prev => ({ ...prev, qrCode: '', hasQrCode: false }));
-                                        }}>
-                                            Remove
-                                        </button>
-                                    </div>
-                                </div>
-                            ) : (
-                                <button type="button" className="btn btn-sm btn-secondary" onClick={() => qrInputRef.current && qrInputRef.current.click()}>
-                                    Upload QR Code
-                                </button>
-                            )}
-                            <input
-                                ref={qrInputRef}
-                                type="file"
-                                accept="image/png,image/jpeg"
-                                style={{ display: 'none' }}
-                                onChange={e => {
-                                    const file = e.target.files && e.target.files[0];
-                                    if (!file) return;
-                                    const reader = new FileReader();
-                                    reader.onload = () => {
-                                        setFields(prev => ({ ...prev, qrCode: reader.result, hasQrCode: true }));
-                                    };
-                                    reader.readAsDataURL(file);
-                                    e.target.value = '';
-                                }}
-                            />
-                        </div>
-                    </div>
-                    {error && <p className="composer-error">{error}</p>}
-                    <div className="dialog-buttons">
-                        <button type="button" className="btn btn-sm btn-header-secondary" onClick={onCancel}>Cancel</button>
-                        <button type="submit" className="btn btn-sm btn-primary">Save</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    );
-}

--- a/src/app/views/Settings/SettingsView.jsx
+++ b/src/app/views/Settings/SettingsView.jsx
@@ -1,17 +1,65 @@
+import { doc, setDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../../../lib/firebase.js';
+import { useAuth } from '../../contexts/AuthContext.jsx';
+import { useBillingData } from '../../hooks/useBillingData.js';
+import { useToast } from '../../contexts/ToastContext.jsx';
+import { isYearReadOnly } from '../../../lib/validation.js';
 import BillingYearSelector from '../../components/BillingYearSelector.jsx';
+import PaymentMethodsManager from '../../components/PaymentMethodsManager.jsx';
 
 /**
- * SettingsView — billing year controls + future settings panels.
+ * Sync QR codes to the publicQrCodes collection (mirrors InvoicingTab).
+ * Called after payment method updates to keep share pages in sync.
+ */
+async function syncPublicQrCodes(userId, methods) {
+    if (!userId) return;
+    const methodsWithQr = (methods || []).filter(m => m.qrCode);
+    for (const m of methodsWithQr) {
+        const docId = userId + '_' + m.id;
+        try {
+            await setDoc(doc(db, 'publicQrCodes', docId), {
+                ownerId: userId,
+                methodId: m.id,
+                qrCode: m.qrCode,
+                updatedAt: serverTimestamp()
+            });
+        } catch (err) {
+            console.error('Error writing public QR code:', err);
+        }
+    }
+    const allMethods = methods || [];
+    const withoutQr = allMethods.filter(m => !m.qrCode && m.hasQrCode === false);
+    for (const m of withoutQr) {
+        const docId = userId + '_' + m.id;
+        try { await deleteDoc(doc(db, 'publicQrCodes', docId)); } catch (_) {}
+    }
+}
+
+/**
+ * SettingsView — billing year controls + payment methods management.
  */
 export default function SettingsView() {
+    const { activeYear, loading, service } = useBillingData();
+    const { user } = useAuth();
+    const { showToast } = useToast();
+    const readOnly = isYearReadOnly(activeYear);
+    const settings = service.getState().settings || {};
+
     return (
         <div>
             <BillingYearSelector />
 
-            <div className="tab-placeholder">
-                <h3>Additional Settings</h3>
-                <p>Payment methods, email preferences, and account settings arrive in Phase 2.</p>
-            </div>
+            {!loading && (
+                <PaymentMethodsManager
+                    settings={settings}
+                    readOnly={readOnly}
+                    onUpdate={paymentMethods => {
+                        service.updateSettings({ paymentMethods });
+                        syncPublicQrCodes(user ? user.uid : null, paymentMethods);
+                        showToast('Payment methods updated');
+                    }}
+                />
+            )}
         </div>
     );
 }

--- a/tests/react/views/InvoicingTab.test.jsx
+++ b/tests/react/views/InvoicingTab.test.jsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
-// Mock Firebase (needed by InvoicingTab for publicQrCodes sync)
+// Mock Firebase (needed by InvoicingTab for share link generation)
 vi.mock('@/lib/firebase.js', () => ({ db: {} }));
 vi.mock('firebase/firestore', () => ({
-    doc: vi.fn(), setDoc: vi.fn(), deleteDoc: vi.fn(), serverTimestamp: vi.fn()
+    doc: vi.fn(), setDoc: vi.fn(), serverTimestamp: vi.fn()
 }));
 
 // Mock auth
@@ -64,28 +64,27 @@ describe('InvoicingTab', () => {
         expect(screen.getByText('Email Template')).toBeInTheDocument();
     });
 
-    it('renders payment methods section', () => {
+    it('does not render payment methods section (moved to Settings)', () => {
         renderTab();
-        // "Payment Methods" appears as both section heading and token chip — use getAllByText
-        expect(screen.getAllByText('Payment Methods').length).toBeGreaterThanOrEqual(1);
+        // Payment Methods heading should not appear as a section heading
+        // (it may still appear as a token chip label)
+        const pmElements = screen.queryAllByText('Payment Methods');
+        // Only the token chip insert button should remain, not a section heading
+        expect(pmElements.length).toBeLessThanOrEqual(2);
+        expect(screen.queryByText('Add Payment Method')).toBeNull();
     });
 
     it('shows template content in contenteditable editor', () => {
         renderTab();
         const editor = screen.getByRole('textbox');
-        // The editor renders token chips with labels, so "Household Total" chip should be present
         expect(editor).toBeInTheDocument();
         expect(editor.textContent).toContain('Household Total');
     });
 
     it('shows token insert buttons', () => {
         renderTab();
-        // Token chips appear as buttons AND in editor content — use getAllByText
         expect(screen.getAllByText('Billing Year').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Household Total').length).toBeGreaterThanOrEqual(1);
-        // "Payment Methods" also serves as token chip — confirmed by getAllByText
-        const pmElements = screen.getAllByText('Payment Methods');
-        expect(pmElements.length).toBeGreaterThanOrEqual(2); // heading + chip
     });
 
     it('shows live preview with To and Subject', () => {
@@ -101,29 +100,9 @@ describe('InvoicingTab', () => {
         expect(saveBtn).toBeInTheDocument();
     });
 
-    it('renders existing payment method', () => {
-        renderTab();
-        // "Venmo" appears in both the payment method card and the type dropdown
-        expect(screen.getAllByText('Venmo').length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('shows Add Payment Method button', () => {
-        renderTab();
-        expect(screen.getByText('Add Payment Method')).toBeInTheDocument();
-    });
-
-    it('adds a new payment method', () => {
-        renderTab();
-        fireEvent.click(screen.getByText('Add Payment Method'));
-        expect(mockService.updateSettings).toHaveBeenCalled();
-        const call = mockService.updateSettings.mock.calls[0][0];
-        expect(call.paymentMethods.length).toBe(2);
-    });
-
-    it('hides controls when year is read-only', () => {
+    it('hides save button when year is read-only', () => {
         renderTab({ activeYear: { id: '2024', label: '2024', status: 'archived' } });
         expect(screen.queryByText('Save Template')).toBeNull();
-        expect(screen.queryByText('Add Payment Method')).toBeNull();
     });
 
     it('shows duplicate payment text warning', () => {


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Extracted `PaymentMethodsManager` (with edit dialog) into a shared component at `src/app/components/PaymentMethodsManager.jsx`
- Removed payment methods UI from the Invoicing tab (`InvoicingTab.jsx`) — it now focuses solely on email template editing
- Added payment methods management to the Settings page (`SettingsView.jsx`), replacing the Phase 2 placeholder
- Updated InvoicingTab tests to reflect the removed payment methods section

Closes #87

## Self-Review
- **Correctness:** The extracted component is an exact copy of the original `PaymentMethodsSection` + `PaymentMethodEditDialog` — no logic changes. `syncPublicQrCodes` is called from SettingsView's `onUpdate` callback, preserving the share page sync behavior
- **Regression risk:** Medium — payment methods now live in a different location. Users navigating to Invoicing will no longer see them. This is the intended behavior per the issue
- **Style:** Component extraction follows existing patterns (props-driven, no internal data fetching)
- **Test coverage:** All 485 tests pass. InvoicingTab tests updated to verify payment methods are no longer rendered there. A follow-up could add SettingsView tests for the payment methods integration
- **Security/dependency hygiene:** No new dependencies. `syncPublicQrCodes` Firestore writes are unchanged

## Test plan
- [ ] Navigate to Settings: payment methods list should appear below Billing Year Selector
- [ ] Add, edit, toggle, and remove a payment method from Settings
- [ ] Navigate to Manage → Invoicing: verify payment methods section is gone
- [ ] Generate an invoice: verify payment methods still render correctly in the email preview (they're stored in settings, not tied to the tab)
- [ ] Check share page: QR codes should still sync correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)