### PR TITLE
chore: refresh stale documentation references

### DIFF
--- a/.ai_context.md
+++ b/.ai_context.md
@@ -25,6 +25,7 @@ React SPA is the primary app; the legacy vanilla JS build is retained at `/site/
 | `src/app/main.jsx` | React app entry point — renders at `/` |
 | `src/app/App.jsx` | Root component — routing, auth, lazy-loaded views |
 | `src/lib/BillingYearService.js` | Service-owns-state pattern — all billing mutations |
+| `src/lib/ShareLinkService.js` | Share link CRUD, token lifecycle, public share sync |
 | `src/lib/firebase.js` | Modular Firebase init (reads from `window.__FIREBASE_CONFIG__`) |
 | `functions/index.js` | Cloud Functions v2 — processMailQueue, resolveShareToken, submitDispute, getEvidenceUrl, submitDisputeDecision |
 | `AGENTS.md` | AI agent instructions and behavioral rules |

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Data is organized per billing year under `/users/{userId}/billingYears/{yearId}`
 - ✅ Full rewrite from vanilla JS to React 19 SPA
 - ✅ Service-owns-state architecture: BillingYearService + useSyncExternalStore
 - ✅ Code-split lazy loading via React.lazy + Suspense
-- ✅ Vite build with ~237 KB main bundle + lazy chunks
+- ✅ Vite build with code-split lazy chunks (~238 KB index + ~400 KB TipTap/InvoicingTab)
 - ✅ React Router v7 with SPA fallback rewrites
 - ✅ 632 Vitest + React Testing Library tests
 - ✅ Public share page ported to React route (/share)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -109,27 +109,16 @@ Just send them your deployed URL. Each person:
 **"Can't login"**
 → Verify Email/Password is enabled in Firebase Console
 
-**"localhost:8000 not working"**
-→ Make sure you're in the correct project directory
+**"localhost:5173 not working"**
+→ Make sure you ran `npm run dev` from the project root and that port 5173 is free
 
-### What Changed from the Old Version?
+### What's in the Stack?
 
-- ✅ **Before**: Data saved in browser (lost if you clear cache)
-- ✅ **After**: Data saved in cloud (accessible from any device)
-
-- ✅ **Before**: Single user only
-- ✅ **After**: Unlimited users, each with private data
-
-- ✅ **Before**: No authentication
-- ✅ **After**: Secure email/password login
-
-All your features still work exactly the same:
-- Family members with avatars
-- Bills with logos
-- Parent-child linking
-- Payment tracking
-- Email invoices
-- Everything!
+- **Frontend:** React 19 SPA (Vite dev server with HMR)
+- **Backend:** Firebase (Firestore, Cloud Functions, Auth, Hosting, Storage)
+- **Testing:** Vitest + React Testing Library (632 tests) + Playwright E2E
+- **Email:** Server-side delivery via Resend Cloud Function
+- **Rich text:** TipTap WYSIWYG editor for invoice templates
 
 ### Pro Tips
 

--- a/docs/agents/repository-overview.md
+++ b/docs/agents/repository-overview.md
@@ -87,6 +87,7 @@ Family Bill Splitter is a cloud-based web application for coordinating and settl
 │       ├── invoice.js             # Invoice text/HTML generation
 │       ├── persistence.js         # Firestore read/write operations
 │       ├── share.js               # Share token, public share data
+│       ├── ShareLinkService.js    # Share link CRUD, token lifecycle, public share sync
 │       ├── sms.js                 # SMS deep link generation
 │       ├── mail.js                # Email queueing via Firestore mailQueue
 │       ├── template-doc.js        # TipTap document ↔ token processing
@@ -319,7 +320,7 @@ npm run dev            # Vite dev server with HMR
 ```
 
 **How it works:**
-1. `build:react` — Vite builds `src/app/` → `app/` (code-split chunks, ~237 KB main bundle)
+1. `build:react` — Vite builds `src/app/` → `app/` (code-split chunks; ~238 KB index + ~400 KB jsx-runtime + ~401 KB InvoicingTab/TipTap lazy chunk)
 2. `build:legacy` — esbuild bundles `src/index.js` → `script.js` (intermediate, repo root)
 3. `build:assemble` — copies legacy files into `app/site/`, shared assets (firebase-config, design tokens, logos) into `app/`
 - `src/app/main.jsx` is the Vite entry point (React `createRoot`)
@@ -352,6 +353,9 @@ Central service owning all billing state. React subscribes via `useSyncExternalS
 - Children cannot be parents
 - A child can only have one parent
 - Parents cannot be children of other members
+
+#### ShareLinkService (src/lib/ShareLinkService.js)
+Manages the full share link lifecycle: create, revoke, update scopes, refresh public share data. Coordinates between `shareTokens` and `publicShares` Firestore collections.
 
 #### Business Logic (src/lib/)
 - `calculations.js` — `calculateAnnualSummary()`, `calculateSettlementMetrics()`, `getPaymentTotalForMember()`, `getBillAnnualAmount()`, `getBillMonthlyAmount()`


### PR DESCRIPTION
## Summary
- Fix `localhost:8000` → `localhost:5173` in QUICKSTART.md (Vite default port)
- Replace outdated "What Changed from the Old Version?" section (Firebase migration era) with current "What's in the Stack?" summary
- Add missing `ShareLinkService.js` to repository-overview.md directory tree and Key Modules
- Update bundle size references to reflect current code-split output (~238 KB index + ~400 KB TipTap lazy chunk)
- Add `ShareLinkService.js` to `.ai_context.md` Key Entry Points

Authoring-Agent: claude

## Self-Review
- **Correctness:** All changes verified against actual build output (`npm run build:react`) and current source tree. Test counts confirmed at 632 React + 288 legacy.
- **Regression risk:** None — documentation-only changes, no code modified.
- **Style:** Follows existing doc conventions (Markdown tables, em dashes, imperative tone).
- **Test coverage:** N/A (docs only). All CI enforcement checks pass.
- **Security/dependency hygiene:** No secrets, no dependency changes.

## Test plan
- [x] Verified `npm run build:react` output matches updated bundle sizes
- [x] Verified `npx vitest run` passes (632 tests)
- [x] Verified all `scripts/ci/` checks pass
- [x] Confirmed no Astro references exist anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)