### PR TITLE
fix: prevent filter chip text wrapping on mobile

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3325,6 +3325,11 @@ img, svg { display: block; max-width: 100%; }
     .settlement-filter-chip {
         flex: 1;
         text-align: center;
+        font-size: 0.7rem;
+        padding: var(--space-1, 4px) var(--space-1, 4px);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .settlement-filter-info {


### PR DESCRIPTION
## Summary

- Reduces filter chip font size to `0.7rem` and padding to `4px` on mobile
- Adds `white-space: nowrap` + `text-overflow: ellipsis` so chip labels stay single-line
- Fixes "Outstanding" chip wrapping to two lines at 393px viewport width

Follow-up to #202 which addressed chip row width but not per-chip text sizing.

Authoring-Agent: claude

## Self-Review

- **Correctness**: Verified by injecting styles into the production site — all 4 chips render single-line at equal width. "Outstanding 0" fits without wrapping.
- **Regression risk**: Minimal. Only adds 5 CSS properties to the existing mobile `.settlement-filter-chip` rule.
- **Style**: Consistent with other mobile font-size reductions in the same media query block.
- **Test coverage**: 632 tests pass. CSS-only.
- **Security/dependency hygiene**: None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance of filter chips on mobile devices by refining font sizing, adjusting spacing, and implementing text truncation to ensure content displays cleanly without overflow on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->