### PR TITLE
fix: gate E2E hooks behind build flag and add E2E to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Run tests (React + secrets scan)
         run: npm test
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
       - name: Generate coverage report
         run: npm run test:coverage
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:legacy": "npm run build:legacy && node --test 'tests/*.test.js'",
     "test:react": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:e2e": "npm run build:react && npx playwright test",
+    "test:e2e": "VITE_E2E_MODE=true npm run build:react && npx playwright test",
     "test:secrets": "node scripts/check-no-public-secrets.mjs",
     "deploy": "op-firebase-deploy --only hosting,firestore:rules,storage",
     "deploy:functions": "op-firebase-deploy --only functions",

--- a/src/app/contexts/AuthContext.jsx
+++ b/src/app/contexts/AuthContext.jsx
@@ -9,7 +9,7 @@ const AuthContext = createContext(null);
  * Listens to Firebase onAuthStateChanged and exposes { user, loading, signOut }.
  */
 export function AuthProvider({ children }) {
-    const isE2E = typeof window !== 'undefined' && window.__E2E_USER__;
+    const isE2E = import.meta.env.VITE_E2E_MODE && typeof window !== 'undefined' && window.__E2E_USER__;
     const [user, setUser] = useState(isE2E ? window.__E2E_USER__ : null);
     const [loading, setLoading] = useState(!isE2E);
 

--- a/src/app/hooks/useBillingData.js
+++ b/src/app/hooks/useBillingData.js
@@ -8,8 +8,8 @@ import { useAuth } from '../contexts/AuthContext.jsx';
  */
 const service = new BillingYearService();
 
-// E2E mode: inject test data before React renders
-if (typeof window !== 'undefined' && window.__E2E_DATA__) {
+// E2E mode: inject test data before React renders (gated behind build flag)
+if (import.meta.env.VITE_E2E_MODE && typeof window !== 'undefined' && window.__E2E_DATA__) {
     service._injectTestState(window.__E2E_DATA__);
 }
 


### PR DESCRIPTION
## Summary

- **P3**: Gate `window.__E2E_USER__` and `window.__E2E_DATA__` checks behind `import.meta.env.VITE_E2E_MODE` so they're tree-shaken from standard production builds. Verified: 0 occurrences in the built bundle without the flag.
- **P2**: Add Playwright install + `npm run test:e2e` step to `.github/workflows/test.yml` so E2E tests run in CI and catch editor regressions.
- `test:e2e` script now sets `VITE_E2E_MODE=true` before `build:react` so the E2E build includes the hooks.

Authoring-Agent: claude

## Self-Review

### Correctness
- Standard `npm run build:react` produces a bundle with zero E2E hook references (verified with grep)
- `VITE_E2E_MODE=true npm run build:react` produces a bundle where the hooks are active
- 7/7 E2E tests pass against the flagged build, 595 unit tests pass

### Regression Risk
- **Low**: The only change to production-shipped code is adding `import.meta.env.VITE_E2E_MODE &&` before the existing window global checks. When the env var is absent (all production builds), Vite replaces it with `undefined` and the dead code is eliminated.

### Security
- E2E auth/data bypass no longer ships in production builds. An attacker cannot set `window.__E2E_USER__` to bypass auth in the deployed app.