### PR TITLE
fix: literal ellipsis in loading text

### DIFF
--- a/src/app/views/Manage/InvoicingTab.jsx
+++ b/src/app/views/Manage/InvoicingTab.jsx
@@ -37,7 +37,7 @@ export default function InvoicingTab() {
     const readOnly = isYearReadOnly(activeYear);
     const settings = service.getState().settings || {};
 
-    if (loading) return <p className="invoicing-loading">Loading\u2026</p>;
+    if (loading) return <p className="invoicing-loading">Loading…</p>;
 
     return (
         <div className="invoicing-tab">


### PR DESCRIPTION
## Summary
- Replace `\u2026` unicode escape in JSX text content with literal `…` character
- Unicode escapes only work inside JS strings, not in JSX text nodes

One-line fix. No `src/lib/` paths modified.

Authoring-Agent: claude

## Self-Review
Single character fix. No regression risk. 595 tests pass. No external review required (no protected paths, 2 lines changed).