### PR TITLE
chore: move misplaced docs into docs/ and remove orphaned stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ Data is organized per billing year under `/users/{userId}/billingYears/{yearId}`
 
 - **[AGENTS.md](AGENTS.md)** - AI agent instructions and technical reference
 - **[DEPLOYMENT.md](DEPLOYMENT.md)** - Detailed deployment instructions
-- **[QUICKSTART.md](QUICKSTART.md)** - Fast 10-minute setup
-- **[FIREBASE_IMPLEMENTATION.md](FIREBASE_IMPLEMENTATION.md)** - Firebase migration details
+- **[QUICKSTART.md](docs/QUICKSTART.md)** - Fast 10-minute setup
+- **[FIREBASE_IMPLEMENTATION.md](docs/FIREBASE_IMPLEMENTATION.md)** - Firebase migration details
 
 ## Troubleshooting
 

--- a/docs/FIREBASE_IMPLEMENTATION.md
+++ b/docs/FIREBASE_IMPLEMENTATION.md
@@ -1,6 +1,6 @@
 # Firebase Multi-User Implementation Summary
 
-> **Historical document.** This file describes the original vanilla-JS Firebase migration. The app has since been rewritten as a React SPA (see the React Migration changelog in README.md). File references like `firebase-config.js`, `script.js`, `login.html`, and deployment commands like `firebase deploy` no longer apply. For current architecture, see `docs/agents/repository-overview.md`. For deployment, see `DEPLOYMENT.md`.
+> **Historical document.** This file describes the original vanilla-JS Firebase migration. The app has since been rewritten as a React SPA (see the React Migration changelog in README.md). File references like `firebase-config.js`, `script.js`, `login.html`, and deployment commands like `firebase deploy` no longer apply. For current architecture, see `agents/repository-overview.md`. For deployment, see `../DEPLOYMENT.md`.
 
 ## What Was Added
 
@@ -210,8 +210,8 @@ You'd need thousands of daily active users to exceed the free tier!
 
 ## Support & Troubleshooting
 
-1. **Check QUICKSTART.md** for fast setup guide
-2. **Check DEPLOYMENT.md** for detailed instructions
+1. **Check QUICKSTART.md** (in this directory) for fast setup guide
+2. **Check [DEPLOYMENT.md](../DEPLOYMENT.md)** for detailed instructions
 3. **Browser console (F12)** shows error messages
 4. **Firebase Console** shows database activity and errors
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -64,7 +64,7 @@ npm install
 npm run deploy
 ```
 
-> **Note:** This repo uses `op-firebase-deploy` for deployments — see DEPLOYMENT.md for the 1Password-based credential setup. If Cloud Functions deployment shows IAM errors, that's OK — share links work via direct Firestore reads instead.
+> **Note:** This repo uses `op-firebase-deploy` for deployments — see [DEPLOYMENT.md](../DEPLOYMENT.md) for the 1Password-based credential setup. If Cloud Functions deployment shows IAM errors, that's OK — share links work via direct Firestore reads instead.
 
 #### 8. Done! 🎉
 Your app is now live at: `https://your-project-id.web.app`
@@ -94,7 +94,7 @@ Just send them your deployed URL. Each person:
 
 ### Need Help?
 
-- Check DEPLOYMENT.md for detailed instructions
+- Check [DEPLOYMENT.md](../DEPLOYMENT.md) for detailed instructions
 - Browser console (F12) shows error messages
 - Firebase console shows database activity
 

--- a/docs/agents/code-review-requirements.md
+++ b/docs/agents/code-review-requirements.md
@@ -1,9 +1,0 @@
-# Code Review Requirements
-
-This section has been consolidated into the repository-wide review policy.
-
-- **Full policy:** [REVIEW_POLICY.md](../../REVIEW_POLICY.md)
-- **Per-repo configuration:** [.github/review-policy.yml](../../.github/review-policy.yml)
-- **Summary in AGENTS.md:** See the "Code Review Policy" section
-
-All review behavior---identities, workflow, thresholds, handoff format, and post-merge issue rules---is governed by those files. Do not add review rules here; update REVIEW_POLICY.md instead.

--- a/docs/agents/documentation-rules.md
+++ b/docs/agents/documentation-rules.md
@@ -3,8 +3,8 @@
 - **`AGENTS.md` / `docs/agents/`:** Update the relevant sub-file when adding new features, new Cloud Functions, new Firestore collections, or new key modules/services. Update the index (`AGENTS.md`) only when adding or removing a section.
 - **`DEPLOYMENT.md`:** Update when the deploy process changes — new targets, credential rotation steps, new environment requirements.
 - **`README.md`:** Update when project description, live URL, or major features change.
-- **`QUICKSTART.md`:** Update when the local development setup process changes.
-- **`FIREBASE_IMPLEMENTATION.md`:** Update when the Firebase architecture changes significantly.
+- **`docs/QUICKSTART.md`:** Update when the local development setup process changes.
+- **`docs/FIREBASE_IMPLEMENTATION.md`:** Update when the Firebase architecture changes significantly.
 - **`rules/repo_rules.md`:** Update when directory structure changes or new invariants are needed.
 - **`.ai_context.md`:** Update when high-risk areas change or external dependencies change.
 


### PR DESCRIPTION
## Summary
- Move `FIREBASE_IMPLEMENTATION.md` and `QUICKSTART.md` from repo root to `docs/` (extended documentation, not required root files per `repo_rules.md`)
- Remove orphaned `docs/agents/code-review-requirements.md` (not referenced from `AGENTS.md` or anywhere else---just a stub redirecting to `REVIEW_POLICY.md`)
- Update all cross-references in `README.md`, `docs/agents/documentation-rules.md`, and the moved files

## Self-Review
- **Correctness:** All internal links updated to reflect new paths. CI checks all pass.
- **Regression risk:** Minimal---docs-only change. No code, tests, or build artifacts affected.
- **Style:** Commit message follows repo convention (`chore:` prefix).
- **Test coverage:** N/A---no code changes.
- **Security/dependency hygiene:** No dependencies or security-sensitive files touched.

Authoring-Agent: claude

## Test plan
- [x] All 6 CI enforcement scripts pass
- [x] No protected paths touched (functions/, src/lib/, .github/)
- [x] Cross-references verified in README.md, documentation-rules.md, and moved files

🤖 Generated with [Claude Code](https://claude.com/claude-code)