### PR TITLE
fix: KPI cards fill row on mobile, revert settlement chip truncation

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3301,7 +3301,13 @@ img, svg { display: block; max-width: 100%; }
     .nav-email { display: none; }
 
     .kpi-grid {
-        grid-template-columns: repeat(2, 1fr);
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    .kpi-grid > * {
+        flex: 1 1 0;
+        min-width: 0;
     }
 
     .manage-tabs {
@@ -3325,11 +3331,6 @@ img, svg { display: block; max-width: 100%; }
     .settlement-filter-chip {
         flex: 1;
         text-align: center;
-        font-size: 0.7rem;
-        padding: var(--space-1, 4px) var(--space-1, 4px);
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
     }
 
     .settlement-filter-info {


### PR DESCRIPTION
## Summary

- **Dashboard KPI grid**: switch from 2-column grid to flex layout at ≤640px so all 3 cards (Outstanding, Settled, Open Reviews) share the row equally—no orphaned third card
- **Settlement filter chips**: remove `font-size`, `padding`, `white-space`, `overflow`, and `text-overflow` overrides from commit 0233d54 that caused "Outstanding" to truncate with ellipsis on narrow viewports

Closes #188

Authoring-Agent: claude

## Self-Review

- **Correctness**: Flex layout with `flex: 1 1 0` distributes 3 KPI cards evenly across any width. Removing truncation props restores the chips to their pre-#203 state (matching the "correct" screenshot from the user).
- **Regression risk**: Low—CSS-only change scoped to the ≤640px breakpoint. Desktop layout unchanged.
- **Style**: Follows existing patterns in the responsive block.
- **Test coverage**: No CSS-specific tests exist; verified by inspection.
- **Security/dependency hygiene**: N/A—no logic or dependency changes.

## Test plan

- [ ] Open dashboard at ~375px viewport, confirm 3 KPI cards share one row evenly
- [ ] Open Settlement Board at ~375px, confirm "Outstanding 0" renders without truncation
- [ ] Resize to desktop, confirm both layouts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile responsiveness for KPI grid display with improved flexible layout wrapping
  * Refined settlement filter chip styling on mobile devices for better clarity and usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->