### PR TITLE
feat: replace email/sign-out with user menu dropdown

### DIFF
--- a/src/app/components/NavBar.jsx
+++ b/src/app/components/NavBar.jsx
@@ -1,12 +1,26 @@
+import { useEffect, useRef, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext.jsx';
 
 /**
  * NavBar — persistent top navigation.
- * Brand link, Dashboard/Manage/Settings nav links, user email, sign-out.
+ * Brand link, Dashboard/Manage/Settings nav links, user menu dropdown.
  */
 export default function NavBar() {
     const { user, signOut } = useAuth();
+    const [menuOpen, setMenuOpen] = useState(false);
+    const menuRef = useRef(null);
+
+    useEffect(() => {
+        if (!menuOpen) return;
+        const handleClick = (e) => {
+            if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false);
+        };
+        document.addEventListener('mousedown', handleClick);
+        return () => document.removeEventListener('mousedown', handleClick);
+    }, [menuOpen]);
+
+    const displayName = user?.displayName || user?.email?.split('@')[0] || 'User';
 
     return (
         <nav className="nav-bar">
@@ -40,9 +54,32 @@ export default function NavBar() {
                     </NavLink>
                 </div>
 
-                <div className="nav-user">
-                    <span className="nav-email">{user?.email}</span>
-                    <button onClick={signOut} className="nav-signout">Sign Out</button>
+                <div className="nav-user-menu" ref={menuRef}>
+                    <button
+                        className="nav-user-trigger"
+                        onClick={() => setMenuOpen((v) => !v)}
+                        aria-expanded={menuOpen}
+                        aria-haspopup="true"
+                    >
+                        <svg className="nav-user-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                            <circle cx="12" cy="7" r="4" />
+                        </svg>
+                        <span className="nav-user-name">{displayName}</span>
+                        <svg className="nav-user-chevron" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                            <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06z" clipRule="evenodd" />
+                        </svg>
+                    </button>
+                    {menuOpen && (
+                        <div className="nav-user-dropdown">
+                            <button
+                                className="nav-user-dropdown-item"
+                                onClick={() => { setMenuOpen(false); signOut(); }}
+                            >
+                                Sign Out
+                            </button>
+                        </div>
+                    )}
                 </div>
             </div>
         </nav>

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -113,35 +113,80 @@ img, svg { display: block; max-width: 100%; }
     color: var(--color-primary, #6E78D6);
 }
 
-.nav-user {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2, 8px);
+.nav-user-menu {
+    position: relative;
     margin-left: auto;
 }
 
-.nav-email {
-    color: var(--color-text-muted, #666);
-    font-size: 0.8rem;
-    max-width: 160px;
+.nav-user-trigger {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border: 1px solid var(--color-border, #e0e0e0);
+    border-radius: 8px;
+    background: var(--color-surface, #ffffff);
+    color: var(--color-text, #1a1a1a);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.nav-user-trigger:hover {
+    border-color: var(--color-border-strong, #cbd5e0);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.nav-user-icon {
+    width: 20px;
+    height: 20px;
+    color: var(--color-text-secondary, #5B6475);
+    flex-shrink: 0;
+}
+
+.nav-user-name {
+    white-space: nowrap;
+    max-width: 140px;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
-.nav-signout {
-    padding: var(--space-1, 4px) var(--space-2, 8px);
-    border: 1px solid var(--color-border, #e0e0e0);
-    border-radius: 6px;
+.nav-user-chevron {
+    width: 16px;
+    height: 16px;
+    color: var(--color-text-muted, #999);
+    flex-shrink: 0;
+}
+
+.nav-user-dropdown {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    min-width: 140px;
     background: var(--color-surface, #ffffff);
-    color: var(--color-text-secondary, #5B6475);
-    font-size: 0.8rem;
-    cursor: pointer;
-    transition: border-color 0.15s;
+    border: 1px solid var(--color-border, #e0e0e0);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    padding: 4px;
+    z-index: 100;
 }
 
-.nav-signout:hover {
-    border-color: var(--color-border-strong, #cbd5e0);
+.nav-user-dropdown-item {
+    display: block;
+    width: 100%;
+    padding: 8px 12px;
+    border: none;
+    border-radius: 6px;
+    background: none;
+    color: var(--color-text, #1a1a1a);
+    font-size: 0.875rem;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.12s;
+}
+
+.nav-user-dropdown-item:hover {
+    background: var(--color-bg-hover, #f5f5f5);
 }
 
 /* ── Manage Tabs ─────────────────────────────────────────── */
@@ -3315,7 +3360,7 @@ img, svg { display: block; max-width: 100%; }
 
 /* ── Responsive ──────────────────────────────────────────── */
 @media (max-width: 640px) {
-    .nav-email { display: none; }
+    .nav-user-name { display: none; }
 
     .kpi-grid {
         display: flex;

--- a/tests/react/components/NavBar.test.jsx
+++ b/tests/react/components/NavBar.test.jsx
@@ -25,14 +25,16 @@ function renderNavBar(route = '/') {
 }
 
 describe('NavBar', () => {
-    it('renders brand, nav links, and user email', () => {
+    it('renders brand, nav links, and user menu', () => {
         renderNavBar();
         expect(screen.getByText('FFB')).toBeInTheDocument();
         expect(screen.getByText('Dashboard')).toBeInTheDocument();
         expect(screen.getByText('Manage')).toBeInTheDocument();
         expect(screen.getByText('Settings')).toBeInTheDocument();
-        expect(screen.getByText('alice@test.com')).toBeInTheDocument();
-        expect(screen.getByText('Sign Out')).toBeInTheDocument();
+        // User menu shows display name (falls back to email username)
+        expect(screen.getByText('alice')).toBeInTheDocument();
+        // Sign Out is inside a dropdown, not visible until menu is opened
+        expect(screen.getByRole('button', { name: /alice/i })).toBeInTheDocument();
     });
 
     it('renders Dashboard link at /dashboard', () => {

--- a/tests/react/routes.test.jsx
+++ b/tests/react/routes.test.jsx
@@ -109,8 +109,9 @@ describe('Routes — authenticated user', () => {
     it('shows dashboard with nav bar when signed in', async () => {
         await renderAuthenticatedRoute(['/dashboard']);
         expect(await screen.findByText('Dashboard')).toBeInTheDocument();
-        expect(screen.getByText('a@b.com')).toBeInTheDocument();
-        expect(screen.getByText('Sign Out')).toBeInTheDocument();
+        // User menu shows username derived from email
+        expect(screen.getByText('a')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /a/i })).toBeInTheDocument();
     });
 
     it('redirects / to /dashboard and renders nav', async () => {


### PR DESCRIPTION
## Summary

- Replace the plain email address and "Sign Out" button in the navbar with a user icon, display name, and chevron dropdown menu
- Dropdown contains the sign-out action; clicking outside closes it
- Display name uses `user.displayName` when available, falls back to email username
- On small screens the name hides but icon + chevron remain

Authoring-Agent: claude

## Self-Review

- **Correctness**: The dropdown uses `useRef` + `useEffect` for outside-click handling, a standard React pattern. The `displayName` fallback chain (`displayName → email username → 'User'`) handles all Firebase user states.
- **Regression risk**: Low. Only the NavBar visual presentation changed. No routing, auth flow, or data logic was modified. Both previously failing tests updated and passing (11/11).
- **Style**: New CSS follows existing patterns (CSS custom properties, consistent spacing/color tokens). The dropdown uses the same border-radius, shadow, and transition patterns as other UI elements.
- **Test coverage**: Updated `NavBar.test.jsx` and `routes.test.jsx` to verify the new user menu structure. All 632 tests pass.
- **Security**: No new external dependencies. No user input is rendered unsafely—`displayName` is set by Firebase Auth, not user-editable in this app.
- **Dependency hygiene**: No new dependencies added.