### PR TITLE
fix: mobile KPI labels, bill logos, abbreviated formulas, update toast

### DIFF
--- a/src/app/components/SettlementBoard.jsx
+++ b/src/app/components/SettlementBoard.jsx
@@ -8,6 +8,7 @@ import { getInitials, getGravatarUrl, formatAnnualSummaryCurrency } from '../../
 import StatusBadge, { getPaymentStatus } from './StatusBadge.jsx';
 import ActionMenu, { ActionMenuItem } from './ActionMenu.jsx';
 import ConfirmDialog from './ConfirmDialog.jsx';
+import CompanyLogo from './CompanyLogo.jsx';
 
 /** Avatar with Gravatar fallback: manual upload → Gravatar → initials. */
 function MemberAvatar({ member }) {
@@ -144,9 +145,36 @@ function formatBillFormula(bill, annualShare) {
     const memberCount = bill.members.length;
     const divisorLabel = memberCount + ' ' + (memberCount === 1 ? 'member' : 'members');
     if (bill.billingFrequency === 'annual') {
-        return formatAnnualSummaryCurrency(bill.amount) + ' / year ÷ ' + divisorLabel + ' = ' + formatAnnualSummaryCurrency(annualShare);
+        return formatAnnualSummaryCurrency(bill.amount) + ' / year \u00F7 ' + divisorLabel + ' = ' + formatAnnualSummaryCurrency(annualShare);
     }
-    return formatAnnualSummaryCurrency(bill.amount) + ' / month × 12 ÷ ' + divisorLabel + ' = ' + formatAnnualSummaryCurrency(annualShare);
+    return formatAnnualSummaryCurrency(bill.amount) + ' / month \u00D7 12 \u00F7 ' + divisorLabel + ' = ' + formatAnnualSummaryCurrency(annualShare);
+}
+
+function formatBillFormulaShort(bill, annualShare) {
+    const n = bill.members.length;
+    const mem = n + ' mem.';
+    if (bill.billingFrequency === 'annual') {
+        return formatAnnualSummaryCurrency(bill.amount) + '/yr \u00F7 ' + mem + ' = ' + formatAnnualSummaryCurrency(annualShare);
+    }
+    return formatAnnualSummaryCurrency(bill.amount) + '/mo. \u00D7 12 \u00F7 ' + mem + ' = ' + formatAnnualSummaryCurrency(annualShare);
+}
+
+/** Bill breakdown row with responsive name/formula. */
+function BillBreakdownRow({ bill, annualShare }) {
+    return (
+        <div className="settlement-breakdown-row">
+            <span className="settlement-bill-name">
+                <CompanyLogo logo={bill.logo} website={bill.website} name={bill.name} size={16} className="settlement-bill-logo" />
+                <span className="settlement-bill-text">{bill.name}</span>
+            </span>
+            <span className="settlement-breakdown-formula settlement-formula-full">
+                {formatBillFormula(bill, annualShare)}
+            </span>
+            <span className="settlement-breakdown-formula settlement-formula-short">
+                {formatBillFormulaShort(bill, annualShare)}
+            </span>
+        </div>
+    );
 }
 
 /** Check whether two member summaries from calculateAnnualSummary share the exact same bill set. */
@@ -270,12 +298,7 @@ function HouseholdCard({ row, payments, readOnly, onRecordPayment, onTextInvoice
                         ) : (
                             <>
                                 {data.bills.map(b => (
-                                    <div key={b.bill.id} className="settlement-breakdown-row">
-                                        <span>{b.bill.name}</span>
-                                        <span className="settlement-breakdown-formula">
-                                            {formatBillFormula(b.bill, b.annualShare)}
-                                        </span>
-                                    </div>
+                                    <BillBreakdownRow key={b.bill.id} bill={b.bill} annualShare={b.annualShare} />
                                 ))}
                                 <div className="settlement-breakdown-row settlement-breakdown-total">
                                     <span>Total ({member.name})</span>
@@ -329,12 +352,7 @@ function HouseholdCard({ row, payments, readOnly, onRecordPayment, onTextInvoice
                                                 ) : (
                                                     <>
                                                         {ls.bills.map(b => (
-                                                            <div key={b.bill.id} className="settlement-breakdown-row">
-                                                                <span>{b.bill.name}</span>
-                                                                <span className="settlement-breakdown-formula">
-                                                                    {formatBillFormula(b.bill, b.annualShare)}
-                                                                </span>
-                                                            </div>
+                                                            <BillBreakdownRow key={b.bill.id} bill={b.bill} annualShare={b.annualShare} />
                                                         ))}
                                                         <div className="settlement-breakdown-row settlement-breakdown-total">
                                                             <span>Total ({ls.member.name})</span>

--- a/src/app/components/UpdateToast.jsx
+++ b/src/app/components/UpdateToast.jsx
@@ -42,7 +42,8 @@ export default function UpdateToast() {
     return (
         <div className="update-toast visible">
             <span className="update-toast-message">
-                A new version of Friends &amp; Family Billing is available.
+                <span className="update-toast-full">A new version of Friends &amp; Family Billing is available.</span>
+                <span className="update-toast-short">Update available</span>
             </span>
             <button className="update-toast-btn" onClick={() => location.reload()}>
                 Refresh

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1423,6 +1423,23 @@ img, svg { display: block; max-width: 100%; }
     padding: 2px 0;
 }
 
+.settlement-bill-name {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+}
+
+.settlement-bill-logo {
+    flex-shrink: 0;
+    border-radius: 3px;
+}
+
+/* Progressive formula disclosure: full by default, short on mobile */
+.settlement-formula-short {
+    display: none;
+}
+
 .settlement-breakdown-total {
     font-weight: 600;
     border-top: 1px solid var(--color-border, #e0e0e0);
@@ -3310,6 +3327,28 @@ img, svg { display: block; max-width: 100%; }
         min-width: 0;
     }
 
+    .kpi-card {
+        padding: var(--space-2, 8px) var(--space-1, 4px);
+    }
+
+    .kpi-label {
+        font-size: 0.6rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .kpi-value {
+        font-size: 0.95rem;
+    }
+
+    .kpi-subtitle {
+        font-size: 0.55rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
     .manage-tabs {
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;
@@ -3382,6 +3421,38 @@ img, svg { display: block; max-width: 100%; }
     .settlement-summary-boxes--linked {
         margin-left: 0;
     }
+
+    /* ── Bill breakdown progressive disclosure ─────────── */
+    .settlement-formula-full {
+        display: none;
+    }
+
+    .settlement-formula-short {
+        display: inline;
+    }
+
+    .settlement-bill-text {
+        display: none;
+    }
+
+    .settlement-breakdown-row {
+        align-items: center;
+    }
+
+    /* ── Update toast mobile ───────────────────────────── */
+    .update-toast {
+        padding: 10px var(--space-3, 12px);
+        font-size: 0.85rem;
+        gap: var(--space-2, 8px);
+    }
+
+    .update-toast-full {
+        display: none;
+    }
+
+    .update-toast-short {
+        display: inline;
+    }
 }
 
 /* ── Update Toast ─────────────────────────────────────── */
@@ -3445,4 +3516,8 @@ img, svg { display: block; max-width: 100%; }
 
 .update-toast-dismiss:hover {
     color: #fff;
+}
+
+.update-toast-short {
+    display: none;
 }


### PR DESCRIPTION
## Summary

Three mobile responsiveness fixes deployed and verified on production:

- **KPI cards**: Labels shrunk to 0.6rem with `nowrap` + `text-overflow: ellipsis` so "OUTSTANDING" and "OPEN REVIEWS" stay single-line at 393px. Tighter padding.
- **Bill breakdown rows**: Added 16px `CompanyLogo` next to bill names (logo.dev integration already existed). On mobile (≤640px), bill name text is hidden (logo only) and formulas use abbreviations ("mo.", "mem.") via a `BillBreakdownRow` component that renders both full and short variants toggled by CSS.
- **Update toast**: Short "Update available" message on mobile instead of the full sentence that wrapped to 6+ lines.

Authoring-Agent: claude

## Self-Review

- **Correctness**: All three fixes verified on production at 393×852px. KPI labels fit, bill rows show logo + short formula on one line, toast is compact.
- **Regression risk**: Low. Desktop layout uses existing full-text rendering (`.settlement-formula-full` shown, `.settlement-formula-short` hidden). Mobile toggles are all CSS `display` switches inside the 640px media query.
- **Style**: New `BillBreakdownRow` component follows existing patterns. `CompanyLogo` import reuses the existing component.
- **Test coverage**: 632 tests pass. No logic changes — purely presentational.
- **Security/dependency hygiene**: No new dependencies. Logo.dev URLs use the existing `VITE_LOGODEV_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Bill breakdowns now display company logos alongside bill names for clearer visual identification
  * Bill formulas improved with mathematical symbols and responsive shortened variants for mobile devices
  * Mobile interface enhanced with optimized spacing, layout adjustments, and condensed update messaging
  * Settlement bill breakdown rows redesigned for more consistent presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->