### PR TITLE
fix: filter chips fill row and details toggle no longer clips on mobile

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3311,13 +3311,24 @@ img, svg { display: block; max-width: 100%; }
 
     .nav-brand span { display: none; }
 
+    /* ── Settlement header + filter chips mobile ──────── */
+    .settlement-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
     .settlement-filters {
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
         width: 100%;
     }
 
     .settlement-filter-chip {
         flex: 1;
+        text-align: center;
+    }
+
+    .settlement-filter-info {
+        flex: 0 0 100%;
         text-align: center;
     }
 
@@ -3333,11 +3344,12 @@ img, svg { display: block; max-width: 100%; }
 
     .settlement-card-right {
         flex: 1 1 100%;
-        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: var(--space-1, 4px) var(--space-2, 8px);
     }
 
     .settlement-summary-boxes {
-        flex: 1;
+        flex: 1 1 100%;
     }
 
     .settlement-summary-box {
@@ -3356,6 +3368,7 @@ img, svg { display: block; max-width: 100%; }
 
     .settlement-expand-toggle {
         font-size: 0.7rem;
+        margin-left: auto;
     }
 
     /* Linked member summary boxes */


### PR DESCRIPTION
## Summary

- Filter chips (All / Outstanding / Partial / Settled) now fill the full row width on mobile, with equal sizing and centered text
- "Linked Groups N" info text wraps to its own centered line below the chips
- Settlement header stacks vertically (title above filters) instead of side-by-side
- Card-right section wraps: summary boxes take a full-width row, badge + "Details" toggle sit on a separate row below — no more text clipping
- Also addresses remaining overflow from #187 (details toggle clipping)

Closes #188

Authoring-Agent: claude

## Self-Review

- **Correctness**: Verified by injecting styles into the production site — filter chips fill the row, "Linked Groups" wraps below, and badge + toggle have their own row with no clipping.
- **Regression risk**: Low. All changes are within the existing `@media (max-width: 640px)` block. Replaced the old `flex-wrap: nowrap` on filters with `wrap` to let the info text flow to a new line — chips still stay on one row thanks to `flex: 1`.
- **Style**: Consistent with existing patterns.
- **Test coverage**: All 632 tests pass. CSS-only change.
- **Security/dependency hygiene**: None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile responsiveness for the settlement interface with enhanced layout organization, optimized spacing, and better element positioning. Settlement cards, filter sections, and header components now display with improved clarity and proper alignment on smaller screens for a more intuitive mobile experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->