### PR TITLE
fix: CodeRabbit detection used awk range that matched start as end

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -477,7 +477,7 @@ jobs:
         id: cr
         run: |
           CONFIG=".github/review-policy.yml"
-          if grep -qE '^\s*enabled:\s*true' <(awk '/^coderabbit:/,/^[^ ]/' "$CONFIG"); then
+          if sed -n '/^coderabbit:/,$ p' "$CONFIG" | grep -qE '^\s*enabled:\s*true'; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix CodeRabbit detection: `awk` range `/^coderabbit:/,/^[^ ]/` matched start line as both start AND end (because `c` is non-space), producing a one-line range that excluded the indented `enabled: true` line
- Replace with `sed -n '/^coderabbit:/,$ p'` which correctly extracts from the section header through EOF
- This is why the "Wait for CodeRabbit review" step was always skipped (output `enabled=false`) even when `coderabbit.enabled: true`

Authoring-Agent: claude

## Self-Review
- **Correctness:** Verified the sed command correctly detects `enabled: true` under `coderabbit:` in all 5 CodeRabbit-enabled repos and correctly returns `false` for the 2 disabled repos.
- **Regression risk:** None for CodeRabbit-disabled repos — `sed` extracts the section, grep finds no `enabled: true`, step is skipped as before.
- **Style:** One-line change per repo, same pattern as the surrounding code.
- **Test coverage:** N/A — workflow-only. Validated by checking swipewatch PR #30 logs where the old awk command caused the skip.
- **Security/dependency hygiene:** No new secrets or dependencies.

## Test plan
- [x] Reproduced the bug: `awk` range outputs only `coderabbit:` (1 line), grep finds no match → `enabled=false`
- [x] Verified the fix: `sed` outputs `coderabbit:` + `  enabled: true` → grep matches → `enabled=true`
- [x] Identical diff applied to all 7 repos
- [ ] Observe this PR's own auto-merge behavior — the wait step should now execute on CodeRabbit-enabled repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)