### PR TITLE
Unify lifecycle state display and add actionable transitions

### DIFF
--- a/specs/settlement-board.md
+++ b/specs/settlement-board.md
@@ -55,11 +55,19 @@ Covers the settlement board component for tracking household payment status, the
 
 ### DashboardView
 
-- Renders billing year pill with label and status badge.
-- Renders KPI cards for Outstanding, Settled, Open Reviews, and Status.
-- Renders lifecycle bar with all four statuses (Open, Settling, Closed, Archived).
+- Renders billing year pill (no status badge—lifecycle state is communicated solely through the stepper).
+- Renders lifecycle bar (stepper) with all four statuses: Open → Settling → Closed → Archived. The stepper is the single authoritative lifecycle indicator on the dashboard.
+- Renders a forward lifecycle action button between the stepper and KPI grid:
+  - Open state: "Start Settlement" (enabled).
+  - Settling state, not ready: "Close Year" (disabled) with hint text showing how many members are still outstanding.
+  - Settling state, all paid: "Close Year" (enabled).
+  - Closed state: "Archive Year" (enabled).
+  - Archived state: no button.
+  - Each enabled button triggers a ConfirmDialog before executing the transition.
+- Renders KPI cards for Outstanding, Settled, and Open Reviews (3 cards; Status card removed as redundant with stepper).
+- Open Reviews card shows "Review requests" subtitle text below the count.
 - Renders progress bar with percentage and settlement message.
+- Progress bar headline is accurate for every lifecycle phase: "Planning in progress" (Open, < 100%), "Ready to start settlement" (Open, 100% settled), "Settlement in progress" (Settling), "Settlement complete" (Settling, all paid), "Year closed" (Closed), "Archive view" (Archived).
 - Shows empty state ("Add members and bills") when no members exist.
 - Shows loading state ("Loading...") when data is loading.
-- Settling status shows "Settlement in progress" message.
-- When settling and all members are paid, shows "Ready to Close" and "Settlement complete".
+- Backward lifecycle transitions (Back to Open, Reopen to Settling) are not available on the dashboard; they remain exclusively in Settings → Billing Controls.

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -201,19 +201,6 @@ img, svg { display: block; max-width: 100%; }
     color: var(--color-primary, #6E78D6);
 }
 
-.dashboard-status-badge {
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 2px 10px;
-    border-radius: 99px;
-}
-
-.dashboard-status-badge--open       { background: var(--color-primary-light); color: var(--color-primary); }
-.dashboard-status-badge--settling   { background: var(--color-warning-bg); color: var(--color-warning-fg); }
-.dashboard-status-badge--closed     { background: var(--color-success-light); color: var(--color-success); }
-.dashboard-status-badge--archived   { background: var(--color-surface-inset); color: var(--color-text-muted); }
-.dashboard-status-badge--ready      { background: var(--color-success-bg); color: var(--color-success-fg); }
-
 /* Lifecycle bar */
 .lifecycle-bar {
     display: flex;
@@ -244,10 +231,23 @@ img, svg { display: block; max-width: 100%; }
     font-size: 0.75rem;
 }
 
+/* Dashboard action button */
+.dashboard-action {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2, 8px);
+    margin-bottom: var(--space-3, 16px);
+}
+
+.dashboard-action-hint {
+    font-size: 0.75rem;
+    color: var(--color-text-muted, #666);
+}
+
 /* KPI grid */
 .kpi-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     gap: var(--space-2, 8px);
     margin-bottom: var(--space-3, 16px);
 }
@@ -287,6 +287,13 @@ img, svg { display: block; max-width: 100%; }
 
 .kpi-value.outstanding { color: var(--color-danger, #C65A5A); }
 .kpi-value.all-clear   { color: var(--color-success, #3FA37C); }
+
+.kpi-subtitle {
+    display: block;
+    font-size: 0.65rem;
+    color: var(--color-text-faint, #999);
+    margin-top: 1px;
+}
 
 /* Progress bar */
 .progress-block {

--- a/src/app/views/Dashboard/DashboardView.jsx
+++ b/src/app/views/Dashboard/DashboardView.jsx
@@ -12,6 +12,7 @@ import PaymentHistoryDialog from '../../components/PaymentHistoryDialog.jsx';
 import EmailInvoiceDialog from '../../components/EmailInvoiceDialog.jsx';
 import TextInvoiceDialog from '../../components/TextInvoiceDialog.jsx';
 import ShareLinkDialog from '../../components/ShareLinkDialog.jsx';
+import ConfirmDialog from '../../components/ConfirmDialog.jsx';
 
 /**
  * DashboardView — hero status panel + KPIs.
@@ -28,6 +29,8 @@ export default function DashboardView() {
 
     // Dialog state — which dialog is open and for which member
     const [dialog, setDialog] = useState({ type: null, memberId: null });
+    // Lifecycle action confirm dialog
+    const [confirmAction, setConfirmAction] = useState(null);
 
     if (loading) {
         return <p style={{ color: '#666', textAlign: 'center', marginTop: '2rem' }}>Loading…</p>;
@@ -59,15 +62,42 @@ export default function DashboardView() {
         ? 'Ready to Close'
         : (BILLING_YEAR_STATUSES[currentStatus] || BILLING_YEAR_STATUSES.open).label;
 
-    const statusBadgeClass = 'dashboard-status-badge dashboard-status-badge--'
-        + (isReadyToClose ? 'ready' : currentStatus);
-
     const statusHeadline = isReadyToClose
         ? 'Settlement complete'
-        : currentStatus === 'open' ? 'Planning in progress'
+        : currentStatus === 'open'
+            ? (metrics.percentage === 100 ? 'Ready to start settlement' : 'Planning in progress')
         : currentStatus === 'settling' ? 'Settlement in progress'
         : currentStatus === 'closed' ? 'Year closed'
         : 'Archive view';
+
+    // Forward lifecycle action (no backward transitions on dashboard)
+    let lifecycleAction = null;
+    if (currentStatus === 'open') {
+        lifecycleAction = {
+            label: 'Start Settlement',
+            newStatus: 'settling',
+            enabled: true,
+            title: 'Start Settlement',
+            message: 'Start settlement for ' + yearLabel + '?\n\nThis signals that invoices are going out and the year is moving toward collection.'
+        };
+    } else if (currentStatus === 'settling') {
+        lifecycleAction = {
+            label: 'Close Year',
+            newStatus: 'closed',
+            enabled: isReadyToClose,
+            disabledReason: remaining + ' member' + (remaining === 1 ? '' : 's') + ' still outstanding',
+            title: 'Close Year',
+            message: 'Close billing year ' + yearLabel + '?\n\nThis makes the year read-only. Any outstanding balances will be preserved.'
+        };
+    } else if (currentStatus === 'closed') {
+        lifecycleAction = {
+            label: 'Archive Year',
+            newStatus: 'archived',
+            enabled: true,
+            title: 'Archive Year',
+            message: 'Archive billing year ' + yearLabel + '?\n\nThis will make all records read-only. You can still view historical data later.'
+        };
+    }
 
     // Settlement message
     let settlementMessage = '';
@@ -96,10 +126,25 @@ export default function DashboardView() {
             <div className="dashboard-hero">
                 <div className="dashboard-meta">
                     <span className="dashboard-year-pill">Billing Year {yearLabel}</span>
-                    <span className={statusBadgeClass}>{statusLabel}</span>
                 </div>
 
                 <LifecycleBar currentStatus={currentStatus} currentOrder={currentOrder} isReadyToClose={isReadyToClose} />
+
+                {lifecycleAction && (
+                    <div className="dashboard-action">
+                        <button
+                            className="btn btn-primary btn-sm"
+                            disabled={!lifecycleAction.enabled}
+                            title={lifecycleAction.enabled ? undefined : lifecycleAction.disabledReason}
+                            onClick={lifecycleAction.enabled ? () => setConfirmAction(lifecycleAction) : undefined}
+                        >
+                            {lifecycleAction.label}
+                        </button>
+                        {!lifecycleAction.enabled && lifecycleAction.disabledReason && (
+                            <span className="dashboard-action-hint">{lifecycleAction.disabledReason}</span>
+                        )}
+                    </div>
+                )}
 
                 <div className="kpi-grid">
                     <KpiCard label="Outstanding" value={'$' + metrics.totalOutstanding.toFixed(2)}
@@ -108,9 +153,9 @@ export default function DashboardView() {
                     <KpiCard
                         label="Open Reviews"
                         value={String(openDisputeCount)}
+                        subtitle="Review requests"
                         onClick={openDisputeCount > 0 ? () => navigate('/manage/reviews') : undefined}
                     />
-                    <KpiCard label="Status" value={statusLabel} />
                 </div>
 
                 <div className="progress-block">
@@ -220,6 +265,24 @@ export default function DashboardView() {
                     />
                 );
             })()}
+
+            <ConfirmDialog
+                open={confirmAction !== null}
+                title={confirmAction ? confirmAction.title : ''}
+                message={confirmAction ? confirmAction.message : ''}
+                confirmLabel={confirmAction ? confirmAction.label : 'Confirm'}
+                onConfirm={async () => {
+                    const { newStatus } = confirmAction;
+                    setConfirmAction(null);
+                    try {
+                        await service.setYearStatus(newStatus);
+                        showToast(BILLING_YEAR_STATUSES[newStatus].label + '\u2014status updated.');
+                    } catch (err) {
+                        showToast('Error: ' + err.message);
+                    }
+                }}
+                onCancel={() => setConfirmAction(null)}
+            />
         </>
     );
 }
@@ -253,7 +316,7 @@ function LifecycleBar({ currentStatus, currentOrder, isReadyToClose }) {
 }
 
 /** Single KPI metric card. */
-function KpiCard({ label, value, valueClass = '', title = '', onClick }) {
+function KpiCard({ label, value, valueClass = '', subtitle = '', title = '', onClick }) {
     return (
         <div
             className={'kpi-card' + (onClick ? ' kpi-card--clickable' : '')}
@@ -263,6 +326,7 @@ function KpiCard({ label, value, valueClass = '', title = '', onClick }) {
         >
             <span className="kpi-label">{label}</span>
             <span className={'kpi-value' + (valueClass ? ' ' + valueClass : '')}>{value}</span>
+            {subtitle && <span className="kpi-subtitle">{subtitle}</span>}
         </div>
     );
 }

--- a/tests/react/views/DashboardView.test.jsx
+++ b/tests/react/views/DashboardView.test.jsx
@@ -26,7 +26,7 @@ const mockState = {
     settings: null,
     loading: false,
     error: null,
-    service: { getState: vi.fn(() => ({ settings: {} })), recordPayment: vi.fn(), reversePayment: vi.fn() },
+    service: { getState: vi.fn(() => ({ settings: {} })), recordPayment: vi.fn(), reversePayment: vi.fn(), setYearStatus: vi.fn() },
     saveQueue: { subscribe: vi.fn(() => () => {}) }
 };
 
@@ -44,31 +44,26 @@ import DashboardView from '@/app/views/Dashboard/DashboardView.jsx';
 import { useBillingData } from '@/app/hooks/useBillingData.js';
 
 function renderDashboard(overrides = {}) {
-    if (Object.keys(overrides).length > 0) {
-        useBillingData.mockReturnValue({ ...mockState, ...overrides });
-    }
+    useBillingData.mockReturnValue({ ...mockState, ...overrides });
     return render(<MemoryRouter><ToastProvider><DashboardView /></ToastProvider></MemoryRouter>);
 }
 
 describe('DashboardView', () => {
-    it('renders year pill and status badge', () => {
+    it('renders year pill without status badge', () => {
         renderDashboard();
         expect(screen.getByText('Billing Year 2026')).toBeInTheDocument();
-        // "Open" appears in badge, lifecycle, and KPI — use getAllByText
+        // "Open" appears once in the lifecycle bar only (badge removed)
         const openElements = screen.getAllByText('Open');
-        expect(openElements.length).toBeGreaterThanOrEqual(2);
-        // Status badge specifically
+        expect(openElements.length).toBe(1);
         expect(screen.getByText('Planning in progress')).toBeInTheDocument();
     });
 
-    it('renders KPI cards', () => {
+    it('renders KPI cards without Status card', () => {
         renderDashboard();
-        // "Outstanding" appears in KPI label + filter chip + status badges — use getAllByText
         expect(screen.getAllByText('Outstanding').length).toBeGreaterThanOrEqual(1);
-        // KPI labels should all be visible (some appear multiple times due to filter chips / badges)
         expect(screen.getAllByText('Settled').length).toBeGreaterThanOrEqual(1);
         expect(screen.getByText('Open Reviews')).toBeInTheDocument();
-        expect(screen.getAllByText('Status').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('Review requests')).toBeInTheDocument();
         // Open Reviews KPI shows real dispute count
         expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(1);
     });
@@ -112,8 +107,63 @@ describe('DashboardView', () => {
                 { memberId: 2, amount: 600, method: 'cash', note: '', date: new Date().toISOString(), type: 'payment' }
             ]
         });
-        const readyElements = screen.getAllByText('Ready to Close');
-        expect(readyElements.length).toBeGreaterThanOrEqual(1);
         expect(screen.getByText('Settlement complete')).toBeInTheDocument();
+    });
+
+    // Lifecycle action button tests
+
+    it('shows Start Settlement button when status is open', () => {
+        renderDashboard();
+        expect(screen.getByRole('button', { name: 'Start Settlement' })).toBeInTheDocument();
+    });
+
+    it('shows Close Year button when ready to close', () => {
+        renderDashboard({
+            activeYear: { id: '2026', label: '2026', status: 'settling' },
+            payments: [
+                { memberId: 1, amount: 600, method: 'cash', note: '', date: new Date().toISOString(), type: 'payment' },
+                { memberId: 2, amount: 600, method: 'cash', note: '', date: new Date().toISOString(), type: 'payment' }
+            ]
+        });
+        const btn = screen.getByRole('button', { name: 'Close Year' });
+        expect(btn).toBeInTheDocument();
+        expect(btn).not.toBeDisabled();
+    });
+
+    it('shows disabled Close Year button when settling but not ready', () => {
+        renderDashboard({
+            activeYear: { id: '2026', label: '2026', status: 'settling' },
+            payments: [{ memberId: 1, amount: 600, method: 'cash', note: '', date: new Date().toISOString() }]
+        });
+        const btn = screen.getByRole('button', { name: 'Close Year' });
+        expect(btn).toBeDisabled();
+        expect(screen.getByText('1 member still outstanding')).toBeInTheDocument();
+    });
+
+    it('shows Archive Year button when status is closed', () => {
+        renderDashboard({
+            activeYear: { id: '2026', label: '2026', status: 'closed' }
+        });
+        expect(screen.getByRole('button', { name: 'Archive Year' })).toBeInTheDocument();
+    });
+
+    it('shows no action button when status is archived', () => {
+        renderDashboard({
+            activeYear: { id: '2026', label: '2026', status: 'archived' }
+        });
+        expect(screen.queryByRole('button', { name: 'Start Settlement' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Close Year' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Archive Year' })).not.toBeInTheDocument();
+    });
+
+    it('shows corrected headline when open and 100% settled', () => {
+        renderDashboard({
+            payments: [
+                { memberId: 1, amount: 600, method: 'cash', note: '', date: new Date().toISOString(), type: 'payment' },
+                { memberId: 2, amount: 600, method: 'cash', note: '', date: new Date().toISOString(), type: 'payment' }
+            ]
+        });
+        expect(screen.getByText('Ready to start settlement')).toBeInTheDocument();
+        expect(screen.queryByText('Planning in progress')).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary
- **Remove redundancy**: Deleted status badge (next to year pill) and Status KPI card—lifecycle state communicated solely through the LifecycleBar stepper
- **Actionable transitions**: Added forward lifecycle button to dashboard (Start Settlement / Close Year / Archive Year) with ConfirmDialog confirmation, eliminating round-trip to Settings
- **Disabled state with reason**: Settling + not ready shows disabled "Close Year" button with "N members still outstanding" hint text
- **Open Reviews clarity**: Added "Review requests" subtitle below the count instead of a hover-only tooltip
- **Label consistency**: Fixed progress bar showing "Planning in progress" alongside "100% settled"—now shows "Ready to start settlement" in that edge case
- **KPI grid**: 4 → 3 cards; CSS grid updated to `repeat(3, 1fr)`

Authoring-Agent: claude

## Self-Review
- **Correctness**: All lifecycle transitions reuse `service.setYearStatus()` with identical confirmation messages to BillingYearSelector. No new state mutation paths introduced.
- **Regression risk**: Low—changes scoped to DashboardView and its CSS. No `src/lib/` changes (protected path untouched). Backward transitions remain exclusively in Settings.
- **Style**: Follows existing patterns (ConfirmDialog reuse, design tokens, CSS class naming). KpiCard subtitle prop is additive.
- **Test coverage**: 6 new tests (action button states, disabled button, corrected headline). Updated 2 existing tests. 14/14 DashboardView + 500/500 full suite pass.
- **Security/dependency**: No new dependencies. No user input interpolation changes.

## Test plan
- [x] `npx vitest run tests/react/views/DashboardView.test.jsx` — 14/14 pass
- [x] `npx vitest run` — 500/500 pass
- [ ] Visual: Open state shows "Start Settlement" button, 3 KPI cards, no status badge
- [ ] Visual: Settling (partial) shows disabled "Close Year" with outstanding count
- [ ] Visual: Settling (all paid) shows enabled "Close Year" + "Settlement complete"
- [ ] Visual: Closed shows "Archive Year" button
- [ ] Visual: Archived shows no action button
- [ ] Visual: Open + 100% settled shows "Ready to start settlement" headline

🤖 Generated with [Claude Code](https://claude.com/claude-code)