### PR TITLE
Fix overflow menu clipping and dispute dialog formatting

### DIFF
--- a/src/app/components/DisputeDetailDialog.jsx
+++ b/src/app/components/DisputeDetailDialog.jsx
@@ -103,7 +103,7 @@ export default function DisputeDetailDialog({ open, dispute, onUpdate, onStatusC
 
     return (
         <div className="dialog-overlay" onClick={onClose}>
-            <div className="dialog dialog--wide" onClick={e => e.stopPropagation()}>
+            <div className="dialog dialog--wide dispute-detail-dialog" onClick={e => e.stopPropagation()}>
                 <div className="dispute-detail-header">
                     <div className="dispute-detail-title">
                         <strong>{dispute.billName || 'Unknown Bill'}</strong>

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1239,7 +1239,6 @@ img, svg { display: block; max-width: 100%; }
     background: var(--color-surface, #ffffff);
     border: 1px solid var(--color-border, #e0e0e0);
     border-radius: 12px;
-    overflow: hidden;
 }
 
 .settlement-card--outstanding { border-left: 3px solid var(--color-danger, #C65A5A); }
@@ -2343,6 +2342,10 @@ img, svg { display: block; max-width: 100%; }
 }
 
 /* Dispute Detail Dialog */
+.dispute-detail-dialog {
+    padding: var(--space-3, 16px) var(--space-4, 24px) var(--space-3, 16px);
+}
+
 .dispute-detail-header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- **#110**: Remove `overflow: hidden` from `.settlement-card` so the ActionMenu dropdown is no longer clipped by the card boundary
- **#108**: Add padding to the dispute detail dialog via `.dispute-detail-dialog` class so content has proper horizontal spacing

Closes #110, closes #108.

Authoring-Agent: claude

## Self-Review
- **Correctness**: The `overflow: hidden` was there to clip child content to rounded corners, but the card's children already respect the border-radius naturally (backgrounds are set on inner elements). Removing it allows the absolutely-positioned ActionMenu dropdown to render outside the card.
- **Regression risk**: Minimal — 7 lines changed. The settlement card border-radius still applies; the visual difference is only noticeable when an ActionMenu dropdown extends past the card edge (which is the desired behavior).
- **Style**: Dispute dialog padding uses the same `--space-3`/`--space-4` tokens used by the standard `.dialog-title` and `.dialog-buttons` for consistency.
- **Test coverage**: 500/500 full suite passes. No test changes needed — these are CSS-only fixes.
- **Security/dependency**: No changes.

## Test plan
- [x] `npx vitest run` — 500/500 pass
- [ ] Visual: ActionMenu dropdown on Settlement Board expanded detail is visible and not clipped
- [ ] Visual: Dispute detail dialog has proper padding and sections are not edge-to-edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)