### PR TITLE
fix: prevent settlement filter chip text wrapping on mobile

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3331,6 +3331,7 @@ img, svg { display: block; max-width: 100%; }
     .settlement-filter-chip {
         flex: 1;
         text-align: center;
+        white-space: nowrap;
     }
 
     .settlement-filter-info {


### PR DESCRIPTION
## Summary

- Add `white-space: nowrap` to `.settlement-filter-chip` in the ≤640px breakpoint so chip text stays on one line instead of wrapping (e.g. "Outstanding" and "0" on separate lines)

Authoring-Agent: claude

## Self-Review

- **Correctness**: Single property addition prevents text wrap while keeping `flex: 1` distribution. No truncation/ellipsis — text simply won't break.
- **Regression risk**: Minimal — one CSS property in mobile breakpoint only.
- **Style**: Consistent with existing responsive overrides.
- **Test coverage**: CSS-only; no test changes needed.
- **Security/dependency hygiene**: N/A.

## Test plan

- [ ] Open Settlement Board at ~375px viewport, confirm "Outstanding 0" stays on one line
- [ ] Confirm chips still fill the row evenly
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filter chip text wrapping on mobile devices, ensuring filter names display properly without line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->