### PR TITLE
fix: settlement board cards reflow on mobile viewports

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3320,6 +3320,49 @@ img, svg { display: block; max-width: 100%; }
         flex: 1;
         text-align: center;
     }
+
+    /* ── Settlement card mobile reflow ──────────────────── */
+    .settlement-card-main {
+        flex-wrap: wrap;
+    }
+
+    .settlement-card-left {
+        flex: 1 1 100%;
+        margin-bottom: var(--space-1, 4px);
+    }
+
+    .settlement-card-right {
+        flex: 1 1 100%;
+        flex-shrink: 1;
+        justify-content: space-between;
+    }
+
+    .settlement-summary-boxes {
+        flex: 1;
+    }
+
+    .settlement-summary-box {
+        min-width: 0;
+        flex: 1;
+        padding: var(--space-1, 4px) var(--space-1, 4px);
+    }
+
+    .settlement-summary-label {
+        font-size: 0.6rem;
+    }
+
+    .settlement-summary-value {
+        font-size: 0.8rem;
+    }
+
+    .settlement-expand-toggle {
+        font-size: 0.7rem;
+    }
+
+    /* Linked member summary boxes */
+    .settlement-summary-boxes--linked {
+        margin-left: 0;
+    }
 }
 
 /* ── Update Toast ─────────────────────────────────────── */

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3333,7 +3333,6 @@ img, svg { display: block; max-width: 100%; }
 
     .settlement-card-right {
         flex: 1 1 100%;
-        flex-shrink: 1;
         justify-content: space-between;
     }
 


### PR DESCRIPTION
## Summary

- Adds responsive CSS at the ≤640px breakpoint so settlement cards stack vertically on mobile
- Card-left (avatar + name) takes full width on top; card-right (summary boxes + badge + toggle) wraps to a full-width second row
- Summary boxes flex to fill available width instead of using a fixed `min-width: 64px` that caused overflow on narrow screens
- Also resets linked-member summary box `margin-left` for mobile

Closes #187

Authoring-Agent: claude

## Self-Review

- **Correctness**: Verified by injecting the styles into the production site at desktop width with forced mobile layout — cards reflow cleanly with all content visible. The `flex-wrap: wrap` on `.settlement-card-main` combined with `flex: 1 1 100%` on both child containers ensures a clean two-row stack.
- **Regression risk**: Low. Changes are scoped to a single `@media (max-width: 640px)` block, affecting only mobile viewports. Desktop layout is untouched.
- **Style**: Follows existing CSS patterns (uses CSS custom properties, consistent naming).
- **Test coverage**: All 632 existing tests pass. CSS-only change — no logic changes.
- **Security/dependency hygiene**: No new dependencies. No security implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved mobile responsiveness for settlement cards: sections now reflow to full-width on small screens, with better spacing and alignment for clearer visual hierarchy.
  * Optimized the settlement summary on mobile with flexible sizing, reduced padding and font sizes for improved readability, and removal of extra left offset for linked summary items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->