### PR TITLE
fix: resolve five InvoicingTab bugs (#148–#152)

### DIFF
--- a/src/app/components/SubjectEditor.jsx
+++ b/src/app/components/SubjectEditor.jsx
@@ -82,6 +82,7 @@ function SubjectSlashCommands() {
  * @param {string} placeholder — optional placeholder text
  */
 const SubjectEditor = forwardRef(function SubjectEditor({ content, onUpdate, readOnly, placeholder }, ref) {
+    const isInternalUpdate = useRef(false);
     const editor = useEditor({
         extensions: [
             StarterKit.configure({
@@ -107,6 +108,7 @@ const SubjectEditor = forwardRef(function SubjectEditor({ content, onUpdate, rea
         content: subjectStringToDoc(content),
         editable: !readOnly,
         onUpdate({ editor: ed }) {
+            isInternalUpdate.current = true;
             if (onUpdate) onUpdate(ed.getText());
         },
         editorProps: {
@@ -158,7 +160,6 @@ const SubjectEditor = forwardRef(function SubjectEditor({ content, onUpdate, rea
     useImperativeHandle(ref, () => editor, [editor]);
 
     // Sync content when it changes externally (e.g., billing year switch)
-    const isInternalUpdate = useRef(false);
     useEffect(() => {
         if (editor && content !== undefined && !isInternalUpdate.current) {
             const currentText = editor.getText();

--- a/src/app/components/TemplateEditor.jsx
+++ b/src/app/components/TemplateEditor.jsx
@@ -125,6 +125,10 @@ function parsePastedTextWithTokens(text) {
  * The parent card structure (subject row, chip bar, save bar) is in InvoicingTab.
  */
 const TemplateEditor = forwardRef(function TemplateEditor({ content, onUpdate, readOnly, onConfigurePaymentMethods }, ref) {
+    // Guard to prevent the content-sync useEffect from re-entrantly calling
+    // setContent when the change originated from the editor's own onUpdate.
+    const isInternalUpdate = useRef(false);
+
     const editor = useEditor({
         extensions: [
             StarterKit.configure({
@@ -144,6 +148,7 @@ const TemplateEditor = forwardRef(function TemplateEditor({ content, onUpdate, r
         content: content || undefined,
         editable: !readOnly,
         onUpdate({ editor: ed }) {
+            isInternalUpdate.current = true;
             if (onUpdate) onUpdate(ed.getJSON());
         },
         editorProps: {
@@ -167,7 +172,6 @@ const TemplateEditor = forwardRef(function TemplateEditor({ content, onUpdate, r
     useImperativeHandle(ref, () => editor, [editor]);
 
     // Sync content when it changes externally (e.g., billing year switch)
-    const isInternalUpdate = useRef(false);
     useEffect(() => {
         if (editor && content && !isInternalUpdate.current) {
             const currentJSON = JSON.stringify(editor.getJSON());

--- a/src/app/components/TokenNode.js
+++ b/src/app/components/TokenNode.js
@@ -32,11 +32,13 @@ const TokenNode = Node.create({
         return [{ tag: 'span[data-token-id]' }];
     },
 
+    selectable: true,
+    draggable: false,
+
     renderHTML({ node, HTMLAttributes }) {
         return ['span', mergeAttributes(HTMLAttributes, {
             'data-token-id': node.attrs.id,
             class: 'template-editor-token',
-            contenteditable: 'false',
         }), node.attrs.label];
     },
 

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -681,6 +681,10 @@ img, svg { display: block; max-width: 100%; }
     padding-right: 0;
 }
 
+.dialog-body-padded {
+    padding: 0 var(--space-4, 24px) var(--space-3, 12px);
+}
+
 .dialog-header {
     padding: var(--space-3, 16px) var(--space-4, 24px);
     border-bottom: 1px solid var(--color-border, #e0e0e0);
@@ -2352,6 +2356,8 @@ img, svg { display: block; max-width: 100%; }
 }
 
 .invoice-preview-message li { margin-bottom: 4px; }
+.invoice-preview-message li p { margin-bottom: 0; }
+.invoice-preview-message li p + p { margin-top: 2px; }
 
 .invoice-preview-message hr {
     border: none;

--- a/src/app/views/Manage/InvoicingTab.jsx
+++ b/src/app/views/Manage/InvoicingTab.jsx
@@ -391,11 +391,13 @@ function EmailTemplateSection({ settings, familyMembers, bills, payments, active
                         <p className="invoicing-hint invoicing-hint--dialog">
                             Changes here update the payment methods block used in invoice emails.
                         </p>
-                        <PaymentMethodsManager
-                            settings={settings}
-                            readOnly={readOnly}
-                            onUpdate={methods => service.updateSettings({ paymentMethods: methods })}
-                        />
+                        <div className="dialog-body-padded">
+                            <PaymentMethodsManager
+                                settings={settings}
+                                readOnly={readOnly}
+                                onUpdate={methods => service.updateSettings({ paymentMethods: methods })}
+                            />
+                        </div>
                         <div className="dialog-buttons">
                             <button className="btn btn-sm btn-primary" onClick={() => setPaymentMethodsModal(false)}>Done</button>
                         </div>

--- a/src/lib/invoice.js
+++ b/src/lib/invoice.js
@@ -159,25 +159,32 @@ export function docToPlainTextWithTokens(doc) {
     if (!doc || !doc.content) return '';
     const blocks = [];
 
+    function wrapMarks(text, marks) {
+        if (!marks || marks.length === 0) return text;
+        let result = text;
+        if (marks.some(m => m.type === 'bold')) result = '**' + result + '**';
+        if (marks.some(m => m.type === 'italic')) result = '*' + result + '*';
+        return result;
+    }
+
     function textFromInline(nodes) {
         if (!nodes) return '';
         return nodes.map(n => {
             if (n.type === 'text') {
-                const text = n.text || '';
+                let text = n.text || '';
                 // Preserve link marks as markdown syntax
                 const linkMark = n.marks?.find(m => m.type === 'link');
                 if (linkMark && linkMark.attrs?.href) {
-                    return '[' + text + '](' + linkMark.attrs.href + ')';
+                    text = '[' + text + '](' + linkMark.attrs.href + ')';
                 }
-                return text;
+                // Wrap bold/italic marks as markdown
+                return wrapMarks(text, n.marks?.filter(m => m.type !== 'link'));
             }
             if (n.type === 'templateToken') {
                 const rawId = n.attrs?.id || '';
                 const id = LEGACY_TOKEN_IDS[rawId] || rawId;
                 const token = '%' + id + '%';
-                // Preserve bold marks for round-trip safety
-                const hasBold = n.marks?.some(m => m.type === 'bold');
-                return hasBold ? '**' + token + '**' : token;
+                return wrapMarks(token, n.marks);
             }
             if (n.type === 'hardBreak') return '\n';
             return '';


### PR DESCRIPTION
## Summary

- Fix #150: body/subject editors only accept one character at a time (re-entrant setContent loop)
- Fix #151: bold/italic formatting not showing in Preview tab (docToPlainTextWithTokens now emits markdown marks)
- Fix #152: cannot select tokens to apply bold (remove contenteditable="false" from TokenNode renderHTML)
- Fix #148: insufficient padding in Payment Methods modal (add .dialog-body-padded wrapper)
- Fix #149: payment options too spaced out in preview (collapse paragraph margins inside list items)

Closes #148, #149, #150, #151, #152.

Authoring-Agent: claude

## Self-Review

### Correctness
- **#150**: The root cause was `isInternalUpdate.current` never being set to `true` in `onUpdate`, causing the content-sync `useEffect` to call `setContent` on every keystroke (which fires another `onUpdate`, creating a loop that resets the cursor). Fix: set the flag in `onUpdate` before calling the parent callback. Moved the ref declaration before `useEditor` so it exists when `onUpdate` first fires.
- **#151**: `docToPlainTextWithTokens.textFromInline` now calls `wrapMarks()` on both text and token nodes, emitting `**text**` / `*text*` for bold/italic marks. The markdown renderer already handles these.
- **#152**: ProseMirror atom nodes are selectable by default, but the explicit `contenteditable="false"` attribute on the rendered span was preventing click events from reaching ProseMirror's selection handling. Removing it lets ProseMirror manage selectability.
- **#148**: Simple padding fix — wraps `PaymentMethodsManager` in a `div.dialog-body-padded`.
- **#149**: CommonMark loose lists wrap each `<li>` content in `<p>` tags. The `<p>` had `margin-bottom: 12px` from preview message styles. Fix: `li p { margin-bottom: 0 }`.

### Regression Risk
- **Low**: The `isInternalUpdate` fix is the most critical — it changes the timing of ref mutations relative to React renders. But the guard is simple: set `true` before parent callback, the `useEffect` checks and resets it.
- **Low**: `wrapMarks()` is additive — only fires when marks are present, which they weren't before TipTap.
- **Low**: Removing `contenteditable="false"` from TokenNode relies on ProseMirror's own `atom: true` to prevent editing. This is the standard pattern for TipTap atom nodes.

### Test Coverage
- 569 tests pass. The `isInternalUpdate` fix is difficult to unit-test (requires a real TipTap editor with React rendering loop), but the character-at-a-time symptom is easily verifiable manually.

### Security / Dependencies
- No new dependencies. No auth or network changes.