### PR TITLE
fix: prevent useEditor from recreating editor on every keystroke

### DIFF
--- a/src/app/components/SubjectEditor.jsx
+++ b/src/app/components/SubjectEditor.jsx
@@ -83,6 +83,9 @@ function SubjectSlashCommands() {
  */
 const SubjectEditor = forwardRef(function SubjectEditor({ content, onUpdate, readOnly, placeholder }, ref) {
     const isInternalUpdate = useRef(false);
+    const onUpdateRef = useRef(onUpdate);
+    onUpdateRef.current = onUpdate;
+
     const editor = useEditor({
         extensions: [
             StarterKit.configure({
@@ -109,7 +112,7 @@ const SubjectEditor = forwardRef(function SubjectEditor({ content, onUpdate, rea
         editable: !readOnly,
         onUpdate({ editor: ed }) {
             isInternalUpdate.current = true;
-            if (onUpdate) onUpdate(ed.getText());
+            onUpdateRef.current?.(ed.getText());
         },
         editorProps: {
             handleKeyDown(view, event) {

--- a/src/app/components/TemplateEditor.jsx
+++ b/src/app/components/TemplateEditor.jsx
@@ -129,6 +129,15 @@ const TemplateEditor = forwardRef(function TemplateEditor({ content, onUpdate, r
     // setContent when the change originated from the editor's own onUpdate.
     const isInternalUpdate = useRef(false);
 
+    // Store callbacks in refs so they're always current without appearing in
+    // useEditor's dependency array. A new onConfigurePaymentMethods function
+    // reference on every render (inline arrow in parent) would otherwise cause
+    // useEditor to tear down and recreate the editor on every keystroke.
+    const onUpdateRef = useRef(onUpdate);
+    const onConfigurePMRef = useRef(onConfigurePaymentMethods);
+    onUpdateRef.current = onUpdate;
+    onConfigurePMRef.current = onConfigurePaymentMethods;
+
     const editor = useEditor({
         extensions: [
             StarterKit.configure({
@@ -141,7 +150,9 @@ const TemplateEditor = forwardRef(function TemplateEditor({ content, onUpdate, r
                 placeholder: 'Type your message, or press / to insert a field\u2026',
             }),
             TokenNode,
-            BlockTokenNode.configure({ onConfigurePaymentMethods }),
+            BlockTokenNode.configure({
+                onConfigurePaymentMethods: () => onConfigurePMRef.current?.(),
+            }),
             SlashCommands(ALL_TOKENS),
             PercentCommands(ALL_TOKENS),
         ],
@@ -149,7 +160,7 @@ const TemplateEditor = forwardRef(function TemplateEditor({ content, onUpdate, r
         editable: !readOnly,
         onUpdate({ editor: ed }) {
             isInternalUpdate.current = true;
-            if (onUpdate) onUpdate(ed.getJSON());
+            onUpdateRef.current?.(ed.getJSON());
         },
         editorProps: {
             handlePaste(view, event) {
@@ -167,7 +178,7 @@ const TemplateEditor = forwardRef(function TemplateEditor({ content, onUpdate, r
                 return false;
             },
         },
-    }, [readOnly, onConfigurePaymentMethods]);
+    }, [readOnly]);
 
     useImperativeHandle(ref, () => editor, [editor]);
 


### PR DESCRIPTION
## Summary

- Fix the actual root cause of the "one character at a time" bug (#150)
- `useEditor`'s dep array included `onConfigurePaymentMethods` (an inline arrow function), causing TipTap to destroy and recreate the editor on every parent re-render
- Store callbacks in refs so the editor instance remains stable across renders

The previous fix in PR #153 (the `isInternalUpdate` guard) was necessary but insufficient — it only prevented re-entrant `setContent` calls. The editor was still being torn down by the dependency array change.

Authoring-Agent: claude

## Self-Review

### Correctness
- **Root cause confirmed**: `useEditor(..., [readOnly, onConfigurePaymentMethods])` — since `onConfigurePaymentMethods` is `() => setPaymentMethodsModal(true)` (inline arrow in parent), it's a new reference on every render. TipTap's `useEditor` destroys and recreates the editor when its dep array changes.
- **Fix**: `onUpdateRef` and `onConfigurePMRef` hold the latest callbacks. The `useEditor` config reads through the refs (`onUpdateRef.current?.(...)`, `() => onConfigurePMRef.current?.()`). The dep array is now `[readOnly]` only — the editor only recreates when readOnly toggles.
- Same pattern applied to SubjectEditor for consistency.

### Regression Risk
- **Low**: The ref pattern is standard React — callbacks are always current via ref assignment on every render. The only behavioral change is that the editor is no longer destroyed on every keystroke.

### Test Coverage
- 569 tests pass. This bug is fundamentally untestable in jsdom (requires real browser focus/input handling), but the root cause is clear from the code.

### Security / Dependencies
- No changes to dependencies, auth, or network.