### PR TITLE
feat: preferred payment method + household billing hierarchy

### DIFF
--- a/src/app/components/PaymentMethodsManager.jsx
+++ b/src/app/components/PaymentMethodsManager.jsx
@@ -20,6 +20,10 @@ export default function PaymentMethodsManager({ settings, readOnly, onUpdate }) 
         ));
     }
 
+    function setPreferred(methodId) {
+        onUpdate(methods.map(m => ({ ...m, preferred: m.id === methodId })));
+    }
+
     function removeMethod() {
         if (!deleteTarget) return;
         onUpdate(methods.filter(m => m.id !== deleteTarget.id));
@@ -51,6 +55,15 @@ export default function PaymentMethodsManager({ settings, readOnly, onUpdate }) 
                                 <span className="payment-method-detail">{getPaymentMethodDetail(method)}</span>
                             </div>
                             <div className="payment-method-controls">
+                                <button
+                                    className={'payment-method-preferred-btn' + (method.preferred ? ' active' : '')}
+                                    title={method.preferred ? 'Preferred method' : 'Set as preferred'}
+                                    onClick={() => !readOnly && setPreferred(method.id)}
+                                    disabled={readOnly}
+                                    aria-label={method.preferred ? 'Preferred method' : 'Set as preferred'}
+                                >
+                                    {method.preferred ? '\u2605' : '\u2606'}
+                                </button>
                                 {(method.qrCode || method.hasQrCode) && (
                                     <span className="pm-qr-badge" title="QR code uploaded">
                                         <img src="/qr-code.svg" alt="QR" className="pm-qr-icon" />
@@ -107,6 +120,7 @@ export default function PaymentMethodsManager({ settings, readOnly, onUpdate }) 
                                 type: selectedType,
                                 label: typeDef ? typeDef.label : selectedType,
                                 enabled: true,
+                                preferred: false,
                                 email: '', phone: '', handle: '', url: '', instructions: ''
                             };
                             onUpdate([...methods, method]);

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -2458,6 +2458,24 @@ img, svg { display: block; max-width: 100%; }
     flex-shrink: 0;
 }
 
+.payment-method-preferred-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.1rem;
+    color: var(--color-text-secondary, #5B6475);
+    padding: 0;
+    line-height: 1;
+}
+
+.payment-method-preferred-btn.active {
+    color: var(--color-warning, #E0A84D);
+}
+
+.payment-method-preferred-btn:disabled {
+    cursor: default;
+}
+
 .payment-method-toggle {
     display: flex;
     align-items: center;
@@ -2906,11 +2924,24 @@ img, svg { display: block; max-width: 100%; }
     margin-bottom: var(--space-2, 8px);
 }
 
-.share-linked-block {
+.share-household-total {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin-bottom: var(--space-3, 12px);
+    color: var(--color-text, #1F2430);
+}
+
+.share-member-row {
     margin-top: var(--space-3, 12px);
 }
 
-.share-linked-toggle {
+.share-member-name {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 var(--space-2, 8px);
+}
+
+.share-member-toggle {
     display: flex;
     align-items: center;
     gap: var(--space-2, 8px);
@@ -2924,13 +2955,13 @@ img, svg { display: block; max-width: 100%; }
     text-align: left;
 }
 
-.share-linked-arrow {
+.share-member-arrow {
     display: inline-block;
     font-size: 0.65rem;
     transition: transform 0.15s ease;
 }
 
-.share-linked-arrow.expanded {
+.share-member-arrow.expanded {
     transform: rotate(90deg);
 }
 
@@ -3063,6 +3094,26 @@ img, svg { display: block; max-width: 100%; }
     padding: var(--space-3, 12px);
     display: flex;
     flex-direction: column;
+}
+
+.share-pm-card--preferred {
+    grid-column: span 2;
+    border-color: var(--color-primary, #4A6FA5);
+}
+
+@media (max-width: 550px) {
+    .share-pm-card--preferred {
+        grid-column: span 1;
+    }
+}
+
+.share-pm-preferred-badge {
+    font-size: 0.68rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--radius-pill, 20px);
+    background: rgba(74, 111, 165, 0.1);
+    color: var(--color-primary, #4A6FA5);
+    font-weight: 500;
 }
 
 .share-pm-header {

--- a/src/app/views/ShareView.jsx
+++ b/src/app/views/ShareView.jsx
@@ -111,7 +111,7 @@ export default function ShareView() {
     return (
         <div className="share-page">
             <ShareHeader data={data} />
-            {data.summary && <BillsSection data={data} canDispute={shareCtx.canDispute} shareCtx={shareCtx} />}
+            {data.summary && <HouseholdBillsSection data={data} canDispute={shareCtx.canDispute} shareCtx={shareCtx} />}
             {data.paymentSummary && <PaymentSummarySection ps={data.paymentSummary} year={data.year} />}
             {data.paymentMethods && data.paymentMethods.length > 0 && <PaymentMethodsSection methods={data.paymentMethods} ownerId={shareCtx.ownerId} />}
             {data.disputes && data.disputes.length > 0 && <DisputesSection disputes={data.disputes} shareCtx={shareCtx} />}
@@ -119,46 +119,70 @@ export default function ShareView() {
     );
 }
 
+function deriveLastName(fullName) {
+    if (!fullName) return '';
+    const parts = fullName.trim().split(/\s+/);
+    return parts.length > 1 ? parts[parts.length - 1] : fullName;
+}
+
 function ShareHeader({ data }) {
+    const lastName = deriveLastName(data.memberName);
     return (
         <header className="share-header">
-            <h1>{data.memberName}'s Annual Billing Summary</h1>
+            <h1>{lastName}'s Annual Billing Summary</h1>
             <p className="share-subtitle">Your shared billing summary for {data.year}.</p>
         </header>
     );
 }
 
-function LinkedMemberBlock({ lm, canDispute, onRequestReview }) {
-    const [expanded, setExpanded] = useState(false);
-    const billCount = lm.bills ? lm.bills.length : 0;
-    const monthlyTotal = lm.bills ? lm.bills.reduce((s, b) => s + (b.monthlyShare || 0), 0) : 0;
+function MemberRow({ member, canDispute, onRequestReview, defaultExpanded }) {
+    const [expanded, setExpanded] = useState(defaultExpanded);
+    const billCount = member.bills ? member.bills.length : 0;
+    const monthlyTotal = member.bills ? member.bills.reduce((s, b) => s + (b.monthlyShare || 0), 0) : 0;
+
+    if (defaultExpanded) {
+        return (
+            <div className="share-member-row">
+                <h3 className="share-member-name">{member.name}</h3>
+                <BillsTable bills={member.bills} canDispute={canDispute} onRequestReview={onRequestReview} />
+            </div>
+        );
+    }
 
     return (
-        <div className="share-linked-block">
-            <button className="share-linked-toggle" onClick={() => setExpanded(!expanded)} aria-expanded={expanded}>
-                <span className={'share-linked-arrow' + (expanded ? ' expanded' : '')}>&#9654;</span>
-                <span>{lm.name}—{billCount} shared {billCount === 1 ? 'bill' : 'bills'} ({formatCurrency(monthlyTotal)}/mo)</span>
+        <div className="share-member-row">
+            <button className="share-member-toggle" onClick={() => setExpanded(!expanded)} aria-expanded={expanded}>
+                <span className={'share-member-arrow' + (expanded ? ' expanded' : '')}>&#9654;</span>
+                <span>{member.name}—{billCount} {billCount === 1 ? 'bill' : 'bills'} ({formatCurrency(monthlyTotal)}/mo)</span>
             </button>
             {expanded && (
-                <>
-                    <p className="share-hint">Included in the linked-member portion of this annual summary.</p>
-                    <BillsTable bills={lm.bills} canDispute={canDispute} onRequestReview={onRequestReview} />
-                </>
+                <BillsTable bills={member.bills} canDispute={canDispute} onRequestReview={onRequestReview} />
             )}
         </div>
     );
 }
 
-function BillsSection({ data, canDispute, shareCtx }) {
+function HouseholdBillsSection({ data, canDispute, shareCtx }) {
     const [disputeForm, setDisputeForm] = useState(null);
+    const allMembers = [data.summary, ...(data.linkedMembers || [])];
+    const isSingleMember = allMembers.length === 1;
 
     return (
         <div className="share-section">
-            <h2>{data.memberName}'s Bills</h2>
-            <BillsTable bills={data.summary.bills} canDispute={canDispute} onRequestReview={bill => setDisputeForm(bill)} />
+            {!isSingleMember && data.paymentSummary && (
+                <div className="share-household-total">
+                    Household Total: {formatCurrency(data.paymentSummary.combinedMonthlyTotal)}/mo · {formatCurrency(data.paymentSummary.combinedAnnualTotal)}/yr
+                </div>
+            )}
 
-            {data.linkedMembers && data.linkedMembers.map(lm => (
-                <LinkedMemberBlock key={lm.memberId || lm.name} lm={lm} canDispute={canDispute} onRequestReview={bill => setDisputeForm(bill)} />
+            {allMembers.map(member => (
+                <MemberRow
+                    key={member.memberId || member.name}
+                    member={member}
+                    canDispute={canDispute}
+                    onRequestReview={bill => setDisputeForm(bill)}
+                    defaultExpanded={isSingleMember}
+                />
             ))}
 
             {disputeForm && (
@@ -280,11 +304,12 @@ function PaymentMethodsSection({ methods, ownerId }) {
             <h2>Payment Methods</h2>
             <p className="share-trust-note">Pay directly through the apps below—Friends &amp; Family Billing doesn't process payments.</p>
             <div className="share-pm-grid">
-                {methods.map((pm, i) => (
-                    <div key={pm.id || i} className="share-pm-card">
+                {[...methods].sort((a, b) => (b.preferred ? 1 : 0) - (a.preferred ? 1 : 0)).map((pm, i) => (
+                    <div key={pm.id || i} className={'share-pm-card' + (pm.preferred ? ' share-pm-card--preferred' : '')}>
                         <div className="share-pm-header">
                             <span className="share-pm-icon" dangerouslySetInnerHTML={{ __html: getPaymentMethodIcon(pm.type) }} />
                             <strong>{pm.label}</strong>
+                            {pm.preferred && <span className="share-pm-preferred-badge">Preferred</span>}
                         </div>
                         <div className="share-pm-body">
                             {pm.type === 'zelle' && [pm.email, pm.phone].filter(Boolean).map(c => (

--- a/tests/react/views/ShareView.test.jsx
+++ b/tests/react/views/ShareView.test.jsx
@@ -45,7 +45,7 @@ import ShareView from '@/app/views/ShareView.jsx';
 // ---------------------------------------------------------------------------
 
 const sampleShareData = {
-    memberName: 'Alice',
+    memberName: 'Alice Smith',
     year: '2024',
     ownerId: 'owner123',
     billingYearId: 'year2024',
@@ -53,6 +53,7 @@ const sampleShareData = {
     scopes: ['disputes:create', 'disputes:read'],
     summary: {
         memberId: 'member456',
+        name: 'Alice Smith',
         bills: [
             { billId: 'b1', name: 'Netflix', monthlyAmount: 15.99, splitCount: 2, monthlyShare: 8.00, annualShare: 96.00 },
             { billId: 'b2', name: 'Spotify', monthlyAmount: 9.99, splitCount: 3, monthlyShare: 3.33, annualShare: 39.96 }
@@ -78,6 +79,27 @@ const sampleShareData = {
             userReview: { state: 'requested' }
         }
     ]
+};
+
+const sampleShareDataWithLinkedMembers = {
+    ...sampleShareData,
+    linkedMembers: [
+        {
+            memberId: 'member789',
+            name: 'Bob Smith',
+            monthlyTotal: 5.00,
+            annualTotal: 60.00,
+            bills: [
+                { billId: 'b3', name: 'iCloud', monthlyAmount: 9.99, splitCount: 2, monthlyShare: 5.00, annualShare: 60.00 }
+            ]
+        }
+    ],
+    paymentSummary: {
+        combinedAnnualTotal: 195.96,
+        combinedMonthlyTotal: 16.33,
+        totalPaid: 50,
+        balanceRemaining: 145.96
+    }
 };
 
 function setToken(token) {
@@ -162,7 +184,7 @@ describe('ShareView', () => {
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText("Alice's Annual Billing Summary")).toBeInTheDocument();
+                expect(screen.getByText("Smith's Annual Billing Summary")).toBeInTheDocument();
             });
 
             // Verify updateDoc was called for access count bump
@@ -193,7 +215,7 @@ describe('ShareView', () => {
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText("Alice's Annual Billing Summary")).toBeInTheDocument();
+                expect(screen.getByText("Smith's Annual Billing Summary")).toBeInTheDocument();
             });
 
             // Confirm fetch was called with correct payload
@@ -258,15 +280,15 @@ describe('ShareView', () => {
     // -----------------------------------------------------------------------
     // 6. BillsSection renders bills table
     // -----------------------------------------------------------------------
-    describe('BillsSection', () => {
-        it('renders bill names, amounts, and totals', async () => {
+    describe('HouseholdBillsSection', () => {
+        it('renders bill names, amounts, and totals for single member', async () => {
             setToken('abc123');
             mockPublicSharesHit();
 
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText("Alice's Bills")).toBeInTheDocument();
+                expect(screen.getByText("Alice Smith")).toBeInTheDocument();
             });
 
             // Netflix appears in both bills table and disputes section
@@ -285,14 +307,14 @@ describe('ShareView', () => {
             expect(screen.getByText('TOTAL')).toBeInTheDocument();
         });
 
-        it('renders bills section heading with member name', async () => {
+        it('renders member name heading for single member', async () => {
             setToken('abc123');
             mockPublicSharesHit();
 
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText("Alice's Bills")).toBeInTheDocument();
+                expect(screen.getByText("Alice Smith")).toBeInTheDocument();
             });
         });
     });
@@ -320,7 +342,7 @@ describe('ShareView', () => {
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText("Alice's Bills")).toBeInTheDocument();
+                expect(screen.getByText("Alice Smith")).toBeInTheDocument();
             });
 
             expect(screen.queryAllByRole('button', { name: 'Question This' })).toHaveLength(0);
@@ -871,7 +893,7 @@ describe('ShareView', () => {
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText("Alice's Annual Billing Summary")).toBeInTheDocument();
+                expect(screen.getByText("Smith's Annual Billing Summary")).toBeInTheDocument();
             });
 
             expect(screen.queryByText('Payment Methods')).not.toBeInTheDocument();
@@ -885,7 +907,7 @@ describe('ShareView', () => {
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText("Alice's Annual Billing Summary")).toBeInTheDocument();
+                expect(screen.getByText("Smith's Annual Billing Summary")).toBeInTheDocument();
             });
 
             expect(screen.queryByText('Your Review Requests')).not.toBeInTheDocument();
@@ -905,6 +927,151 @@ describe('ShareView', () => {
             await waitFor(() => {
                 expect(screen.getByText(/Pay directly through the apps below/)).toBeInTheDocument();
             });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Household hierarchy
+    // -----------------------------------------------------------------------
+    describe('household hierarchy', () => {
+        it('derives last name for page title', async () => {
+            setToken('abc123');
+            mockPublicSharesHit();
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText("Smith's Annual Billing Summary")).toBeInTheDocument();
+            });
+        });
+
+        it('uses full name when single-word name', async () => {
+            setToken('abc123');
+            const singleNameData = { ...sampleShareData, memberName: 'Cher' };
+            mockPublicSharesHit(singleNameData);
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText("Cher's Annual Billing Summary")).toBeInTheDocument();
+            });
+        });
+
+        it('shows single member expanded with no household total', async () => {
+            setToken('abc123');
+            mockPublicSharesHit();
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+            });
+
+            // Bills should be visible (expanded by default for single member)
+            // Netflix appears in both bills table and disputes section
+            expect(screen.getAllByText('Netflix').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getByText('Spotify')).toBeInTheDocument();
+
+            // No household total line for single member
+            expect(screen.queryByText(/Household Total/)).not.toBeInTheDocument();
+        });
+
+        it('shows household total and collapsible members for multi-member', async () => {
+            setToken('abc123');
+            mockPublicSharesHit(sampleShareDataWithLinkedMembers);
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Household Total/)).toBeInTheDocument();
+            });
+
+            // Household total shows combined amounts
+            expect(screen.getByText(/\$16\.33\/mo/)).toBeInTheDocument();
+            expect(screen.getByText(/\$195\.96\/yr/)).toBeInTheDocument();
+
+            // Both members appear as toggle buttons
+            expect(screen.getByText(/Alice Smith/)).toBeInTheDocument();
+            expect(screen.getByText(/Bob Smith/)).toBeInTheDocument();
+        });
+
+        it('multi-member bills are collapsed by default', async () => {
+            setToken('abc123');
+            const noDisputesData = { ...sampleShareDataWithLinkedMembers, disputes: [] };
+            mockPublicSharesHit(noDisputesData);
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Household Total/)).toBeInTheDocument();
+            });
+
+            // Individual bill names should NOT be visible (collapsed)
+            // (disputes removed to avoid Netflix appearing in disputes section)
+            expect(screen.queryByText('Netflix')).not.toBeInTheDocument();
+            expect(screen.queryByText('iCloud')).not.toBeInTheDocument();
+        });
+
+        it('expands member on click to show bills', async () => {
+            const user = userEvent.setup();
+            setToken('abc123');
+            const noDisputesData = { ...sampleShareDataWithLinkedMembers, disputes: [] };
+            mockPublicSharesHit(noDisputesData);
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Alice Smith/)).toBeInTheDocument();
+            });
+
+            // Click to expand Alice's section
+            await user.click(screen.getByText(/Alice Smith/));
+
+            // Now Netflix and Spotify should appear
+            await waitFor(() => {
+                expect(screen.getByText('Netflix')).toBeInTheDocument();
+                expect(screen.getByText('Spotify')).toBeInTheDocument();
+            });
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Preferred payment method
+    // -----------------------------------------------------------------------
+    describe('preferred payment method', () => {
+        it('renders preferred card first with badge and class', async () => {
+            setToken('abc123');
+            const dataWithPreferred = {
+                ...sampleShareData,
+                paymentMethods: [
+                    { id: 'pm1', type: 'venmo', label: 'Venmo', handle: '@john' },
+                    { id: 'pm2', type: 'zelle', label: 'Zelle', email: 'pay@example.com', preferred: true }
+                ]
+            };
+            mockPublicSharesHit(dataWithPreferred);
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Preferred')).toBeInTheDocument();
+            });
+
+            // Zelle (preferred) should render with the preferred badge
+            expect(screen.getByText('Zelle')).toBeInTheDocument();
+            expect(screen.getByText('Venmo')).toBeInTheDocument();
+        });
+
+        it('does not render preferred badge when no method is preferred', async () => {
+            setToken('abc123');
+            mockPublicSharesHit();
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Venmo')).toBeInTheDocument();
+            });
+
+            expect(screen.queryByText('Preferred')).not.toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

- Add preferred payment method: star toggle in admin settings, double-width card with "Preferred" badge on share page
- Flatten household billing hierarchy: all members rendered as equal collapsible rows under a household total line, page title uses household last name
- Single-member households render bills expanded directly (no collapsible wrapper, no household total line)

## Self-Review

**Correctness:** Both features implemented as specified. The preferred toggle uses exclusive selection (clicking one deselects others). The household restructure properly handles single-member (expanded, no total line) vs multi-member (all collapsed, total line shown). Last name derivation uses simple `split(' ').pop()` with single-word fallback.

**Regression risk:** Medium. The `BillsSection` → `HouseholdBillsSection` restructure replaces the existing primary-member rendering path. However, the single-member code path preserves equivalent behavior (bills expanded by default, member name shown). All 892 tests pass (287 node + 605 React), including 8 new tests.

**Style:** Follows existing component patterns. New CSS classes use `share-member-*` prefix (replacing `share-linked-*`). Preferred card uses existing design tokens for colors. Star button uses Unicode characters (★/☆) to avoid SVG dependency.

**Test coverage:** 8 new tests added: household total rendering, collapsible member rows, collapsed-by-default, expand on click, single-member bypass, last name derivation, single-word name fallback, preferred card rendering with badge. Updated existing test fixture from `'Alice'` to `'Alice Smith'` with cascading assertion updates.

**Security/dependency hygiene:** No new dependencies. No credential or security rule changes. No `src/lib/` or `functions/` modifications. Secret scan passes.