### PR TITLE
fix: balanced bold-token regex and round-trip safe serialization

### DIFF
--- a/src/lib/invoice.js
+++ b/src/lib/invoice.js
@@ -174,7 +174,10 @@ export function docToPlainTextWithTokens(doc) {
             if (n.type === 'templateToken') {
                 const rawId = n.attrs?.id || '';
                 const id = LEGACY_TOKEN_IDS[rawId] || rawId;
-                return '%' + id + '%';
+                const token = '%' + id + '%';
+                // Preserve bold marks for round-trip safety
+                const hasBold = n.marks?.some(m => m.type === 'bold');
+                return hasBold ? '**' + token + '**' : token;
             }
             if (n.type === 'hardBreak') return '\n';
             return '';
@@ -229,8 +232,9 @@ export function docToPlainTextWithTokens(doc) {
 export function plainTextToDoc(text) {
     if (!text) return { type: 'doc', content: [{ type: 'paragraph' }] };
 
-    // Matches both %token% and **%token%** (bold-wrapped)
-    const tokenPattern = /(\*\*)?%([a-z_]+)%(\*\*)?/g;
+    // Matches **%token%** (bold-wrapped) or plain %token%.
+    // Bold requires both ** on each side — one-sided ** is left as literal text.
+    const tokenPattern = /\*\*%([a-z_]+)%\*\*|%([a-z_]+)%/g;
     const blockTokenIds = new Set(['payment_methods', 'share_link']);
     const tokenLabels = {
         first_name: 'First Name', last_name: 'Last Name', full_name: 'Full Name',
@@ -255,9 +259,10 @@ export function plainTextToDoc(text) {
 
         // Standalone block token on its own line
         tokenPattern.lastIndex = 0;
-        const soloMatch = trimmed.match(/^(?:\*\*)?%([a-z_]+)%(?:\*\*)?$/);
-        if (soloMatch && blockTokenIds.has(soloMatch[1])) {
-            const id = soloMatch[1];
+        const soloMatch = trimmed.match(/^(?:\*\*%([a-z_]+)%\*\*|%([a-z_]+)%)$/);
+        const soloId = soloMatch && (soloMatch[1] || soloMatch[2]);
+        if (soloId && blockTokenIds.has(soloId)) {
+            const id = soloId;
             content.push({
                 type: 'blockToken',
                 attrs: {
@@ -286,8 +291,8 @@ export function plainTextToDoc(text) {
         while ((match = tokenPattern.exec(line)) !== null) {
             const before = line.slice(lastIdx, match.index);
             if (before) nodes.push({ type: 'text', text: before });
-            const isBold = match[1] === '**' && match[3] === '**';
-            const tokenId = match[2];
+            const isBold = match[1] != null;
+            const tokenId = match[1] || match[2];
             if (tokenLabels[tokenId]) {
                 // Map legacy token IDs to new IDs
                 const normalizedId = tokenId === 'member_first' ? 'first_name'

--- a/tests/react/lib/invoice.test.js
+++ b/tests/react/lib/invoice.test.js
@@ -254,6 +254,33 @@ describe('docToPlainTextWithTokens', () => {
         expect(docToPlainTextWithTokens(null)).toBe('');
         expect(docToPlainTextWithTokens(undefined)).toBe('');
     });
+
+    it('preserves bold marks on tokens as **%token%**', () => {
+        const doc = {
+            type: 'doc',
+            content: [{
+                type: 'paragraph',
+                content: [
+                    { type: 'text', text: 'Total: ' },
+                    { type: 'templateToken', attrs: { id: 'household_total' }, marks: [{ type: 'bold' }] },
+                ]
+            }]
+        };
+        expect(docToPlainTextWithTokens(doc)).toBe('Total: **%household_total%**');
+    });
+
+    it('does not add ** for non-bold tokens', () => {
+        const doc = {
+            type: 'doc',
+            content: [{
+                type: 'paragraph',
+                content: [
+                    { type: 'templateToken', attrs: { id: 'first_name' } },
+                ]
+            }]
+        };
+        expect(docToPlainTextWithTokens(doc)).toBe('%first_name%');
+    });
 });
 
 describe('plainTextToDoc', () => {
@@ -297,6 +324,43 @@ describe('plainTextToDoc', () => {
         const doc = plainTextToDoc('');
         expect(doc.content.length).toBe(1);
         expect(doc.content[0].type).toBe('paragraph');
+    });
+
+    it('converts **%token%** to bold-marked token node', () => {
+        const doc = plainTextToDoc('Total: **%household_total%**');
+        const para = doc.content[0];
+        expect(para.content[0].text).toBe('Total: ');
+        const token = para.content[1];
+        expect(token.type).toBe('templateToken');
+        expect(token.attrs.id).toBe('household_total');
+        expect(token.marks).toEqual([{ type: 'bold' }]);
+    });
+
+    it('does not swallow one-sided ** around tokens', () => {
+        const doc = plainTextToDoc('**Hello %first_name%**');
+        const para = doc.content[0];
+        // The ** before Hello is prose text, not consumed by the token
+        expect(para.content[0].text).toBe('**Hello ');
+        // The token is plain (no bold) because ** is only on the right side of it
+        const token = para.content[1];
+        expect(token.type).toBe('templateToken');
+        expect(token.marks).toBeUndefined();
+        // The trailing ** is left as literal text
+        expect(para.content[2].text).toBe('**');
+    });
+
+    it('round-trips bold tokens through plainTextToDoc and docToPlainTextWithTokens', () => {
+        const input = 'Your total is **%household_total%**.';
+        const doc = plainTextToDoc(input);
+        const output = docToPlainTextWithTokens(doc);
+        expect(output).toBe(input);
+    });
+
+    it('round-trips plain tokens through plainTextToDoc and docToPlainTextWithTokens', () => {
+        const input = 'Hello %first_name%, your bill is ready.';
+        const doc = plainTextToDoc(input);
+        const output = docToPlainTextWithTokens(doc);
+        expect(output).toBe(input);
     });
 });
 


### PR DESCRIPTION
## Summary

- Fix P1: `plainTextToDoc` regex consumed one-sided `**` around tokens, corrupting legacy markdown templates on save
- Fix P2: `docToPlainTextWithTokens` now emits `**%token%**` for bold-marked tokens, making the plaintext fallback round-trip safe
- Add 6 targeted regression tests for round-trip safety

Resolves post-merge review findings from issue #145.

Authoring-Agent: claude

## Self-Review

### Correctness
- New regex `\*\*%([a-z_]+)%\*\*|%([a-z_]+)%` requires both `**` markers to match the bold branch; one-sided `**` falls through as literal text. Verified with test case: `"**Hello %first_name%**"` preserves the `**` around "Hello" and the trailing `**` as literal text.
- `docToPlainTextWithTokens` checks `n.marks?.some(m => m.type === 'bold')` and wraps with `**...**`. Round-trip test: `"Your total is **%household_total%**."` survives `plainTextToDoc → docToPlainTextWithTokens` unchanged.

### Regression Risk
- **Low**: The regex change only affects how `**` around tokens is parsed during legacy migration. Plain `%token%` matching is unaffected (separate alternation branch).
- Solo block token regex also updated to balanced form for consistency.

### Test Coverage
- 6 new tests covering: bold serialization, non-bold serialization, bold migration, one-sided `**` preservation, and two full round-trip cases.
- All 569 tests pass.

### Security / Dependencies
- No new dependencies. No network or auth changes.