### PR TITLE
docs: add no-direct-push-to-main rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ If any of these files are missing, flag the gap before proceeding.
 
 # Code Review — Mandatory Checklist
 
+Never push directly to `main`. All changes must go through a pull request.
+
 Every PR you open must follow this workflow. No exceptions unless the human
 explicitly authorizes a break-glass override in chat.
 

--- a/rules/repo_rules.md
+++ b/rules/repo_rules.md
@@ -32,6 +32,7 @@ The following tool config directories must contain only configuration — no ins
 
 ## Forbidden Patterns
 
+- **Never push directly to `main`.** All changes must go through a pull request—even single-line fixes, documentation updates, and deploy config changes. The only exception is if the human explicitly authorizes a direct push in chat as a break-glass override.
 - **Never edit the `app/` output directory directly.** It is a build artifact produced by Vite from `src/`. Always edit source in `src/` and run `npm run build` to regenerate.
 - **Never commit `.env.local`.** It contains the real Firebase web config as `VITE_FIREBASE_*` variables and is gitignored.
 - **Never commit credentials.** API keys, service account JSON, ADC credentials, Firebase web config, and tokens must never appear in tracked files. The `npm test` script includes a secret scan that will fail on detected credentials.


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Add explicit "never push directly to main" rule to `rules/repo_rules.md` Forbidden Patterns
- Add prominent reminder line to `CLAUDE.md` Code Review section
- Prevents agents from bypassing the PR review workflow

## Self-Review
- **Correctness:** Rule text is clear and matches existing break-glass override pattern
- **Regression risk:** None—documentation only
- **Style:** Consistent with existing forbidden pattern entries
- **Test coverage:** N/A (docs only)
- **Security/dependency hygiene:** No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)