### PR TITLE
Move QR badge to controls row on payment method cards

### DIFF
--- a/src/app/components/PaymentMethodsManager.jsx
+++ b/src/app/components/PaymentMethodsManager.jsx
@@ -48,33 +48,35 @@ export default function PaymentMethodsManager({ settings, readOnly, onUpdate }) 
                             <div className="payment-method-icon" dangerouslySetInnerHTML={{ __html: getPaymentMethodIcon(method.type) }} />
                             <div className="payment-method-info">
                                 <strong>{method.label}</strong>
+                                <span className="payment-method-detail">{getPaymentMethodDetail(method)}</span>
+                            </div>
+                            <div className="payment-method-controls">
                                 {(method.qrCode || method.hasQrCode) && (
                                     <span className="pm-qr-badge" title="QR code uploaded">
                                         <img src="/qr-code.svg" alt="QR" className="pm-qr-icon" />
                                     </span>
                                 )}
-                                <span className="payment-method-detail">{getPaymentMethodDetail(method)}</span>
+                                {!readOnly && (
+                                    <>
+                                        <label className="payment-method-toggle">
+                                            <input
+                                                type="checkbox"
+                                                checked={method.enabled}
+                                                onChange={() => toggleEnabled(method.id)}
+                                            />
+                                            <span className="toggle-label">{method.enabled ? 'On' : 'Off'}</span>
+                                        </label>
+                                        <ActionMenu label={'Actions for ' + method.label}>
+                                            <ActionMenuItem onClick={() => setEditTarget({ ...method })}>
+                                                Edit
+                                            </ActionMenuItem>
+                                            <ActionMenuItem onClick={() => setDeleteTarget(method)} danger>
+                                                Remove
+                                            </ActionMenuItem>
+                                        </ActionMenu>
+                                    </>
+                                )}
                             </div>
-                            {!readOnly && (
-                                <div className="payment-method-controls">
-                                    <label className="payment-method-toggle">
-                                        <input
-                                            type="checkbox"
-                                            checked={method.enabled}
-                                            onChange={() => toggleEnabled(method.id)}
-                                        />
-                                        <span className="toggle-label">{method.enabled ? 'On' : 'Off'}</span>
-                                    </label>
-                                    <ActionMenu label={'Actions for ' + method.label}>
-                                        <ActionMenuItem onClick={() => setEditTarget({ ...method })}>
-                                            Edit
-                                        </ActionMenuItem>
-                                        <ActionMenuItem onClick={() => setDeleteTarget(method)} danger>
-                                            Remove
-                                        </ActionMenuItem>
-                                    </ActionMenu>
-                                </div>
-                            )}
                         </div>
                     ))}
                 </div>

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -2516,8 +2516,6 @@ img, svg { display: block; max-width: 100%; }
     display: inline-flex;
     align-items: center;
     padding: 2px 4px;
-    margin-left: 6px;
-    vertical-align: middle;
 }
 
 .pm-qr-icon {


### PR DESCRIPTION
## Summary
- Move QR badge from the info/label column to the controls row (right side), grouping it with the On/Off toggle and overflow menu: QR icon → On toggle → ⋯ menu
- Show QR badge in read-only mode too (it's status metadata, not a mutation control)
- Remove left margin from QR badge CSS (no longer inline with label text)

Authoring-Agent: claude

## Self-Review
- **Correctness**: QR badge rendering logic unchanged — just repositioned in the DOM. Controls div now always renders (for the QR badge) with mutation controls conditionally inside it via a Fragment.
- **Regression risk**: Minimal — 46 lines changed, purely structural JSX reorganization. No logic changes.
- **Style**: QR badge now groups naturally with other right-side indicators. Read-only mode shows QR + no toggles/menu.
- **Test coverage**: 500/500 full suite passes. No test changes needed — tests don't assert QR badge position.
- **Security/dependency**: No changes.

## Test plan
- [x] `npx vitest run` — 500/500 pass
- [ ] Visual: QR icon appears to the left of the On toggle on cards with QR codes
- [ ] Visual: Cards without QR codes show only toggle + menu (no empty gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)