### PR TITLE
feat: propagate Phase 4a Codex external review automation (#47)

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -24,8 +24,9 @@ external_review_threshold: 300
 # Glob patterns are supported. If any file in the PR diff matches a pattern
 # listed here, external review is mandatory.
 external_review_paths:
+  - "src/auth/**"
+  - "src/payments/**"
   - "functions/**"
-  - "src/lib/**"
   - "**/*secret*"
   - "**/*credential*"
   - ".github/**"
@@ -64,12 +65,12 @@ author_identity: nathanjohnpayne
 # review and before the threshold check for agent handoff.
 #
 # CodeRabbit is typically enabled for public repositories (free plan) and
-# disabled for private ones.
+# disabled for private ones. The template ships with enabled: false; set to
+# true when deploying to a public repo.
 #
 # CodeRabbit review is advisory — it does not block merge via CI. The agent
 # is required to read and address substantive CodeRabbit findings before
 # proceeding past Phase 2.5.
-#
 #
 # When enabled, the agent MUST:
 #   1. Wait for CodeRabbit to post before proceeding (up to 3 min; ask
@@ -79,8 +80,113 @@ author_identity: nathanjohnpayne
 #      - gh api repos/{owner}/{repo}/pulls/{pr}/comments    (inline diff comments)
 #   3. Grep inline comments for "Potential issue" or "⚠️" — every flagged
 #      finding must be explicitly addressed (fixed or dismissed with reasoning).
+#
 # To reverse: set enabled: false, delete .coderabbit.yml, uninstall the
 # CodeRabbit GitHub App. All agent instructions use conditional language
 # and will skip Phase 2.5 automatically.
 coderabbit:
   enabled: true
+
+# ---------------------------------------------------------------------------
+# Codex (Automated External Review — Phase 4a)
+# ---------------------------------------------------------------------------
+# When enabled, the OpenAI Codex GitHub App provides automated external review
+# on PRs carrying the `needs-external-review` label. The agent posts
+# `@codex review` as a PR comment; Codex responds with a standard GitHub code
+# review as `chatgpt-codex-connector[bot]`.
+#
+# This replaces the human-shuttled Phase 4 external review on the happy path.
+# On timeout, disagreement, or runaway, the flow falls back to the manual
+# CLI path described in REVIEW_POLICY.md § Phase 4b.
+#
+# Prerequisite: the ChatGPT Codex Connector GitHub App must be installed on
+# the repository with Code Review enabled at
+# https://chatgpt.com/codex/cloud/settings/code-review.
+#
+# The agent MUST:
+#   1. Run `scripts/codex-review-request.sh <PR#>` to post the trigger
+#      comment and poll for the Codex review.
+#   2. Parse the returned JSON. Address each P0/P1 finding with a fix OR
+#      a reply explaining why the finding does not apply.
+#   3. Repeat up to `max_review_rounds`. On runaway (round > max), escalate
+#      to the human per REVIEW_POLICY.md § Disagreements and Tiebreaking.
+#   4. On timeout (silence within `review_timeout_seconds`), the script
+#      exits with code 4 (FALLBACK_REQUIRED). The agent then falls back
+#      to the manual handoff in REVIEW_POLICY.md § Phase 4b, targeting
+#      `cli_login` below.
+#   5. Before merging, run `scripts/codex-review-check.sh <PR#>` to verify
+#      the merge gate. All of the following must hold:
+#        a) required CI checks are green
+#        b) an approving review from a registered reviewer identity
+#           (`available_reviewers`) is present on the PR
+#        c) Codex has signaled clearance on the current HEAD in one of two
+#           forms — NEVER an `APPROVED` review state, because the Codex
+#           GitHub App does not post `APPROVED` reviews:
+#            - a `COMMENTED` review from `chatgpt-codex-connector[bot]`
+#              on or after the latest commit, with no unaddressed P0/P1
+#              inline findings on the `/pulls/{pr}/comments` endpoint, OR
+#            - a 👍 / `+1` reaction from `chatgpt-codex-connector[bot]`
+#              on the PR issue, posted after the latest commit
+#      See #29 for the observational evidence behind this behavior.
+codex:
+  enabled: true
+
+  # GitHub login of the Codex GitHub App bot. Reviews posted by this login
+  # satisfy the external-review requirement in `.github/workflows/pr-audit.yml`.
+  # Do not change unless OpenAI renames the app. Confirmed via GitHub API
+  # metadata; see issue #26 for the audit trail.
+  bot_login: "chatgpt-codex-connector[bot]"
+
+  # Fallback CLI reviewer identity used when the Codex App path times out.
+  # This identity posts reviews manually via the Codex CLI as a human-driven
+  # Phase 4b handoff. Must be a member of `available_reviewers` above.
+  cli_login: nathanpayne-codex
+
+  # Maximum number of `@codex review` rounds before escalating as runaway.
+  # The 3rd round trips the guard. Normal termination is either approval,
+  # disagreement (repeat-after-rebuttal), or timeout → Phase 4b fallback.
+  max_review_rounds: 2
+
+  # Poll timeout per round, in seconds, for `codex-review-request.sh`.
+  # If Codex has not posted a review within this window, treat as timeout
+  # and exit with code 4. Silence is NEVER treated as implicit approval;
+  # see issue #27 for the explicit-review-required decision.
+  review_timeout_seconds: 600
+
+  # When true, `codex-review-check.sh` requires all required CI checks to
+  # report green before allowing merge. Strongly recommended; do not disable
+  # without explicit human authorization.
+  require_ci_green: true
+
+  # Maximum age, in seconds, of a `+1` / 👍 reaction from the Codex bot that
+  # can clear gate (c) in codex-review-check.sh and be treated as a current
+  # signal by the pre-flight scan in codex-review-request.sh.
+  #
+  # Background: GitHub's REST and GraphQL APIs do not expose a per-PR push
+  # timestamp for ordinary (non-force) pushes. The timeline endpoint has a
+  # `committed` event for each commit, but its `created_at` field is null
+  # (verified against PR #63 on 2026-04-15). For force-push, the
+  # `head_ref_force_pushed` event provides a tight per-PR arrival time;
+  # for ordinary push, the best anchor we can derive is the commit's
+  # committer date, which is commit metadata and can be arbitrarily old
+  # (cherry-pick, rebase with `--committer-date-is-author-date`, or any
+  # commit amended from a previously-authored SHA).
+  #
+  # Consequence: without a freshness constraint, a stale 👍 reaction from
+  # a prior HEAD would pass `reaction.created_at >= HEAD_COMMITTER_DATE`
+  # when the new HEAD's committer date is older than the prior 👍 — a
+  # false clear.
+  #
+  # Mitigation: require the 👍 reaction to be created within this many
+  # seconds of the scan time. A stale 👍 from a prior HEAD is filtered
+  # out once it ages past the window, closing the exposure in practice.
+  # The window must be long enough for a typical Phase 4a cycle (push →
+  # `@codex review` trigger → Codex response → gate check) to complete
+  # without forcing a re-trigger, and short enough that cross-cycle
+  # staleness is caught.
+  #
+  # Default 1800 seconds (30 min) is conservative for the agent flow;
+  # typical cycles complete in 1–5 minutes. Applies to both
+  # codex-review-check.sh gate (c) and codex-review-request.sh pre-flight
+  # and poll scans.
+  reaction_freshness_window_seconds: 1800

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,5 +1,20 @@
 name: Weekly PR Audit
 
+# Cron-driven retroactive check that the previous week's merged PRs
+# satisfied the review policy. Five checks per merged PR:
+#
+#   1. Self-Review section present in PR body (Dependabot exempted)
+#   2. external-review-labeled PRs have either an APPROVED CLI
+#      reviewer review OR a review from the Codex GitHub app bot;
+#      Dependabot PRs require an APPROVED CLI reviewer review
+#   3. No bot self-approval (reviewer identity approving its own PR)
+#   4. needs-human-review label not still present at merge time
+#   5. policy-violation label not still present at merge time
+#
+# Violations are aggregated into a single audit issue per run.
+# See REVIEW_POLICY.md, .github/review-policy.yml, and #36 for
+# the canonical policy and the most recent semantics changes.
+
 on:
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 9:00 UTC
@@ -15,31 +30,52 @@ jobs:
     name: Audit Merged PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install js-yaml
         run: npm install js-yaml
 
       - name: Audit merged PRs for review policy compliance
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
             const fs = require('fs');
             const yaml = require('js-yaml');
 
-            // Read reviewer accounts from review-policy.yml
+            // Read reviewer accounts and the Codex bot login from
+            // review-policy.yml. The Codex bot login is read from
+            // codex.bot_login (added in #31) so that the OpenAI
+            // Codex GitHub app's reviews count as satisfying the
+            // external-review requirement, in addition to the
+            // nathanpayne-* CLI reviewer identities. See #26 for
+            // the bot identity decision and #36 for the audit-side
+            // allow-list change.
             let reviewerAccounts;
             let authorIdentity;
+            let codexBotLogin;
             try {
               const config = yaml.load(fs.readFileSync('.github/review-policy.yml', 'utf8'));
               reviewerAccounts = config.available_reviewers || [];
               authorIdentity = config.author_identity || 'nathanjohnpayne';
+              codexBotLogin = (config.codex && config.codex.bot_login) || 'chatgpt-codex-connector[bot]';
             } catch (e) {
               console.log('WARNING: Could not read review-policy.yml, using defaults');
               reviewerAccounts = ['nathanpayne-claude', 'nathanpayne-codex', 'nathanpayne-cursor'];
               authorIdentity = 'nathanjohnpayne';
+              codexBotLogin = 'chatgpt-codex-connector[bot]';
             }
+
+            // The Codex bot's review-state semantics differ from
+            // CLI reviewer identities, so the external-review check
+            // below treats them on separate code paths rather than
+            // unioning them into a single allow-list. See the
+            // Check 2 block for the full rationale; the short
+            // version is that CLI identities still require
+            // state === 'APPROVED' but the Codex bot can clear
+            // with any review state because the GitHub app never
+            // emits APPROVED — only COMMENTED with a 👍 reaction
+            // or no findings (see #29 for observational evidence).
 
             const since = new Date();
             since.setDate(since.getDate() - 7);
@@ -67,38 +103,96 @@ jobs:
 
             for (const pr of mergedPRs) {
               const prViolations = [];
+              const isDependabot = pr.user.login === 'dependabot[bot]';
+
+              // Fetch all reviews for this PR once, up front. Both
+              // Check 2 (external-review approval) and Check 3 (bot
+              // self-approval) consume them, and an earlier version
+              // of this script fetched twice. CodeRabbit caught the
+              // duplicate on PR #68.
+              const reviewsResp = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+              const reviews = reviewsResp.data;
 
               // Check 1: Missing Self-Review section
-              if (!pr.body || !pr.body.match(/^## Self-Review/m)) {
-                prViolations.push('Missing `## Self-Review` section');
+              //
+              // Skip for Dependabot PRs. Dependabot doesn't author a
+              // body with the Self-Review template, and the
+              // pre-merge gate in pr-review-policy.yml already
+              // skips Dependabot via `if: github.actor != 'dependabot[bot]'`
+              // (line 14). The audit was previously flagging every
+              // Dependabot PR as a false positive — see #20.
+              if (!isDependabot) {
+                if (!pr.body || !pr.body.match(/^## Self-Review/m)) {
+                  prViolations.push('Missing `## Self-Review` section');
+                }
               }
 
-              // Check 2: Had needs-external-review label — verify approval from a reviewer identity
+              // Check 2: Had needs-external-review label — verify approval
+              //
+              // Also runs unconditionally for Dependabot PRs (see #20):
+              // even patch/minor bumps must have ONE reviewer-identity
+              // approval before merge. The existing
+              // .github/workflows/dependabot-auto-merge.yml posts
+              // `gh pr review --approve` via REVIEWER_ASSIGNMENT_TOKEN
+              // before enabling auto-merge, so well-behaved auto-merge
+              // PRs satisfy this naturally. Only Dependabot PRs that
+              // were merged manually WITHOUT any reviewer-identity
+              // approval will be flagged — which is the real gap.
               const hadExternalLabel = pr.labels.some(
                 l => l.name === 'needs-external-review'
               );
+              const dependabotNeedsApproval = isDependabot;
 
-              if (hadExternalLabel) {
-                const reviews = await github.rest.pulls.listReviews({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                });
-
-                const approvals = reviews.data.filter(
-                  r => r.state === 'APPROVED'
+              if (hadExternalLabel || dependabotNeedsApproval) {
+                // For the external-review path we accept either:
+                //   - an APPROVED review from a CLI reviewer identity
+                //     (nathanpayne-claude / nathanpayne-codex / etc.), OR
+                //   - ANY review from the Codex GitHub app bot,
+                //     regardless of state, because the Codex app
+                //     never emits APPROVED — only COMMENTED with a
+                //     👍 reaction or no findings (see #29 for the
+                //     observational evidence).
+                //
+                // The state-agnostic exception is intentionally
+                // SCOPED to the Codex bot only. CLI reviewer
+                // identities still require state === 'APPROVED'
+                // because a non-opinionated COMMENTED review from
+                // a CLI reviewer is not a clearance signal under
+                // policy. nathanpayne-codex caught this on PR #68
+                // round 1 — earlier draft accepted any review from
+                // any external approver, which would have let a
+                // Phase 4b fallback PR with only a COMMENTED CLI
+                // review pass the audit.
+                const cliApprovedReviews = reviews.filter(
+                  r => r.state === 'APPROVED' &&
+                       reviewerAccounts.includes(r.user.login)
                 );
 
-                // Per REVIEW_POLICY.md: external-review PRs need at least one
-                // approval from a reviewer identity (nathanpayne-{agent}).
-                // nathanjohnpayne is the PR author, so their approval does not
-                // count toward the reviewer approval requirement.
-                const reviewerApprovals = approvals.filter(
-                  r => reviewerAccounts.includes(r.user.login)
+                const codexBotReviews = reviews.filter(
+                  r => r.user.login === codexBotLogin
                 );
-                if (reviewerApprovals.length === 0) {
+
+                if (hadExternalLabel &&
+                    cliApprovedReviews.length === 0 &&
+                    codexBotReviews.length === 0) {
                   prViolations.push(
-                    'External-review PR merged with no reviewer identity approval'
+                    'External-review PR merged with no APPROVED review from a CLI reviewer identity and no review from the Codex bot'
+                  );
+                }
+
+                // Dependabot PRs use a strictly narrower rule: only
+                // an APPROVED review from a CLI reviewer identity
+                // counts. Codex doesn't review Dependabot PRs in
+                // the Phase 4a flow, so this is just defensive
+                // against future weirdness — and reuses the
+                // cliApprovedReviews array computed above.
+                if (dependabotNeedsApproval && cliApprovedReviews.length === 0) {
+                  prViolations.push(
+                    'Dependabot PR merged with no reviewer identity approval (auto-merge approval missing or removed)'
                   );
                 }
               }
@@ -108,13 +202,9 @@ jobs:
               // authorIdentity (nathanjohnpayne). The human IS that identity,
               // so nathanjohnpayne approving is legitimate (human tiebreaker).
               // Only flag if a reviewer bot account approved its own PR.
-              const reviews = await github.rest.pulls.listReviews({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-              });
-
-              const botSelfApproval = reviews.data.some(
+              // Reuses the `reviews` array fetched at the top of this
+              // PR's iteration.
+              const botSelfApproval = reviews.some(
                 r => r.user.login === pr.user.login &&
                      r.state === 'APPROVED' &&
                      reviewerAccounts.includes(r.user.login)

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: make_ci_scripts_executable
         run: chmod +x scripts/ci/*
@@ -44,6 +44,9 @@ jobs:
             MISSING=1
           fi
           exit $MISSING
+
+      - name: check_codex_scripts
+        run: ./scripts/ci/check_codex_scripts
 
       - name: check_governance_files
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,15 +38,18 @@ This repository uses a multi-identity AI agent code review system. The full poli
    b. **Read both endpoints:** PR-level comments (`gh api repos/{owner}/{repo}/issues/{pr}/comments`) and inline diff comments (`gh api repos/{owner}/{repo}/pulls/{pr}/comments`).
    c. **Grep inline comments** for `Potential issue` or `⚠️` — these must each be explicitly addressed (fixed or dismissed with reasoning).
    d. Address other substantive findings. CodeRabbit review is advisory and does not block merge.
-6. Check .github/review-policy.yml for the external review threshold. If the PR meets the threshold (lines changed >= external_review_threshold OR files match external_review_paths), post a handoff message (see REVIEW_POLICY.md for format) and alert the human.
-7. If external review is not required, merge as nathanjohnpayne.
-8. If external review is required, wait for the human to relay external reviewer feedback. Resolve all issues through back-and-forth until the external reviewer approves.
-9. If the external reviewer flags observations or risks while approving, create a GitHub Issue for each one assigned to nathanjohnpayne with labels "post-review" and "observation" or "risk" before merging.
-10. Merge as nathanjohnpayne.
+6. Check .github/review-policy.yml for the external review threshold. If the PR does NOT meet it (lines changed < external_review_threshold AND no file matches external_review_paths), merge as nathanjohnpayne. Done.
+7. If the PR meets the threshold, proceed to Phase 4 (see REVIEW_POLICY.md § Phase 4). Phase 4 has two legs:
+   - **Phase 4a — Automated (preferred)** when ALL of: `codex.enabled: true` in `.github/review-policy.yml`, BOTH `scripts/codex-review-request.sh` AND `scripts/codex-review-check.sh` exist on disk, AND the **ChatGPT Codex Connector GitHub App is review-ready on this repo**. "Review-ready" means installed, Code Review enabled at [chatgpt.com/codex/cloud/settings/code-review](https://chatgpt.com/codex/cloud/settings/code-review), AND a Codex environment configured at [chatgpt.com/codex/cloud/settings/environments](https://chatgpt.com/codex/cloud/settings/environments). Verify only by observation: did a recent PR in this repo receive an auto-review from `chatgpt-codex-connector[bot]`? That is the only reliable check from a reviewer PAT — `gh api repos/{owner}/{repo}/installation` requires a GitHub App JWT and returns 401 for normal tokens. Drive the Codex GitHub App review loop: post `@codex review` via the request script, address **P0/P1** findings (fix code or rebuttal reply — P2/P3 findings do NOT block clearance), loop up to `codex.max_review_rounds`. On clearance (COMMENTED review with no unaddressed P0/P1 findings on the current HEAD, OR 👍 reaction from `chatgpt-codex-connector[bot]`), run `scripts/codex-review-check.sh` to verify the merge gate and merge. On exit code 4 (timeout), drop to Phase 4b. On repeat-after-rebuttal or round > `max_review_rounds`, escalate per § Disagreements below. If any of the conditions is false (Codex App not review-ready, partial script rollout, or Codex disabled in config), fall back to Phase 4b directly rather than entering 4a and stalling.
+   - **Phase 4b — Manual CLI fallback** when 4a is unavailable or 4a fell back. Post the handoff message (see REVIEW_POLICY.md § Handoff Message Format) and wait for an external reviewer identity (e.g., nathanpayne-codex) to post an `APPROVED` review via a separate agent CLI session. Address feedback via back-and-forth.
+8. If the external reviewer flags observations or risks while approving, create a GitHub Issue for each one assigned to nathanjohnpayne with labels "post-review" and "observation" or "risk" before merging.
+9. Merge as nathanjohnpayne.
 
 ### Disagreements
 
-If the internal reviewer and external reviewer disagree, the human is the tiebreaker. Surface both positions clearly and wait.
+If the internal reviewer and external reviewer disagree on whether code is ready to merge, the human is the tiebreaker. Surface both positions clearly and wait.
+
+In Phase 4a specifically, the agent escalates automatically on either of two signals: **repeat-after-rebuttal** (Codex re-flags a finding after the agent posted a rebuttal reply) or **runaway rounds** (round counter exceeds `codex.max_review_rounds`, default 2). On escalation, the agent stops the loop, posts a comment on the PR summarizing both positions with links to the review rounds, alerts the human, and does not merge. Timeout (exit code `4` from `codex-review-request.sh`) is NOT a disagreement — it falls back to Phase 4b directly. Full detail in REVIEW_POLICY.md § Disagreements and Tiebreaking.
 
 ### Adding a New Agent
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,84 @@ explicitly authorizes a break-glass override in chat.
 ## Before merging
 
 8. Check `.github/review-policy.yml` for the external review threshold.
-   If the PR meets the threshold (lines changed ≥ threshold OR files match
-   external_review_paths), post the handoff message and alert the human.
-   Do NOT merge — wait for external review.
-9. If external review is not required, merge as nathanjohnpayne.
+   If the PR does NOT meet it (lines changed < `external_review_threshold`
+   AND no file matches `external_review_paths`), merge as nathanjohnpayne.
+   Done.
+
+9. If the PR meets the threshold, it enters Phase 4 external review.
+   See REVIEW_POLICY.md § Phase 4 for the canonical procedure. Short form:
+
+   **Phase 4a — Automated (preferred).** Applies when ALL of the
+   following are true:
+
+   - `codex.enabled: true` in `.github/review-policy.yml`
+   - BOTH `scripts/codex-review-request.sh` AND
+     `scripts/codex-review-check.sh` exist on disk
+   - The **ChatGPT Codex Connector GitHub App is review-ready on this
+     repository**. "Review-ready" is strictly stronger than
+     "installed": the App must be installed, Code Review must be
+     enabled at
+     [chatgpt.com/codex/cloud/settings/code-review](https://chatgpt.com/codex/cloud/settings/code-review),
+     AND a Codex environment must be configured at
+     [chatgpt.com/codex/cloud/settings/environments](https://chatgpt.com/codex/cloud/settings/environments).
+     Without the environment, Codex may post a "create an environment
+     for this repo" comment instead of a review, even though the App
+     is present (observed on PR #62 on 2026-04-14). Treat the App as
+     not review-ready until all three pieces are in place.
+
+     **Verification from an agent identity.** The only reliable check
+     is observational: has a recent PR in this repo received an
+     auto-review from `chatgpt-codex-connector[bot]` within the last
+     few hours? If yes, the App is review-ready. If no, check the
+     two settings pages above manually, or test with a small throwaway
+     PR before routing real work through Phase 4a. **Do NOT use
+     `gh api repos/{owner}/{repo}/installation`** as a check — that
+     endpoint requires a GitHub App JWT and returns `401 "A JSON web
+     token could not be decoded"` for normal user/reviewer PATs.
+
+   If any of these conditions is false (Codex not enabled, either
+   helper script missing, or the Codex App is not review-ready), fall
+   back to Phase 4b directly rather than entering 4a and stalling:
+
+   a. Run `scripts/codex-review-request.sh <PR#>`. It posts `@codex review`
+      (or skips the trigger if Codex already auto-reviewed on open) and
+      polls for a response from `chatgpt-codex-connector[bot]`.
+   b. Parse the JSON output. Address each P0/P1 inline finding by either
+      fixing the code and pushing a new commit, OR posting a reply on the
+      finding thread with a clear rebuttal. Increment the round counter.
+   c. Re-run `scripts/codex-review-request.sh` for the next round. Loop
+      until Codex clears: a `COMMENTED` review with no unaddressed
+      **P0/P1** findings on the current HEAD (P2 and P3 findings do NOT
+      block clearance — address them at the agent's judgment), OR a
+      👍 reaction on the PR issue.
+   d. On exit code `4` (FALLBACK_REQUIRED, timeout), stop 4a and drop to
+      Phase 4b below.
+   e. On disagreement (repeat-after-rebuttal) or runaway (round counter
+      exceeds `codex.max_review_rounds`), escalate per REVIEW_POLICY.md
+      § Disagreements and Tiebreaking: stop the loop, post a summary
+      comment on the PR with both positions, alert the human, do NOT merge.
+   f. On clearance, run `scripts/codex-review-check.sh <PR#>` to verify
+      the merge gate (CI green + internal reviewer approved + Codex
+      cleared on current HEAD). The merge gate does NOT require an
+      `APPROVED` review state from the Codex bot — the app never emits
+      one. If the gate passes, merge as nathanjohnpayne with
+      `gh pr merge --squash --delete-branch`.
+
+   **Phase 4b — Manual CLI fallback.** Applies when Phase 4a is
+   unavailable (`codex.enabled: false`, either helper script missing,
+   Codex App not review-ready, or 4a fell back via exit code 4):
+
+   a. Post the handoff message per REVIEW_POLICY.md § Handoff Message
+      Format as a PR comment.
+   b. Alert the human via chat. The human takes the handoff to a
+      different agent CLI session (typically `nathanpayne-codex`), which
+      posts an external review.
+   c. Address feedback via the usual nathanjohnpayne commit loop.
+   d. Wait for the external reviewer identity to post an `APPROVED` review.
+   e. If the external reviewer flags observations or risks, file the
+      post-merge GitHub Issues per step 11 below.
+   f. Merge as nathanjohnpayne.
+
 10. Never use `--admin` to merge unless the human explicitly authorizes it
     in chat as a break-glass exception. The hook will block it otherwise.
 

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -38,34 +38,34 @@ When posting a PR review as a reviewer identity, always pass a PAT from 1Passwor
 to `gh` explicitly. Do not rely on the GitHub connector session or on the
 account shown by `gh auth status`.
 
+#### PAT lookup table
+
+| Agent | Reviewer Identity | 1Password Item ID | `op read` path |
+|-------|-------------------|-------------------|----------------|
+| Claude | `nathanpayne-claude` | `pvbq24vl2h6gl7yjclxy2hbote` | `op://Private/pvbq24vl2h6gl7yjclxy2hbote/token` |
+| Cursor | `nathanpayne-cursor` | `bslrih4spwxgookzfy6zedz5g4` | `op://Private/bslrih4spwxgookzfy6zedz5g4/token` |
+| Codex | `nathanpayne-codex` | `o6ekjxjjl5gq6rmcneomrjahpu` | `op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token` |
+| Human | `nathanjohnpayne` | `sm5kopwk6t6p3xmu2igesndzhe` | `op://Private/sm5kopwk6t6p3xmu2igesndzhe/token` |
+
 ```bash
-# ── Preferred: use preflight-cached PATs (no biometric prompts) ──
-
-# As reviewer (after running op-preflight.sh):
-GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
+# Example: verify the Claude reviewer identity before approving a PR
+GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
+  gh api user --jq '.login'
 # expected: nathanpayne-claude
-
-GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" \
-  gh pr review <PR#> --repo <owner/repo> --approve --body "Review comment"
-
-# As author (merge, address comments, etc.):
-GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT" gh pr merge <PR#> --merge
-
-# ── Fallback: inline op read (triggers biometric if session expired) ──
 
 GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
   gh pr review <PR#> --repo <owner/repo> --approve --body "Review comment"
 ```
 
+- Use the item ID from the lookup table above for your agent identity. Do not use the 1Password item title.
 - If `gh auth status` still shows `nathanjohnpayne`, that is okay.
   `GH_TOKEN=...` overrides the ambient login for that command.
 - If `op whoami` says you are not signed in, still run the `op read ...`
   command in an interactive TTY. That is what triggers the 1Password biometric
   prompt on local machines.
 - If GitHub returns `Review Can not approve your own pull request`, the wrong
-  reviewer identity is still being used.
-- Use the 1Password item ID, not the item title, in `op read`.
-- Swap the item ID for the Claude or Cursor reviewer as needed.
+  reviewer identity is still being used. Check the lookup table and verify you
+  are using your agent's item ID, not the author identity's.
 
 ## Workflow
 
@@ -139,22 +139,80 @@ Before moving past Phase 2.5, confirm all of the following:
 
 ### Phase 3: External Review Threshold Check
 
-> **Note on automation timing:** CI workflows may apply the `needs-external-review` label automatically when a PR is opened or updated, as an early advisory based on line count and protected paths. This label blocks merge immediately. The agent's responsibility is to post the handoff message and alert the human after internal review passes—the label itself may already be present.
+> **Note on automation timing:** CI workflows may apply the `needs-external-review` label automatically when a PR is opened or updated, as an early advisory based on line count and protected paths. The label blocks merge via the label-gate until external review clears. When the label is present, the agent's responsibility after internal review passes is to proceed to [Phase 4](#phase-4-external-review) — which routes the PR to Phase 4a (automated via the Codex GitHub App) or Phase 4b (manual handoff) depending on `codex.enabled` and on whether 4a converges. The label itself does NOT imply immediate human mediation; Phase 4b only posts the handoff message when the fallback path is actually taken.
 
 8. After internal review passes, the agent evaluates whether the PR meets the external review threshold (see [Review Policy Configuration](#review-policy-configuration)).
 9. If the threshold is **not** met, the agent merges the PR as `nathanjohnpayne`. Done.
-10. If the threshold **is** met, the agent posts a **handoff message** (see [Handoff Message Format](#handoff-message-format)) as a PR comment and alerts the human.
+10. If the threshold **is** met, the agent proceeds to [Phase 4: External Review](#phase-4-external-review). Phase 4 itself routes the PR to Phase 4a (automated, via the Codex GitHub App) or Phase 4b (manual handoff) based on `codex.enabled` in `.github/review-policy.yml` and on whether 4a's automated loop converges. The agent does NOT post a handoff message directly from this step — Phase 4b posts its own handoff message if and when the fallback path is taken.
 
 ### Phase 4: External Review
 
-11. The human takes the handoff message to a different agent (e.g., from Claude to Cursor, or from Cursor to Codex).
-12. The external agent's reviewer identity (e.g., `nathanpayne-codex`) reviews the PR and posts comments.
-13. The human relays the external reviewer's feedback back to the originating agent.
-14. The originating agent, as `nathanjohnpayne`, addresses the feedback and pushes fixes.
-15. The human shuttles updated code back to the external reviewer.
-16. Steps 12–15 repeat until the external reviewer approves.
-17. If the external reviewer flags **observations** or **risks** while approving, those are converted to GitHub Issues on the repo, assigned to `nathanjohnpayne` (see [Post-Merge Issue Creation](#post-merge-issue-creation)).
-18. `nathanjohnpayne` merges the PR. Done.
+Phase 4 has two sub-phases that together cover the two ways external review can run:
+
+- **Phase 4a — Automated external review** via the ChatGPT Codex Connector GitHub App. This is the default happy path. The authoring agent drives the review loop without human intervention until Codex signals clearance, then runs a merge-gate check and merges.
+- **Phase 4b — Manual CLI fallback** via a different agent's CLI session (e.g., Codex CLI as `nathanpayne-codex`, or Cursor, or Claude Code). This is the escape hatch when 4a escalates (disagreement or runaway), times out, or is unavailable because `codex.enabled: false`. The human mediates the handoff.
+
+An agent proceeds to 4a first. If 4a escalates, times out, or is disabled, the agent falls back to 4b and surfaces the handoff to the human per [Handoff Message Format](#handoff-message-format).
+
+#### Phase 4a: Automated External Review (Codex GitHub App)
+
+> **Applies only to repos with `codex.enabled: true` in `.github/review-policy.yml`.** The **ChatGPT Codex Connector GitHub App must also be review-ready on the repository**, meaning installed, with Code Review enabled at [chatgpt.com/codex/cloud/settings/code-review](https://chatgpt.com/codex/cloud/settings/code-review), AND with a Codex environment configured at [chatgpt.com/codex/cloud/settings/environments](https://chatgpt.com/codex/cloud/settings/environments). "Installed" alone is not sufficient — a PR in a repo where the App is present but the environment is not configured will receive a "create an environment for this repo" comment from `chatgpt-codex-connector[bot]` instead of a review (observed on PR #62 on 2026-04-14). The only verification available from an agent reviewer PAT is observational: check whether a recent PR in this repo received an auto-review from `chatgpt-codex-connector[bot]`; `gh api repos/{owner}/{repo}/installation` requires a GitHub App JWT and is NOT usable from normal tokens. If any of these conditions is not met, skip directly to Phase 4b.
+
+11a. The authoring agent runs `scripts/codex-review-request.sh <PR#>` to trigger or await a Codex review. If the Codex App's "Automatic reviews" setting has already caused Codex to review the PR on open (typical latency ~2 minutes for small PRs), the script skips posting `@codex review` and goes straight to polling.
+
+12a. `codex-review-request.sh` polls the PR until one of the following:
+
+     - **Codex posts a review.** Always in `COMMENTED` state — the Codex GitHub App never uses `APPROVED` or `CHANGES_REQUESTED`. Findings appear as **inline comments on the diff** (`/pulls/{pr}/comments` endpoint), not in the top-level review body. Inline findings carry priority markers: `![P0 Badge]`, `![P1 Badge]`, `![P2 Badge]`, or `![P3 Badge]`.
+     - **Codex reacts 👍 / `+1`** on the PR issue with no review body. This is Codex's no-findings clearance signal per the ChatGPT Codex Connector documentation.
+     - **Timeout.** No review and no reaction within `codex.review_timeout_seconds` (default: 600s / 10 min). The script exits with code `4` (`FALLBACK_REQUIRED`).
+
+13a. If Codex posted inline findings, the agent addresses each P0/P1 by either:
+
+     - **Fixing the code** and pushing a new commit to the same branch, or
+     - **Replying on the finding thread** with a clear rebuttal explaining why the finding does not apply (for false positives or scope disagreements).
+
+     P2 and P3 findings are addressed at the agent's judgment — not every cosmetic or nit-level finding needs a fix or a rebuttal.
+
+14a. The agent increments its round counter and re-runs `scripts/codex-review-request.sh` to request a re-review of the new HEAD.
+
+15a. The loop continues until one of the following terminates it:
+
+     - **Clearance (happy path).** Codex posts a review with no unaddressed P0/P1 inline findings on the current HEAD, OR reacts 👍 on or after the current HEAD commit. Proceed to step 16a.
+     - **Disagreement (escalate).** Codex re-flags the same finding after the agent posted a rebuttal. This is "repeat-after-rebuttal." See [Disagreements and Tiebreaking](#disagreements-and-tiebreaking).
+     - **Runaway (escalate).** The round counter exceeds `codex.max_review_rounds` (default: 2). The 3rd round trips this guard. See [Disagreements and Tiebreaking](#disagreements-and-tiebreaking).
+     - **Timeout (fall back).** `codex-review-request.sh` exits with code `4` (`FALLBACK_REQUIRED`) for the current round. The agent falls back to Phase 4b. There is no "second timeout" escalation — a single timeout already routes to human mediation via the 4b handoff.
+
+16a. Before merging, the agent runs `scripts/codex-review-check.sh <PR#>` to verify the merge gate. All of the following must be true:
+
+     - `gh pr checks` reports all required CI checks green
+     - A reviewer identity from `available_reviewers` has posted an `APPROVED` review (Phase 2 internal self-peer review)
+     - Codex has signaled clearance on the current HEAD via one of the two forms in step 12a
+
+     **The merge gate must never require an `APPROVED` review state from `chatgpt-codex-connector[bot]` — the app does not emit that state.** This point is load-bearing; a merge gate that looks for Codex APPROVED will never be satisfied and the Phase 4a happy path will be unreachable.
+
+17a. On a passing merge gate, `nathanjohnpayne` merges the PR with `gh pr merge <n> --squash --delete-branch`. Never `--admin` unless the human explicitly authorizes a break-glass override in chat.
+
+#### Phase 4b: Manual CLI Fallback (Human Handoff)
+
+Phase 4b is invoked when Phase 4a escalates to disagreement or runaway, times out (single timeout, exit code `4` from `codex-review-request.sh`), or when `codex.enabled: false` in the repo. It preserves the cross-agent review flow that existed before the Codex GitHub App integration and provides a human-mediated escape hatch.
+
+11b. The authoring agent posts the handoff message (see [Handoff Message Format](#handoff-message-format)) as a PR comment and alerts the human.
+
+12b. The human takes the handoff message to a different agent session (e.g., from Claude to Cursor, or to a Codex CLI session authenticated as `nathanpayne-codex`).
+
+13b. The external agent's reviewer identity reviews the PR and posts review comments. Unlike the Codex GitHub App, CLI-driven reviews use the standard GitHub review states (`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`) as expected.
+
+14b. The human relays the external reviewer's feedback back to the originating agent.
+
+15b. The originating agent, as `nathanjohnpayne`, addresses the feedback and pushes fix commits to the same branch.
+
+16b. The human shuttles updated code back to the external reviewer.
+
+17b. Steps 13b–16b repeat until the external reviewer submits an `APPROVED` review.
+
+18b. If the external reviewer flags **observations** or **risks** while approving, those are converted to GitHub Issues on the repo, assigned to `nathanjohnpayne` (see [Post-Merge Issue Creation](#post-merge-issue-creation)).
+
+19b. `nathanjohnpayne` merges the PR. Done.
 
 ### Flow Diagram
 
@@ -187,21 +245,50 @@ Before moving past Phase 2.5, confirm all of the following:
   │  Lines changed ≥ threshold OR protected paths touched?   │
   │                                                          │
   │  NO ──→ nathanjohnpayne merges. Done.                    │
-  │  YES ──→ Post handoff message. Alert human.              │
+  │  YES ──→ Proceed to Phase 4                              │
   └──────────────────────────┬──────────────────────────────┘
                              │
                              ▼
   ┌─────────────────────────────────────────────────────────┐
-  │  PHASE 4: EXTERNAL REVIEW                                │
-  │  Human hands PR to different agent                       │
-  │  External nathanpayne-{agent} reviews → posts comments   │
-  │  Human relays feedback to original agent                 │
-  │  nathanjohnpayne fixes → human relays back               │
-  │  ↻ Repeat until external reviewer approves               │
-  │                                                          │
-  │  Observations/risks → GitHub Issues                      │
-  │  nathanjohnpayne merges. Done.                           │
-  └─────────────────────────────────────────────────────────┘
+  │  PHASE 4a: AUTOMATED EXTERNAL REVIEW                    │
+  │  (Codex GitHub App, default when codex.enabled: true)   │
+  │                                                         │
+  │  round ← 1                                              │
+  │  Agent runs codex-review-request.sh                     │
+  │    → Codex posts COMMENTED review OR 👍 reaction        │
+  │                                                         │
+  │  ┌─ no unaddressed P0/P1 findings → clearance           │
+  │  ├─ P0/P1 findings → fix or reply; round += 1; repeat   │
+  │  ├─ repeat-after-rebuttal → ESCALATE (Disagreements)    │
+  │  ├─ round > max_review_rounds → ESCALATE (Disagreements)│
+  │  └─ timeout (exit code 4) → FALL BACK to Phase 4b       │
+  └──────────────┬───────────────────────┬──────────────────┘
+                 │ clearance              │ escalate / fallback
+                 ▼                        ▼
+  ┌──────────────────────────┐  ┌────────────────────────────┐
+  │  MERGE GATE:             │  │  PHASE 4b: MANUAL CLI      │
+  │  codex-review-check.sh   │  │  FALLBACK                  │
+  │                          │  │                            │
+  │  • gh pr checks = green  │  │  Post handoff message;     │
+  │  • internal reviewer     │  │  alert human.              │
+  │    identity APPROVED     │  │                            │
+  │  • Codex cleared on HEAD │  │  Human takes handoff to    │
+  │    via COMMENTED-no-P0/1 │  │  different agent CLI       │
+  │    OR 👍 reaction        │  │  (e.g. nathanpayne-codex). │
+  │                          │  │                            │
+  │  (NEVER expects APPROVED │  │  External reviewer posts   │
+  │   state from Codex bot —  │  │  comments / APPROVED /     │
+  │   the app does not emit  │  │  CHANGES_REQUESTED.         │
+  │   that state.)           │  │                            │
+  └──────────┬───────────────┘  │  Human relays feedback.    │
+             │                  │  Agent fixes. Repeat.       │
+             ▼                  │                            │
+  ┌──────────────────────────┐  │  Observations/risks →      │
+  │  nathanjohnpayne merges  │  │  GitHub Issues             │
+  │  (--squash). Done.       │  │                            │
+  └──────────────────────────┘  │  nathanjohnpayne merges.   │
+                                │  Done.                     │
+                                └────────────────────────────┘
 ```
 
 ## Handoff Message Format
@@ -248,7 +335,40 @@ These issues are tracked like any other work item. They are not blockers to the 
 
 ## Disagreements and Tiebreaking
 
-If the internal reviewer and external reviewer disagree on whether code is ready to merge, the human is the tiebreaker. The agent should surface the disagreement clearly, summarizing both positions, and wait for the human's decision.
+When the internal reviewer and external reviewer disagree on whether code is ready to merge, the human is the tiebreaker. The agent surfaces the disagreement clearly, summarizing both positions, and waits for the human's explicit decision before taking further action.
+
+### Concrete detection signals (Phase 4a)
+
+In Phase 4a, the agent escalates to the human when either of the following fires:
+
+1. **Repeat-after-rebuttal.** The agent posted a reply to a Codex inline finding explaining why the finding does not apply. Codex's next review re-flags the same or substantively-equivalent finding. The agent treats this as a disagreement: Codex is not convinced by the rebuttal, and the agent stops trying to change Codex's mind autonomously. Continuing the loop past this point is rude to the reviewer and wastes API calls.
+
+2. **Runaway rounds.** The round counter exceeds `codex.max_review_rounds` (default: 2). The 3rd `@codex review` request trips this guard. This catches cases where Codex keeps finding new, distinct issues on each pass without the review converging. Even if each individual finding is valid, three rounds of novel issues is a signal that the PR scope is too broad and a human should weigh in.
+
+**Timeout is NOT a disagreement signal.** A Codex response timeout (`codex-review-request.sh` exit code `4` = `FALLBACK_REQUIRED`) routes the PR directly to Phase 4b per step 15a above. It is a fallback trigger, not a tiebreaker trigger. Phase 4b itself mediates via the human through the manual handoff, so there is nothing for the disagreement detector to add on top.
+
+Phase 4b escalation (the traditional cross-agent CLI flow) uses the human's judgment directly — there is no automated detection loop to fire, so this subsection does not apply there.
+
+### Escalation procedure
+
+When either of the two signals above fires, the agent:
+
+1. **Stops the automated loop immediately.** Does NOT push more commits, does NOT re-run `@codex review`, does NOT run the merge gate, does NOT merge.
+2. **Posts a comment on the PR** summarizing:
+   - Which signal fired and what triggered it
+   - Both positions (the agent's and Codex's) in plain language, with links to the specific review rounds and the rebuttal replies
+   - The current round counter and a link to the `scripts/codex-review-request.sh` output from the terminating round
+3. **Alerts the human via chat** and waits for an explicit decision before taking any further action on the PR.
+
+Note that timeout does NOT go through this escalation procedure. On a timeout (exit code `4` from `codex-review-request.sh`), the agent posts the handoff message per [Handoff Message Format](#handoff-message-format) and routes to Phase 4b directly from step 15a — no in-place tiebreaker.
+
+The human resolves by one of:
+
+- **Approving the existing state** — posting an `APPROVED` review as `nathanjohnpayne` or removing the `needs-external-review` label manually. This unblocks merge under the label-gate rules in [Review Policy Configuration](#review-policy-configuration).
+- **Requesting additional changes** — typing the feedback directly in chat. The agent addresses it as normal edits. No `@codex review` loop, no round counter.
+- **Taking the PR over manually** — the human merges on behalf of the agent, or closes and reopens with a different approach, or promotes the escalation to Phase 4b manually.
+
+The agent never resolves a fired escalation signal on its own.
 
 ## Review Policy Configuration
 
@@ -282,7 +402,33 @@ available_reviewers:
 # Default suggestion when the agent needs to recommend an external reviewer.
 # The agent may override this suggestion based on context.
 default_external_reviewer: nathanpayne-codex
+
+# Author identity under which all agents commit and merge.
+author_identity: nathanjohnpayne
+
+# CodeRabbit (Phase 2.5 advisory automated review).
+# Enabled on public repos only; advisory, does not block merge.
+# NOTE: This flag governs AGENT behavior only (whether agents wait for
+# CodeRabbit in Phase 2.5). It does NOT control whether the CodeRabbit
+# GitHub App itself runs — the App runs based on its own install state.
+# To fully disable CodeRabbit, uninstall the GitHub App AND set this flag.
+coderabbit:
+  enabled: false
+
+# Codex (Phase 4a automated external review) — see Phase 4a above.
+# Same semantics note as coderabbit: this flag governs agent behavior,
+# not app runtime. The ChatGPT Codex Connector App runs based on its
+# per-repo install state and its "Automatic reviews" setting.
+codex:
+  enabled: true
+  bot_login: "chatgpt-codex-connector[bot]"   # REST API form, with [bot] suffix
+  cli_login: nathanpayne-codex                # manual CLI fallback (Phase 4b)
+  max_review_rounds: 2                        # runaway guard; 3rd round escalates
+  review_timeout_seconds: 600                 # per-round poll timeout
+  require_ci_green: true                      # merge gate
 ```
+
+> **Note on `enabled` flags (both `coderabbit` and `codex`).** These flags govern **agent behavior only** — whether the authoring agent waits for the corresponding review in its phase. They do NOT control whether the underlying GitHub App runs. Both apps run based on their own install state on GitHub, independent of what this YAML says. Setting `enabled: false` alone will cause the agent to skip the corresponding phase while the app continues to post reviews silently in the background. This may be desired as a "dark launch," but can confuse readers who expect the flag to mean "off." To fully disable an integration, uninstall the GitHub App AND set the flag to false.
 
 ### Threshold Evaluation
 
@@ -346,27 +492,37 @@ git remote set-url origin git@github.com:nathanjohnpayne/repo-name.git
 
 For posting PR reviews and comments under a reviewer identity, use `gh` with an
 explicit PAT from 1Password. Do not rely on the GitHub connector session or on
-the ambient `gh` login.
+the ambient `gh` login. Refer to the [PAT lookup table](#pat-lookup-table) for
+your agent's 1Password item ID.
 
 ```bash
-# Example: verify the Codex reviewer identity before posting the review
-GH_TOKEN="$(op read 'op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token')" \
-  gh api user --jq '.login'
-# expected: nathanpayne-codex
+# ── Preferred: use preflight-cached PATs (no biometric prompts) ──
 
-# Post the review with the same explicit token
-GH_TOKEN="$(op read 'op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token')" \
+# As reviewer (after running op-preflight.sh):
+GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq '.login'
+# expected: nathanpayne-claude
+
+GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" \
+  gh pr review <PR#> --repo <owner/repo> --approve --body "Review comment"
+
+# As author (merge, address comments, etc.):
+GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT" gh pr merge <PR#> --merge
+
+# ── Fallback: inline op read (triggers biometric if session expired) ──
+
+GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
   gh pr review <PR#> --repo <owner/repo> --approve --body "Review comment"
 ```
 
+- Use the item ID from the [PAT lookup table](#pat-lookup-table) for your agent identity. Do not use the 1Password item title.
 - If `gh auth status` shows `nathanjohnpayne`, that is fine.
   `GH_TOKEN=...` overrides the ambient login for that command.
 - If `op whoami` says you are not signed in, still run the `op read ...`
   command in an interactive TTY. That is what triggers the 1Password biometric
   prompt on local machines.
 - If GitHub returns `Review Can not approve your own pull request`, the wrong
-  reviewer identity is still being used.
-- Use the 1Password item ID, not the item title, in `op read`.
+  reviewer identity is still being used. Check the [PAT lookup table](#pat-lookup-table)
+  and verify you are using your agent's item ID, not the author identity's.
 
 > **If `op read` fails with a sign-in or biometric error here**, follow the pause-and-prompt procedure in `docs/agents/operating-rules.md` under "1Password CLI authentication failures." Do not hardcode tokens, skip review, or retry in a loop.
 
@@ -376,7 +532,7 @@ Reviewer accounts are **collaborators** on repos owned by `nathanjohnpayne`. Thi
 
 - **Classic PATs with `repo` scope** — required for collaborator accounts. Fine-grained PATs on personal (non-org) GitHub accounts only cover repos the account *owns*. The "All repositories" scope means all owned repos (zero for collaborators), and "Only select repositories" does not list collaborator repos.
 - Store each PAT in 1Password as `GitHub PAT (pr-review-{agent})` with a concealed field named `token`.
-- Access via item ID to avoid shell escaping issues with parentheses in the title: `op read "op://Private/<item-uuid>/token"`
+- Access via item ID to avoid shell escaping issues with parentheses in the title. See the [PAT lookup table](#pat-lookup-table) for all current item IDs.
 
 ### 1Password SSH agent setup (one-time)
 
@@ -445,7 +601,7 @@ This policy and the accompanying `review-policy.yml` should be included in every
 5. Ensure all agent environments have credentials configured for the repo.
 6. If the repo is public, enable secret scanning and push protection via GitHub settings (or API).
 7. If the repo is public and using CodeRabbit, set `coderabbit.enabled: true` in `.github/review-policy.yml` and install the CodeRabbit GitHub App on the repo.
-8. The `.coderabbit.yml` file at the repo root ships with the template and requires no per-repo customization for default behavior.
+8. The `.coderabbit.yml` file at the repo root ships with the template and works out of the box. Customize `reviews.path_instructions` to add repo-specific review guidance (e.g., flag currency rounding in billing code, verify type compatibility in shared packages).
 
 ### CodeRabbit Removal
 

--- a/rules/repo_rules.md
+++ b/rules/repo_rules.md
@@ -64,5 +64,6 @@ The following checks are implemented in `scripts/ci/` and must pass before any c
 5. `check_spec_test_alignment` — Verifies every file in specs/ has a corresponding test file in tests/react/ (advisory; skips if specs/ is empty)
 6. `check_duplicate_docs` — Verifies no documentation topic is duplicated between root files and tool folders
 7. `check_review_policy_exists` — Verifies .github/review-policy.yml and REVIEW_POLICY.md both exist
+8. `check_codex_scripts` — Verifies `scripts/codex-review-request.sh` and `scripts/codex-review-check.sh` exist and are executable. Required for Phase 4a automated external review.
 
 Additionally, `npm test` includes a secret scan (`scripts/check-no-public-secrets.mjs`) that must pass on every commit.

--- a/scripts/ci/check_codex_scripts
+++ b/scripts/ci/check_codex_scripts
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# check_codex_scripts
+#
+# Verifies that the Phase 4a Codex helper scripts are present and
+# executable. Both are required for `CLAUDE.md` step 8 Phase 4a to
+# be able to run, and both are referenced by the gh-pr-guard.sh hook
+# and REVIEW_POLICY.md § Phase 4a. Missing either script breaks the
+# automated external-review flow and silently drops callers to the
+# Phase 4b manual CLI fallback.
+#
+# Enforces the `rules/repo_rules.md` § CI Enforcement entry for
+# these scripts. See issue #38 and Project #2 for the broader
+# context.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+REQUIRED_SCRIPTS=(
+  "scripts/codex-review-request.sh"
+  "scripts/codex-review-check.sh"
+)
+
+FAILED=0
+
+for rel in "${REQUIRED_SCRIPTS[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [[ ! -f "$full" ]]; then
+    echo "FAIL: Missing required Codex helper script: $rel"
+    FAILED=1
+    continue
+  fi
+  if [[ ! -x "$full" ]]; then
+    echo "FAIL: Codex helper script is not executable: $rel"
+    echo "      Fix with: chmod +x $rel"
+    FAILED=1
+  fi
+done
+
+if [[ $FAILED -eq 1 ]]; then
+  echo "check_codex_scripts: FAIL"
+  exit 1
+fi
+
+echo "check_codex_scripts: PASS"
+exit 0

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -1,0 +1,648 @@
+#!/usr/bin/env bash
+# scripts/codex-review-check.sh — Phase 4a merge gate
+#
+# Verifies that a pull request is ready to merge under the Phase 4a
+# automated external review flow. Read-only. Never merges, labels, or
+# comments on the PR.
+#
+# Usage:
+#   scripts/codex-review-check.sh <PR_NUMBER> [REPO]
+#
+# Arguments:
+#   PR_NUMBER  Required. The pull request number (integer).
+#   REPO       Optional. "owner/repo". Defaults to the current repo.
+#
+# Environment:
+#   GH_TOKEN   Required. Needs pull_requests:read + checks:read.
+#
+# Merge gate (all three must pass):
+#
+#   (a) Required CI checks are green.
+#       `gh pr checks` reports no failing or pending required checks.
+#
+#   (b) At least one APPROVED review from a reviewer identity in
+#       codex.available_reviewers (e.g., nathanpayne-claude,
+#       nathanpayne-cursor, nathanpayne-codex) is present on the PR,
+#       from an account != the PR author.
+#
+#   (c) Codex has cleared on or after the current HEAD commit via one
+#       of two signals:
+#
+#         - A COMMENTED review from the Codex bot on the current HEAD
+#           with NO unaddressed P0/P1 inline findings, OR
+#         - A +1 / 👍 reaction from the Codex bot on the PR issue
+#           with created_at >= current HEAD committer date.
+#
+#       The merge gate explicitly does NOT require an APPROVED review
+#       state from the Codex bot. The ChatGPT Codex Connector GitHub
+#       App never emits APPROVED — it uses COMMENTED with inline
+#       findings, or no review at all when it reacts 👍. See #29 for
+#       live observational evidence from the PR #53 bootstrap.
+#
+# "Unaddressed" heuristic for v1:
+#   A P0/P1 finding is considered unaddressed if it exists on the
+#   current HEAD (original_commit_id == HEAD or commit_id == HEAD) in
+#   Codex's LATEST review round. Findings from earlier rounds that
+#   are not re-raised by Codex on the current HEAD are considered
+#   implicitly addressed — the agent either fixed them or Codex
+#   accepted a rebuttal. This is the simpler end of the two options
+#   discussed in the #35 refinement; see #35 comment thread for the
+#   reply-matching version if false-negatives become a problem.
+#
+# Exit codes:
+#   0   All three gate conditions pass; PR is mergeable.
+#   1   At least one gate condition fails. A one-line reason is
+#       printed to stderr.
+#   3   API / infrastructure error. Error message on stderr.
+#
+# Design notes:
+#   - Read-only. The only API calls are GETs: pulls, reviews, comments,
+#     reactions, commits, checks. No POSTs, no PATCHes, no DELETEs.
+#   - Uses jq for all JSON parsing. No ad-hoc string extraction.
+#   - The available_reviewers list is read from .github/review-policy.yml
+#     at runtime via the same state-machine awk parser used in
+#     agent-review.yml post-#54.
+#
+# References:
+#   - Project #2 — External Review (Phase 4 Review)
+#   - #35 — this script
+#   - #29 — live observations
+#   - REVIEW_POLICY.md § Phase 4a merge gate (canonical policy)
+#   - #37 — scripts/hooks/gh-pr-guard.sh extension that will call this
+#     script before allowing `gh pr merge` on a labeled PR
+
+set -euo pipefail
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <PR_NUMBER> [REPO]" >&2
+  exit 3
+fi
+
+PR_NUMBER=$1
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 3
+fi
+
+REPO=${2:-}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 3
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 3
+fi
+
+# --- config readers ---------------------------------------------------------
+
+CONFIG=".github/review-policy.yml"
+
+# Read a scalar field from the codex: block. See agent-review.yml
+# post-#54 for the rationale on the state-machine awk parser.
+codex_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^codex:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && $1 == field":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0)
+      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+BOT_LOGIN=$(codex_field bot_login)
+BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
+
+REACTION_FRESHNESS_SECONDS=$(codex_field reaction_freshness_window_seconds)
+REACTION_FRESHNESS_SECONDS=${REACTION_FRESHNESS_SECONDS:-1800}
+if ! [[ "$REACTION_FRESHNESS_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: codex.reaction_freshness_window_seconds must be an integer; got '$REACTION_FRESHNESS_SECONDS'" >&2
+  exit 3
+fi
+
+# Honor codex.require_ci_green. When true (default), gate (a) runs
+# and any non-passing required check blocks merge. When false, gate
+# (a) is skipped — useful for emergency or manual flows where CI
+# is intentionally bypassed. Codex caught the missing wire-up on
+# the nathanpaynedotcom propagation PR #180 (the field was read by
+# the policy parser and documented in the codex: block but never
+# actually consulted by this script).
+REQUIRE_CI_GREEN=$(codex_field require_ci_green)
+REQUIRE_CI_GREEN=${REQUIRE_CI_GREEN:-true}
+
+# Read the available_reviewers list (one per line). Same state-machine
+# awk pattern, but collecting list items rather than matching a scalar.
+# Outputs one reviewer login per line to stdout. Handles both quoted
+# (`  - "name"`) and unquoted (`  - name`) list item formats.
+read_available_reviewers() {
+  [ -f "$CONFIG" ] || return 0
+  awk '
+    /^available_reviewers:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && /^ *-/ {print}
+  ' "$CONFIG" | sed -E 's/^[[:space:]]*-[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/'
+}
+
+REVIEWERS=$(read_available_reviewers)
+if [ -z "$REVIEWERS" ]; then
+  echo "ERROR: no available_reviewers found in $CONFIG" >&2
+  exit 3
+fi
+
+# --- logging helpers --------------------------------------------------------
+
+log() {
+  echo "[codex-review-check] $*" >&2
+}
+
+fail_gate() {
+  echo "[codex-review-check] FAIL: $*" >&2
+  exit 1
+}
+
+die() {
+  local code=$1
+  shift
+  echo "[codex-review-check] ERROR: $*" >&2
+  exit "$code"
+}
+
+# Fetch a paginated GitHub REST API endpoint and return the flattened JSON
+# array on stdout. See the identical helper in codex-review-request.sh for
+# the rationale; both scripts need the same fix (#64 review finding 3).
+fetch_api_array() {
+  local endpoint=$1
+  local label=$2
+  local raw
+  raw=$(gh api --paginate "$endpoint" 2>&1) || die 3 "failed to fetch $label: $raw"
+  echo "$raw" | jq -s 'add // []' 2>/dev/null \
+    || die 3 "failed to flatten $label pagination output"
+}
+
+# --- fetch PR metadata ------------------------------------------------------
+
+log "PR $REPO#$PR_NUMBER — fetching metadata"
+
+PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) || die 3 "failed to fetch PR metadata: $PR_JSON"
+
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+  die 3 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+
+HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
+  || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
+
+# HEAD_PUSHED_AT: the timestamp to use as the "when did this commit
+# become current on THIS PR" anchor for reaction freshness. Committer
+# date is commit metadata and can be ARBITRARILY OLD if someone force-
+# pushes a previously-authored commit — a stale Codex 👍 from a prior
+# HEAD would then satisfy `reaction.created_at >= committer_date` even
+# though the reaction predates the current HEAD's existence on this
+# PR. See #64 Codex P1 finding ("Anchor reaction freshness to PR head
+# update time") and the #65 round-1/2/3 follow-up findings.
+#
+# Iteration history and why the obvious fixes don't work:
+#
+#   Round 1 tried `repos/{repo}/commits/{sha}/check-runs`. Rejected:
+#   that endpoint is COMMIT-scoped, not PR-scoped — if the same SHA
+#   ran in an earlier context (different branch, previous PR, direct
+#   push to main), the earliest check-run's started_at comes from
+#   THAT context and leaks across PRs.
+#
+#   Round 2 tried `repos/{repo}/issues/{pr}/timeline` with a
+#   `head_ref_force_pushed` event selector. Better: that endpoint is
+#   strictly PR-scoped. BUT it only covers force-push. For ORDINARY
+#   push / fast-forward to a descendant commit, the timeline emits a
+#   `committed` event whose `created_at` is `null` — verified against
+#   PR #63's raw timeline payload on 2026-04-15. There is no per-PR
+#   push timestamp for non-force pushes in the GitHub API.
+#
+# The ordinary-push hole:
+#
+#   Scenario — PR HEAD is at commit A, Codex reacts 👍 on the PR at
+#   time T1, then the PR is advanced via ordinary push (fast-forward)
+#   to descendant commit B whose committer date is OLDER than T1
+#   (e.g., cherry-pick of a pre-existing SHA, or a commit authored
+#   weeks ago and just now pushed). The stale 👍 from HEAD A would
+#   pass `reaction.created_at >= HEAD_COMMITTER_DATE` on HEAD B and
+#   false-clear gate (c) because the anchor can only be advanced by a
+#   signal we don't have access to.
+#
+# Two-layer mitigation applied below:
+#
+#   Layer 1 — per-PR push anchor via force-push events. For the cases
+#   where a per-PR push time IS observable (force-push), use it.
+#   Start with HEAD_COMMITTER_DATE as the base (correct for the
+#   common case where committer date ≈ push time), then override to
+#   `head_ref_force_pushed.created_at` if later. This closes the
+#   force-push-of-old-commit variant identified in the #64 review.
+#
+#   Layer 2 — reaction freshness floor. Bound the exposure window of
+#   the residual ordinary-push-old-committer-date hole by requiring a
+#   👍 reaction to be within `codex.reaction_freshness_window_seconds`
+#   of the gate-check time. A stale 👍 from a prior HEAD that outlives
+#   the window is automatically filtered out, regardless of how old
+#   the new HEAD's committer date is. Default 1800s (30 min) is
+#   generous for the typical Phase 4a cycle (1–5 min push → clearance)
+#   while catching cross-cycle stale 👍s. See review-policy.yml
+#   `codex.reaction_freshness_window_seconds` for the full rationale.
+#
+# Residual hole: if the stale 👍 is within the freshness window AND
+# the new HEAD was pushed via ordinary push AND the new HEAD has an
+# old committer date, a false clear is still mechanically possible.
+# That combination is narrow — it requires a rebased/cherry-picked
+# old commit pushed within the freshness window after a prior-HEAD
+# 👍. Closing it fully would require a per-PR push timestamp that
+# GitHub does not currently expose.
+HEAD_PUSHED_AT="$HEAD_COMMITTER_DATE"
+
+TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
+
+LATEST_FORCE_PUSH_TIME=$(echo "$TIMELINE_JSON" | jq -r '
+  [ .[] | select(.event == "head_ref_force_pushed") | .created_at ]
+  | max // ""
+')
+
+if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_PUSHED_AT" ]]; then
+  HEAD_PUSHED_AT="$LATEST_FORCE_PUSH_TIME"
+  ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
+else
+  ANCHOR_SOURCE="HEAD committer date"
+fi
+
+# Compute freshness floor = NOW - reaction_freshness_window_seconds.
+# ISO 8601 UTC so it sorts lexicographically against reaction
+# created_at values. Cross-platform epoch→ISO conversion: try BSD
+# `date -r` first (macOS), fall back to GNU `date -d @...` (Linux).
+EPOCH_NOW=$(date +%s)
+EPOCH_FLOOR=$((EPOCH_NOW - REACTION_FRESHNESS_SECONDS))
+if REACTION_FLOOR_ISO=$(date -u -r "$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+  :
+else
+  REACTION_FLOOR_ISO=$(date -u -d "@$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+    || die 3 "could not compute reaction freshness floor from epoch $EPOCH_FLOOR"
+fi
+
+# Effective threshold a 👍 reaction must satisfy = max(HEAD_PUSHED_AT,
+# REACTION_FLOOR_ISO). Both are ISO 8601 UTC; lexicographic comparison
+# is chronological.
+if [[ "$REACTION_FLOOR_ISO" > "$HEAD_PUSHED_AT" ]]; then
+  REACTION_THRESHOLD="$REACTION_FLOOR_ISO"
+  REACTION_THRESHOLD_SOURCE="freshness floor (NOW - ${REACTION_FRESHNESS_SECONDS}s = $REACTION_FLOOR_ISO)"
+else
+  REACTION_THRESHOLD="$HEAD_PUSHED_AT"
+  REACTION_THRESHOLD_SOURCE="HEAD pushed-at anchor ($HEAD_PUSHED_AT, source: $ANCHOR_SOURCE)"
+fi
+
+log "HEAD = $HEAD_SHA    author = $PR_AUTHOR"
+log "committer_date = $HEAD_COMMITTER_DATE"
+log "anchor = $HEAD_PUSHED_AT (source: $ANCHOR_SOURCE)"
+log "reaction_threshold = $REACTION_THRESHOLD (source: $REACTION_THRESHOLD_SOURCE)"
+
+# --- preflight: blocking labels --------------------------------------------
+#
+# `needs-human-review` is applied by the detect-disagreement job in
+# agent-review.yml when two reviewers have opposing opinionated states —
+# a human must resolve it. `policy-violation` is applied by
+# block-self-approval when a reviewer bot tries to approve its own PR.
+# Both block merge categorically and are not resolvable by Phase 4a flow.
+#
+# Note: `needs-external-review` is NOT a blocking label from this script's
+# perspective — it's the signal that this script should run, not a block.
+# Gate (c) resolves whether the external review is actually complete.
+PR_LABELS=$(echo "$PR_JSON" | jq -r '[.labels[].name] | join(",")')
+case ",$PR_LABELS," in
+  *,needs-human-review,*)
+    fail_gate "blocking label 'needs-human-review' present — human disagreement resolution required"
+    ;;
+  *,policy-violation,*)
+    fail_gate "blocking label 'policy-violation' present — policy violation must be resolved"
+    ;;
+esac
+
+# --- gate (a): CI checks green ---------------------------------------------
+
+if [ "$REQUIRE_CI_GREEN" != "true" ]; then
+  log "gate (a): SKIPPED (codex.require_ci_green=$REQUIRE_CI_GREEN)"
+else
+
+log "gate (a): checking CI state"
+
+# Use the structured statusCheckRollup instead of `gh pr checks` so we can
+# filter out checks that are EXPECTED to be failing during Phase 4a flow:
+#
+#   - "Label Gate" (from the "PR Review Policy" workflow) fails by design
+#     whenever `needs-external-review`, `needs-human-review`, or
+#     `policy-violation` is present on the PR. During Phase 4a, the first
+#     of those labels is always set by pr-review-policy.yml, so Label Gate
+#     will fail. It's the enforcement mechanism for "don't merge until
+#     external review clears" — NOT a code-quality signal. We verify
+#     external review clearance separately in gate (b) below.
+#
+# All OTHER checks must be in a successful or explicitly skipped terminal
+# state. A check still running (no conclusion yet) is treated as not-green
+# — the caller should wait or retry. SKIPPED is treated as success because
+# many Agent Review Pipeline jobs skip by design when the label is set.
+ROLLUP_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup 2>&1) \
+  || die 3 "failed to fetch statusCheckRollup: $ROLLUP_JSON"
+
+# statusCheckRollup mixes two entry types:
+#   - CheckRun (GitHub Actions jobs): uses .name, .workflowName,
+#     .status, .conclusion (SUCCESS/SKIPPED/FAILURE/NEUTRAL/CANCELLED/
+#     TIMED_OUT/ACTION_REQUIRED).
+#   - StatusContext (commit statuses, e.g. CodeRabbit): uses .context
+#     (as the label) and .state (SUCCESS/FAILURE/PENDING/ERROR/EXPECTED).
+#     No .workflowName, .name, .status, or .conclusion.
+#
+# Normalize both into {label, workflow, result}, then accept only
+# SUCCESS / SKIPPED / NEUTRAL as non-blocking.
+# Determine which checks are REQUIRED via branch protection. Without
+# this filter, gate (a) blocks on any non-passing check in the
+# rollup including optional / informational ones that branch
+# protection wouldn't actually require for merge. nathanpayne-codex
+# caught the over-strict behavior on swipewatch propagation PR #33
+# round 4.
+#
+# The base branch is read from PR_JSON. If branch protection isn't
+# configured (or returns empty), fall back to the prior behavior
+# (consider all checks). If branch protection IS configured, only
+# checks listed in required_status_checks.contexts AND/OR
+# required_status_checks.checks[].context block the gate.
+BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.base.ref')
+REQUIRED_CHECK_NAMES=$(gh api "repos/$REPO/branches/$BASE_BRANCH/protection/required_status_checks" 2>/dev/null \
+  | jq -r '[.contexts[]?, .checks[]?.context] | unique | .[]' 2>/dev/null \
+  || true)
+
+if [ -z "$REQUIRED_CHECK_NAMES" ]; then
+  # No required-check list available. This can happen because:
+  #   - The branch has no branch protection rules at all, OR
+  #   - The token lacks Administration:read scope (which the
+  #     required_status_checks endpoint requires).
+  #
+  # Earlier versions treated "no list" as "all checks required",
+  # which caused over-strict blocking when the token lacked perms
+  # and optional/flaky checks happened to be failing. Codex caught
+  # this on swipewatch propagation PR #33 round 8.
+  #
+  # New behavior: log a warning and SKIP the required-check filter
+  # entirely, letting gate (a) pass. The rationale is that if
+  # branch protection isn't configured or the token can't read it,
+  # the BRANCH PROTECTION ITSELF doesn't enforce required checks,
+  # so gate (a) shouldn't either.
+  log "gate (a): WARNING — could not determine required checks from branch protection for $BASE_BRANCH (no rules configured or token lacks Administration:read scope). Skipping required-check filter — all checks treated as passing this gate."
+  # Skip gate (a) entirely for this case
+  ROLLUP_JSON='{"statusCheckRollup":[]}'
+  REQUIRED_JSON='[]'
+else
+  # Build a jq array of required check names
+  REQUIRED_JSON=$(echo "$REQUIRED_CHECK_NAMES" | jq -R . | jq -s .)
+fi
+
+BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:-[]}" '
+  [.statusCheckRollup[]
+    | {
+        label: (.name // .context // "?"),
+        workflow: (.workflowName // ""),
+        result: (.conclusion // .state // "")
+      }
+    # Filter out the known "expected to fail during Phase 4a" check.
+    # Label Gate lives in the "PR Review Policy" workflow and fails by
+    # design whenever needs-external-review / needs-human-review /
+    # policy-violation is set. That enforcement is what Phase 4a is
+    # trying to unblock; we verify clearance separately in gate (c).
+    | select(
+        (.workflow != "PR Review Policy") or
+        (.label != "Label Gate")
+      )
+    # When branch protection lists required checks, only those
+    # checks block the gate. When the list is empty (no branch
+    # protection configured or query failed), fall back to the
+    # prior behavior of treating all checks as required.
+    | select(
+        ($required_names | length) == 0
+        or ($required_names | index(.label)) != null
+      )
+    # A check passes the gate iff its result is SUCCESS, SKIPPED, or
+    # NEUTRAL. Everything else — FAILURE, CANCELLED, TIMED_OUT,
+    # ACTION_REQUIRED, PENDING, EXPECTED, ERROR, or unknown — blocks.
+    | select(
+        (.result != "SUCCESS") and
+        (.result != "SKIPPED") and
+        (.result != "NEUTRAL")
+      )
+  ]
+')
+
+BAD_COUNT=$(echo "$BAD_CHECKS" | jq 'length')
+
+if [ "$BAD_COUNT" -gt 0 ]; then
+  SUMMARY=$(echo "$BAD_CHECKS" | jq -r '
+    [.[] | (if .workflow == "" then .label else "\(.workflow)/\(.label)" end) + "=" + .result]
+    | unique | join(", ")
+  ')
+  fail_gate "CI not green: $BAD_COUNT non-passing check(s): $SUMMARY"
+fi
+
+log "gate (a): CI is green (Label Gate failure, if present, is expected during Phase 4a)"
+
+fi  # end REQUIRE_CI_GREEN
+
+# --- gate (b): reviewer identity approval ----------------------------------
+
+log "gate (b): checking for latest-state APPROVED review from a reviewer identity"
+
+REVIEWS_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
+
+# Build a JSON array of reviewer logins for the filter.
+REVIEWERS_JSON=$(echo "$REVIEWERS" | jq -R . | jq -s .)
+
+# Take each reviewer identity's LATEST OPINIONATED review state — where
+# "opinionated" means APPROVED, CHANGES_REQUESTED, or DISMISSED. COMMENTED
+# reviews are informational and do not change a reviewer's position. The
+# gate passes iff at least one reviewer identity's latest opinionated
+# state is APPROVED.
+#
+# Note (#64 review finding 1): the previous implementation matched any
+# historical APPROVED review, which meant a reviewer who approved at t=0
+# and later submitted CHANGES_REQUESTED at t=5 still cleared the gate.
+# The group_by + max_by pattern below fixes that by collapsing each
+# reviewer's review history down to their latest opinionated state.
+#
+# Multi-reviewer disagreement (one reviewer approves, another requests
+# changes) is caught by the preflight blocking-label check above: the
+# Agent Review Pipeline's detect-disagreement job applies
+# `needs-human-review`, which the preflight rejects before this gate runs.
+APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
+  --argjson reviewers "$REVIEWERS_JSON" \
+  --arg author "$PR_AUTHOR" '
+    [ .[]
+      | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+      | select(.user.login as $u | $reviewers | index($u))
+      | select(.user.login != $author)
+    ]
+    | group_by(.user.login)
+    | map(max_by(.submitted_at))
+    | map(select(.state == "APPROVED"))
+    | first
+    | if . == null then empty else .user.login end
+')
+
+if [ -z "$APPROVING_REVIEWER" ]; then
+  fail_gate "no reviewer identity in available_reviewers has a latest-state APPROVED review (COMMENTED reviews are ignored; later CHANGES_REQUESTED/DISMISSED overrides earlier APPROVED)"
+fi
+
+log "gate (b): latest-state APPROVED by $APPROVING_REVIEWER"
+
+# --- gate (c): Codex cleared on current HEAD -------------------------------
+
+log "gate (c): checking Codex clearance on $HEAD_SHA"
+
+# Latest Codex review on the current HEAD commit (if any). Codex always
+# uses COMMENTED state regardless of findings — do NOT filter on state.
+CODEX_REVIEW=$(echo "$REVIEWS_JSON" | jq \
+  --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
+  [.[] | select(.user.login == $bot) | select(.commit_id == $sha)]
+  | max_by(.submitted_at) // null
+')
+
+# If a Codex review on HEAD exists, extract its id for filtering inline
+# comments down to THAT REVIEW ONLY. Older reviews on the same HEAD
+# (same-HEAD rebuttal flow) must not count, per #64 review finding 2:
+# if Codex posted a review with P1 findings, the agent replied with a
+# rebuttal, and Codex's next review on the same HEAD cleared the
+# finding, the earlier P1 comments are still visible in the API but
+# tied to the older review's id. Filtering by pull_request_review_id
+# scopes the findings to the latest round only.
+CODEX_REVIEW_ID=$(echo "$CODEX_REVIEW" | jq -r 'if . == null then "" else .id end')
+
+COMMENTS_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "inline comments")
+
+# P0/P1 inline findings from the LATEST Codex review round on HEAD only.
+# P2/P3 don't block clearance per REVIEW_POLICY.md § Phase 4a step 15a.
+# If there's no Codex review on HEAD, UNADDRESSED_P01 is [] — the
+# reaction path is then the only way gate (c) can clear.
+#
+# Filter MUST include user.login == BOT_LOGIN. Review-thread replies
+# (e.g., a human quoting a P1 badge from a Codex finding while
+# debugging) share the same pull_request_review_id as the original
+# Codex comments, so a quote-only reply containing `![P1 Badge]`
+# would otherwise be misclassified as an unaddressed Codex finding
+# and incorrectly block merge. nathanpayne-codex caught this on
+# nathanpaynedotcom propagation PR #180 round 3.
+if [ -n "$CODEX_REVIEW_ID" ] && [ "$CODEX_REVIEW_ID" != "null" ]; then
+  UNADDRESSED_P01=$(echo "$COMMENTS_JSON" | jq \
+    --arg bot "$BOT_LOGIN" \
+    --argjson review_id "$CODEX_REVIEW_ID" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.pull_request_review_id == $review_id)
+      | select(.body | test("!\\[P[01] Badge\\]"))
+      | { path, line, comment_id: .id }
+    ]
+  ')
+else
+  UNADDRESSED_P01='[]'
+fi
+
+UNADDRESSED_COUNT=$(echo "$UNADDRESSED_P01" | jq 'length')
+
+# Latest +1 reaction on the PR issue from the Codex bot, filtered by
+# REACTION_THRESHOLD. REACTION_THRESHOLD = max(HEAD_PUSHED_AT,
+# freshness_floor), where the freshness floor is NOW minus
+# reaction_freshness_window_seconds. See the anchor computation
+# earlier in the script for why both bounds are required and the
+# residual hole the freshness floor mitigates.
+REACTIONS_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
+
+LATEST_THUMBS_UP_TIME=$(echo "$REACTIONS_JSON" | jq -r \
+  --arg bot "$BOT_LOGIN" --arg after "$REACTION_THRESHOLD" '
+  [ .[]
+    | select(.user.login == $bot)
+    | select(.content == "+1")
+    | select(.created_at >= $after)
+    | .created_at
+  ]
+  | max // ""
+')
+
+# Latest Codex review submission time on HEAD (empty if none).
+CODEX_REVIEW_TIME=$(echo "$CODEX_REVIEW" | jq -r 'if . == null then "" else .submitted_at end')
+
+# Decide clearance using the LATEST Codex signal, not whichever signal
+# the script happens to check first. See #64 Codex P1 finding ("Reject
+# stale thumbs-up when newer Codex findings exist").
+#
+# Semantics: Codex sends either a review OR a 👍 reaction per pass, but
+# on a PR with multiple rounds on the same HEAD it can end up with both
+# historical review comments AND a reaction. The LATEST one wins:
+#
+#   - If Codex's most recent signal is a review, inspect its P0/P1
+#     findings. Zero findings → clear. Any findings → block.
+#   - If Codex's most recent signal is a 👍 reaction, clear. Codex only
+#     reacts 👍 when it has no suggestions, so a newer 👍 overrides any
+#     earlier review's findings.
+#   - If both timestamps exist, use max() to pick the latest.
+#   - If neither exists, block.
+#
+# All review-side analysis still uses the latest review's
+# pull_request_review_id to scope findings (addressed in round 1's
+# finding 2), so an older review's stale comments are never counted.
+
+CLEARED=false
+CLEARANCE_REASON=""
+
+if [ -n "$LATEST_THUMBS_UP_TIME" ] && [ -n "$CODEX_REVIEW_TIME" ]; then
+  # Both signals present on HEAD — compare timestamps. ISO 8601 sorts
+  # chronologically under lexicographic string comparison.
+  if [[ "$LATEST_THUMBS_UP_TIME" > "$CODEX_REVIEW_TIME" ]]; then
+    CLEARED=true
+    CLEARANCE_REASON="latest signal is 👍 reaction @ $LATEST_THUMBS_UP_TIME (newer than review @ $CODEX_REVIEW_TIME)"
+  else
+    if [ "$UNADDRESSED_COUNT" -eq 0 ]; then
+      CLEARED=true
+      CLEARANCE_REASON="latest signal is COMMENTED review @ $CODEX_REVIEW_TIME on $HEAD_SHA with no unaddressed P0/P1 findings (newer than 👍 @ $LATEST_THUMBS_UP_TIME)"
+    fi
+  fi
+elif [ -n "$LATEST_THUMBS_UP_TIME" ]; then
+  # Only a qualifying reaction, no review on HEAD.
+  CLEARED=true
+  CLEARANCE_REASON="👍 reaction from $BOT_LOGIN @ $LATEST_THUMBS_UP_TIME (on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
+elif [ -n "$CODEX_REVIEW_TIME" ]; then
+  # Only a review on HEAD, no qualifying reaction.
+  if [ "$UNADDRESSED_COUNT" -eq 0 ]; then
+    CLEARED=true
+    CLEARANCE_REASON="COMMENTED review from $BOT_LOGIN @ $CODEX_REVIEW_TIME on $HEAD_SHA with no unaddressed P0/P1 findings"
+  fi
+fi
+
+if [ "$CLEARED" != "true" ]; then
+  if [ -z "$LATEST_THUMBS_UP_TIME" ] && [ -z "$CODEX_REVIEW_TIME" ]; then
+    fail_gate "Codex has not cleared current HEAD (no review on $HEAD_SHA and no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
+  else
+    PATHS=$(echo "$UNADDRESSED_P01" | jq -r '[.[] | "\(.path):\(.line)"] | join(", ")')
+    fail_gate "latest Codex signal is a review on HEAD with $UNADDRESSED_COUNT unaddressed P0/P1 finding(s): $PATHS"
+  fi
+fi
+
+log "gate (c): cleared — $CLEARANCE_REASON"
+
+# --- all gates pass ---------------------------------------------------------
+
+log "all merge gates pass — PR $REPO#$PR_NUMBER is mergeable under Phase 4a"
+exit 0

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -1,0 +1,580 @@
+#!/usr/bin/env bash
+# scripts/codex-review-request.sh — Phase 4a automated external review trigger
+#
+# Triggers (or awaits) a review from the ChatGPT Codex Connector GitHub App
+# on a pull request, polls for a response against the current HEAD commit,
+# and emits a machine-parseable JSON summary of what Codex produced so a
+# caller (e.g. an authoring agent) can reason over it.
+#
+# Usage:
+#   scripts/codex-review-request.sh <PR_NUMBER> [REPO]
+#
+# Arguments:
+#   PR_NUMBER  Required. The pull request number (integer).
+#   REPO       Optional. Fully-qualified "owner/repo". Defaults to the
+#              current repository detected by `gh repo view`.
+#
+# Environment:
+#   GH_TOKEN   Required. GitHub token with pull_requests:write to post the
+#              trigger comment and read reviews/comments/reactions. In the
+#              standard template flow this is set to $OP_PREFLIGHT_AUTHOR_PAT
+#              after running `scripts/op-preflight.sh`, or via inline
+#              `op read` per REVIEW_POLICY.md § PAT lookup table.
+#
+# Behavior:
+#   1. Reads codex.review_timeout_seconds and codex.bot_login from
+#      .github/review-policy.yml (defaults: 600 / chatgpt-codex-connector[bot]).
+#   2. Fetches the PR's current HEAD commit SHA and committer date. Any
+#      Codex review is only considered "current" if it is anchored on
+#      this commit (commit_id == HEAD_SHA). Any Codex +1 reaction is
+#      only considered "current" if created_at >= REACTION_THRESHOLD,
+#      where REACTION_THRESHOLD = max(HEAD_PUSHED_AT, freshness floor):
+#        - HEAD_PUSHED_AT is HEAD_COMMITTER_DATE advanced past any
+#          `head_ref_force_pushed` event on this PR's timeline, which
+#          is strictly PR-scoped. This closes the force-push-with-
+#          old-commit false-clear path.
+#        - freshness floor = NOW minus
+#          `codex.reaction_freshness_window_seconds` (default 1800).
+#          This closes the ordinary-push-with-old-committer-date
+#          false-clear path by ensuring a stale 👍 from a prior HEAD
+#          ages out of the window.
+#      See codex-review-check.sh for the iteration history behind this
+#      design and the residual hole it does NOT fully close.
+#   3. Scans existing reviews, inline comments, and issue reactions for
+#      a Codex signal already present on the current HEAD. If found,
+#      skips the trigger comment and goes straight to emitting JSON —
+#      re-posting `@codex review` when Codex has already responded can
+#      cause double-processing or rate-limit pushback.
+#   4. Otherwise posts `@codex review` as a PR comment and polls every
+#      15 seconds for up to `review_timeout_seconds` for either:
+#        - a review from the Codex bot on the current HEAD, OR
+#        - a +1 reaction from the Codex bot on the PR issue dated after
+#          the current HEAD committer date.
+#   5. Emits a JSON object to stdout summarizing what Codex produced.
+#      The JSON shape is the contract with the caller; do not change
+#      field names without also updating scripts/codex-review-check.sh
+#      and the policy docs (CLAUDE.md, AGENTS.md, REVIEW_POLICY.md).
+#
+# Output JSON shape:
+#   {
+#     "pr_number": 123,
+#     "repo": "owner/repo",
+#     "head_sha": "<full sha>",
+#     "head_committer_date": "<iso-8601>",
+#     "bot_login": "chatgpt-codex-connector[bot]",
+#     "review": null | {
+#       "state": "COMMENTED",
+#       "submitted_at": "<iso-8601>",
+#       "commit_id": "<full sha>",
+#       "body": "<top-level review body>"
+#     },
+#     "findings": [
+#       { "path": "...", "line": N, "priority": "P0|P1|P2|P3",
+#         "comment_id": N, "body": "<full finding body>" }
+#     ],
+#     "reaction": null | {
+#       "content": "+1",
+#       "created_at": "<iso-8601>",
+#       "reaction_id": N
+#     },
+#     "trigger_posted": true | false,
+#     "rounds_waited_seconds": N
+#   }
+#
+# Exit codes:
+#   0   Codex signal received on current HEAD. JSON on stdout.
+#   3   API / infrastructure error. Error message on stderr.
+#   4   FALLBACK_REQUIRED — timed out waiting for a Codex signal. The
+#       caller should route to REVIEW_POLICY.md § Phase 4b. See #27 for
+#       the explicit-review-required decision that mandates this path.
+#
+# Design notes:
+#   - Read-only against the PR except for the one `@codex review` trigger
+#     comment. Does not push commits, does not modify labels, does not
+#     merge.
+#   - Idempotent. Re-running on the same PR with the same HEAD is safe:
+#     it will see the existing Codex response and skip the trigger.
+#   - JSON emission uses `jq` throughout. No ad-hoc string concatenation.
+#
+# References:
+#   - Project #2 — External Review (Phase 4 Review)
+#   - #34 — this script
+#   - #29 — live observations behind the dual-endpoint / reaction polling
+#   - REVIEW_POLICY.md § Phase 4a (canonical policy)
+
+set -euo pipefail
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <PR_NUMBER> [REPO]" >&2
+  echo "  PR_NUMBER  pull request number (integer)" >&2
+  echo "  REPO       owner/repo (optional; defaults to current repo)" >&2
+  exit 3
+fi
+
+PR_NUMBER=$1
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 3
+fi
+
+REPO=${2:-}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 3
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 3
+fi
+
+# --- config readers ---------------------------------------------------------
+
+CONFIG=".github/review-policy.yml"
+
+# Extract a scalar field from the codex: block in review-policy.yml.
+# Uses the state-machine awk pattern established in #54 (stops at the next
+# top-level key, tolerates column-0 comments). Returns empty string if the
+# field is not present, which the caller should turn into a default.
+codex_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^codex:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block {
+      # Match "  field: value" or "  field: \"value\""
+      if ($1 == field":") {
+        sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+        gsub(/^"/, "", $0)
+        gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+        gsub(/[[:space:]]*#.*$/, "", $0)
+        sub(/[[:space:]]+$/, "", $0)
+        print
+        exit
+      }
+    }
+  ' "$CONFIG"
+}
+
+TIMEOUT_SECONDS=$(codex_field review_timeout_seconds)
+TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-600}
+if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: codex.review_timeout_seconds must be an integer; got '$TIMEOUT_SECONDS'" >&2
+  exit 3
+fi
+
+BOT_LOGIN=$(codex_field bot_login)
+BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
+
+REACTION_FRESHNESS_SECONDS=$(codex_field reaction_freshness_window_seconds)
+REACTION_FRESHNESS_SECONDS=${REACTION_FRESHNESS_SECONDS:-1800}
+if ! [[ "$REACTION_FRESHNESS_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: codex.reaction_freshness_window_seconds must be an integer; got '$REACTION_FRESHNESS_SECONDS'" >&2
+  exit 3
+fi
+
+POLL_INTERVAL_SECONDS=15
+
+# --- logging helpers --------------------------------------------------------
+
+log() {
+  echo "[codex-review-request] $*" >&2
+}
+
+die() {
+  local code=$1
+  shift
+  echo "[codex-review-request] ERROR: $*" >&2
+  exit "$code"
+}
+
+# Fetch a paginated GitHub REST API endpoint and return the flattened JSON
+# array on stdout. `gh api --paginate` emits one JSON value per page
+# concatenated into a single stream — `jq`'s default mode runs the filter
+# once per input (per page), which miscounts and misfilters on multi-page
+# PRs. Slurp with `-s` collects all inputs into an outer array, then `add`
+# concatenates the per-page arrays into one flat array. Defaults to `[]`
+# on empty input. Exits 3 on API or parse error.
+fetch_api_array() {
+  local endpoint=$1
+  local label=$2
+  local raw
+  raw=$(gh api --paginate "$endpoint" 2>&1) || die 3 "failed to fetch $label: $raw"
+  echo "$raw" | jq -s 'add // []' 2>/dev/null \
+    || die 3 "failed to flatten $label pagination output"
+}
+
+# --- fetch PR metadata ------------------------------------------------------
+
+log "PR $REPO#$PR_NUMBER — fetching HEAD commit metadata"
+
+PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) || die 3 "failed to fetch PR metadata: $PR_JSON"
+
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+  die 3 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+
+# committer date, not author date — reactions are compared against commit
+# arrival time at GitHub, not commit authorship
+HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
+  || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
+
+# HEAD_PUSHED_AT + REACTION_THRESHOLD: mirrors codex-review-check.sh so
+# that the pre-flight scan below does NOT treat a stale 👍 from a prior
+# HEAD as a current signal (which would cause the trigger comment to be
+# skipped and the caller to re-run gate (c) against the same stale
+# reaction). See codex-review-check.sh for the full rationale; the short
+# version: committer date is unreliable for force-push-of-old-commit
+# and ordinary-push-of-old-committer-date. Layer 1 advances the anchor
+# via `head_ref_force_pushed` events from the PR-scoped timeline; Layer
+# 2 bounds residual exposure with a freshness floor.
+HEAD_PUSHED_AT="$HEAD_COMMITTER_DATE"
+ANCHOR_SOURCE="HEAD committer date"
+
+TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
+
+LATEST_FORCE_PUSH_TIME=$(echo "$TIMELINE_JSON" | jq -r '
+  [ .[] | select(.event == "head_ref_force_pushed") | .created_at ]
+  | max // ""
+')
+
+if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_PUSHED_AT" ]]; then
+  HEAD_PUSHED_AT="$LATEST_FORCE_PUSH_TIME"
+  ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
+fi
+
+EPOCH_NOW=$(date +%s)
+EPOCH_FLOOR=$((EPOCH_NOW - REACTION_FRESHNESS_SECONDS))
+if REACTION_FLOOR_ISO=$(date -u -r "$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+  :
+else
+  REACTION_FLOOR_ISO=$(date -u -d "@$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+    || die 3 "could not compute reaction freshness floor from epoch $EPOCH_FLOOR"
+fi
+
+if [[ "$REACTION_FLOOR_ISO" > "$HEAD_PUSHED_AT" ]]; then
+  REACTION_THRESHOLD="$REACTION_FLOOR_ISO"
+  REACTION_THRESHOLD_SOURCE="freshness floor (NOW - ${REACTION_FRESHNESS_SECONDS}s)"
+else
+  REACTION_THRESHOLD="$HEAD_PUSHED_AT"
+  REACTION_THRESHOLD_SOURCE="HEAD pushed-at anchor ($ANCHOR_SOURCE)"
+fi
+
+log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
+log "anchor = $HEAD_PUSHED_AT (source: $ANCHOR_SOURCE)"
+log "reaction_threshold = $REACTION_THRESHOLD (source: $REACTION_THRESHOLD_SOURCE)"
+log "bot_login = $BOT_LOGIN    timeout = ${TIMEOUT_SECONDS}s"
+
+# --- Codex signal scan ------------------------------------------------------
+
+# Scan for (a) a review from the bot on the current HEAD commit, (b) inline
+# findings from the bot on the current HEAD, (c) a +1 reaction on the issue
+# dated after the HEAD committer date. Returns a JSON object to stdout on
+# success. Emits empty object { "review": null, "findings": [], "reaction": null }
+# if nothing matches yet.
+scan_codex_state() {
+  local reviews comments reactions review findings reaction
+
+  reviews=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
+  comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "inline comments")
+  reactions=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
+
+  # Latest review from the Codex bot on the current HEAD commit, if any.
+  # Codex always uses COMMENTED state regardless of findings. We also
+  # capture the review id so the findings filter can scope to THIS
+  # review only and not pick up stale findings from an earlier review
+  # round on the same HEAD.
+  review=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
+    [.[] | select(.user.login == $bot) | select(.commit_id == $sha)]
+    | sort_by(.submitted_at) | last
+    | if . == null then null
+      else { id, state, submitted_at, commit_id, body }
+      end
+  ')
+
+  # Get the LATEST Codex review id so findings are scoped to that
+  # round only. nathanpayne-codex caught (swipewatch propagation
+  # PR #33 round 2) that filtering by SHA alone keeps old P0/P1
+  # comments from earlier reviews on the same HEAD forever — same
+  # bug class as PR #65 round 1's gate (c) findings filter on
+  # codex-review-check.sh.
+  latest_review_id=$(echo "$review" | jq -r 'if . == null then "" else .id end')
+
+  # Inline findings from the bot on the current HEAD commit, scoped
+  # to the LATEST review round (via pull_request_review_id), with
+  # P0-P3 priority extracted from the ![P{0-3} Badge] markdown
+  # shortcode. If there's no current review, findings is empty.
+  if [ -n "$latest_review_id" ] && [ "$latest_review_id" != "null" ]; then
+    findings=$(echo "$comments" | jq \
+      --arg bot "$BOT_LOGIN" \
+      --argjson review_id "$latest_review_id" '
+      [ .[]
+        | select(.user.login == $bot)
+        | select(.pull_request_review_id == $review_id)
+        | { path, line, comment_id: .id, body,
+            priority: (
+              (.body | capture("!\\[P(?<n>[0-3]) Badge\\]")? // {n: null}) | .n
+              | if . == null then "P?" else "P" + . end
+            )
+          }
+      ]
+    ')
+  else
+    findings='[]'
+  fi
+
+  # Most recent +1 reaction from the bot on the issue with created_at
+  # strictly >= REACTION_THRESHOLD. Threshold = max(HEAD_PUSHED_AT,
+  # freshness floor). See the anchor computation above and
+  # codex-review-check.sh for the full rationale. Without the
+  # freshness floor, a stale 👍 from a prior HEAD (where the new HEAD
+  # is a normal push with an old committer date) would read as a
+  # "current" signal here and cause the pre-flight scan to skip the
+  # trigger comment, leaving the caller to re-evaluate gate (c)
+  # against the same stale reaction.
+  reaction=$(echo "$reactions" | jq --arg bot "$BOT_LOGIN" --arg after "$REACTION_THRESHOLD" '
+    [.[]
+      | select(.user.login == $bot)
+      | select(.content == "+1")
+      | select(.created_at >= $after)
+    ]
+    | sort_by(.created_at) | last
+    | if . == null then null
+      else { content, created_at, reaction_id: .id }
+      end
+  ')
+
+  jq -n --argjson review "$review" --argjson findings "$findings" --argjson reaction "$reaction" '
+    { review: $review, findings: $findings, reaction: $reaction }
+  '
+}
+
+# Returns 0 iff the scan produced ANY signal (review or reaction).
+# Used by the poll loop, which stops as soon as Codex has produced
+# any response — even a review with P0/P1 findings counts because
+# the caller will then process the findings and decide what to do.
+has_signal() {
+  local scan=$1
+  [ "$(echo "$scan" | jq -r '.review != null or .reaction != null')" = "true" ]
+}
+
+# Returns 0 iff the scan produced a signal that should be treated as
+# CLEARED (no further @codex review trigger needed). Cleared means
+# EITHER:
+#   - any +1 reaction on the PR issue (the no-findings happy path), OR
+#   - a review on HEAD with zero P0/P1 inline findings (the
+#     reviewed-and-clean path)
+#
+# A review with P0/P1 findings does NOT count as cleared — the caller
+# may have replied to the findings with a rebuttal and want Codex to
+# re-evaluate. Earlier versions of this function used has_signal in
+# the pre-flight, which caused the rebuttal-without-commit path to
+# stall: re-running the script saw the existing P1-bearing review
+# and skipped the trigger, so Codex was never asked to reconsider.
+# Codex caught this on swipewatch propagation PR #33 — same shape as
+# the manual `@codex review` workaround I had to use on template PR
+# #73 during dry-run C.
+has_cleared_signal() {
+  local scan=$1
+  # Latest-signal-wins: when both a reaction and a review exist on
+  # HEAD, the more recent one is authoritative. Otherwise an older
+  # 👍 from a prior round can mask a later P1-bearing review and
+  # skip a needed retrigger. nathanpayne-codex caught this on
+  # nathanpaynedotcom propagation PR #180 round 2 — same shape as
+  # PR #65 round 1's gate (c) latest-state rule on
+  # codex-review-check.sh.
+  #
+  # Cleared iff EITHER:
+  #   - reaction exists AND (review is null OR reaction is newer
+  #     than review), OR
+  #   - review exists AND review is newer than (or only signal vs)
+  #     reaction AND review has zero P0/P1 findings (the findings
+  #     array is already scoped to the latest review's id by the
+  #     pull_request_review_id filter in scan_codex_state)
+  [ "$(echo "$scan" | jq -r '
+    def review_time: if .review == null then "" else .review.submitted_at end;
+    def reaction_time: if .reaction == null then "" else .reaction.created_at end;
+    def review_clean: ([.findings[] | select(.priority == "P0" or .priority == "P1")] | length) == 0;
+
+    if .reaction == null and .review == null then "false"
+    elif .reaction != null and .review == null then "true"
+    elif .reaction == null and .review != null then
+      (review_clean | tostring)
+    elif (reaction_time > review_time) then "true"
+    else
+      (review_clean | tostring)
+    end
+  ')" = "true" ]
+}
+
+# --- pre-flight: is Codex already working on HEAD? --------------------------
+
+log "checking for existing Codex signal on HEAD"
+if ! INITIAL_SCAN=$(scan_codex_state); then
+  die 3 "initial Codex scan failed"
+fi
+
+TRIGGER_POSTED=false
+TRIGGER_POST_TIME=""
+
+if has_cleared_signal "$INITIAL_SCAN"; then
+  log "Codex has already cleared on HEAD (reaction or no-P0/P1 review) — skipping trigger comment"
+else
+  log "posting '@codex review' trigger comment"
+  # Capture stderr (and stdout) into a diagnostic variable so a failure
+  # here surfaces the actual gh error — e.g. "404" from a nonexistent
+  # PR, "403" from a token without comment scope, or "422" from a closed
+  # PR — rather than a bare "failed to post". CodeRabbit non-blocking
+  # note on PR #64.
+  POST_OUTPUT=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+    || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  TRIGGER_POSTED=true
+  # Capture the post time so the poll loop can ignore stale signals
+  # that were already on HEAD before the trigger fired. Without this,
+  # `has_signal "$INITIAL_SCAN"` would return true on the very first
+  # iteration of the poll loop and the script would exit with the
+  # stale review/reaction without waiting for Codex's actual response
+  # to the new trigger. Codex caught this on swipewatch propagation
+  # PR #33 round 2 — same shape as the round-1 has_cleared_signal
+  # bug, just on the post-trigger side.
+  #
+  # Use GitHub's authoritative timestamp from the just-posted comment
+  # (extracted from the URL gh returns) rather than local wall-clock.
+  # Local wall-clock can be ahead of or behind GitHub by a few seconds
+  # due to NTP skew, and the strict `>` comparison would misclassify
+  # a real Codex response as pre-trigger. Falls back to local wall-
+  # clock minus a 60-second buffer if the comment ID can't be
+  # extracted (e.g., gh output format change). Codex caught the
+  # wall-clock issue on nathanpaynedotcom propagation PR #180 round 4.
+  TRIGGER_COMMENT_ID=$(echo "$POST_OUTPUT" | grep -oE 'issuecomment-[0-9]+' | head -1 | sed 's/issuecomment-//')
+  if [ -n "$TRIGGER_COMMENT_ID" ]; then
+    TRIGGER_POST_TIME=$(gh api "repos/$REPO/issues/comments/$TRIGGER_COMMENT_ID" --jq '.created_at' 2>/dev/null || true)
+  fi
+  if [ -z "$TRIGGER_POST_TIME" ]; then
+    # Fallback: local wall-clock minus a 60-second buffer for
+    # clock skew tolerance.
+    EPOCH_NOW=$(date +%s)
+    EPOCH_BUFFER=$((EPOCH_NOW - 60))
+    if TRIGGER_POST_TIME=$(date -u -r "$EPOCH_BUFFER" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+      :
+    else
+      TRIGGER_POST_TIME=$(date -u -d "@$EPOCH_BUFFER" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || die 3 "could not compute fallback TRIGGER_POST_TIME")
+    fi
+  fi
+fi
+
+# --- poll loop --------------------------------------------------------------
+
+START_TS=$(date +%s)
+DEADLINE=$((START_TS + TIMEOUT_SECONDS))
+ELAPSED=0
+
+# Returns 0 iff the scan has a signal that is at least as recent
+# as TRIGGER_POST_TIME (>=, not >). Used by the poll loop only
+# when TRIGGER_POSTED=1 so we don't short-circuit on stale signals.
+#
+# Uses >= rather than > because GitHub timestamps are second-
+# precision and a legitimate Codex response in the same second as
+# the trigger comment post would otherwise be classified as stale
+# forever, forcing the script to time out to Phase 4b unnecessarily.
+# nathanpayne-codex caught the >-vs->= bug on swipewatch propagation
+# PR #33 round 4 and the related wall-clock-vs-GitHub-time bug on
+# nathanpaynedotcom propagation PR #180 round 4.
+has_post_trigger_signal() {
+  local scan=$1
+  [ "$(echo "$scan" | jq -r --arg after "$TRIGGER_POST_TIME" '
+    ((.review != null and .review.submitted_at >= $after)
+     or (.reaction != null and .reaction.created_at >= $after))
+  ')" = "true" ]
+}
+
+if [ "$TRIGGER_POSTED" = "true" ]; then
+  # We just posted a trigger. The INITIAL_SCAN data is now stale by
+  # definition — Codex will respond with something new. Skip the
+  # initial has_signal check; force the loop to actually poll.
+  FINAL_SCAN='{"review":null,"findings":[],"reaction":null}'
+else
+  FINAL_SCAN=$INITIAL_SCAN
+fi
+
+while :; do
+  # If we just triggered a fresh review, only break on a signal
+  # strictly newer than the trigger. Otherwise (no trigger sent),
+  # any existing signal is fine — that's the cleared-on-arrival path.
+  if [ "$TRIGGER_POSTED" = "true" ]; then
+    if has_post_trigger_signal "$FINAL_SCAN"; then
+      log "Codex signal received after ${ELAPSED}s (post-trigger)"
+      break
+    fi
+  elif has_signal "$FINAL_SCAN"; then
+    log "Codex signal received after ${ELAPSED}s"
+    break
+  fi
+
+  NOW=$(date +%s)
+  if [ "$NOW" -ge "$DEADLINE" ]; then
+    log "TIMEOUT after ${ELAPSED}s — no Codex review or reaction on HEAD"
+    log "emitting JSON with review=null, reaction=null; exit code 4 (FALLBACK_REQUIRED)"
+    # Fall through to JSON emission so the caller still gets a structured
+    # answer (all nulls), then exit 4.
+    break
+  fi
+
+  log "polling... (${ELAPSED}s / ${TIMEOUT_SECONDS}s)"
+  sleep "$POLL_INTERVAL_SECONDS"
+  ELAPSED=$(( $(date +%s) - START_TS ))
+
+  if ! FINAL_SCAN=$(scan_codex_state); then
+    die 3 "poll scan failed"
+  fi
+done
+
+# --- emit final JSON --------------------------------------------------------
+
+jq -n \
+  --argjson pr_number "$PR_NUMBER" \
+  --arg repo "$REPO" \
+  --arg head_sha "$HEAD_SHA" \
+  --arg head_committer_date "$HEAD_COMMITTER_DATE" \
+  --arg bot_login "$BOT_LOGIN" \
+  --argjson scan "$FINAL_SCAN" \
+  --argjson trigger_posted "$TRIGGER_POSTED" \
+  --argjson elapsed "$ELAPSED" '
+  {
+    pr_number: $pr_number,
+    repo: $repo,
+    head_sha: $head_sha,
+    head_committer_date: $head_committer_date,
+    bot_login: $bot_login,
+    review: $scan.review,
+    findings: $scan.findings,
+    reaction: $scan.reaction,
+    trigger_posted: $trigger_posted,
+    rounds_waited_seconds: $elapsed
+  }
+'
+
+# Exit 0 if a signal arrived; exit 4 (FALLBACK_REQUIRED) if we timed
+# out. When TRIGGER_POSTED=true, "a signal arrived" means a signal
+# strictly newer than the trigger post — the existing pre-trigger
+# signal doesn't count, otherwise the script would exit 0 with stale
+# findings the moment we time out polling for the new review.
+if [ "$TRIGGER_POSTED" = "true" ]; then
+  if has_post_trigger_signal "$FINAL_SCAN"; then
+    exit 0
+  else
+    exit 4
+  fi
+elif has_signal "$FINAL_SCAN"; then
+  exit 0
+else
+  exit 4
+fi

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1,28 +1,517 @@
 #!/usr/bin/env bash
 # gh-pr-guard.sh — PreToolUse hook for Claude Code
 #
-# Gates two operations:
+# Gates three operations:
 #   1. gh pr create — blocks unless the command text includes
 #      "Authoring-Agent:" and "## Self-Review"
 #   2. gh pr merge --admin — blocks unless BREAK_GLASS_ADMIN=1
 #      (human must explicitly authorize in chat)
+#   3. gh pr merge (non-admin) — blocks when the target PR carries
+#      the `needs-external-review` label unless CODEX_CLEARED=1
+#      (agent must have just run scripts/codex-review-check.sh
+#      successfully). This enforces REVIEW_POLICY.md § Phase 4a
+#      merge gate at the hook layer so an agent can't accidentally
+#      merge past Label Gate by removing the label without running
+#      the gate check first.
 #
 # Exit codes:
 #   0 = allow
 #   2 = block (hard stop)
+#
+# Architecture notes:
+#
+#   The hook does ALL its parsing on a tokenized form of the
+#   command produced by `xargs -n 1`, which honors POSIX shell
+#   quoting. Earlier iterations used substring `grep` on the raw
+#   command string and were buggy in two correlated ways:
+#
+#     1. nathanpayne-codex caught (PR #66 round 2) that
+#        `TOKENS=( $COMMAND )` performed bash word splitting that
+#        ignored shell quotes — `gh pr merge --body "hello world"
+#        65` would split into (gh, pr, merge, --body, "hello,
+#        world", 65) and confuse the value-flag SKIP logic.
+#
+#     2. nathanpayne-codex caught (PR #66 round 3) that the
+#        top-level matcher `^\s*gh\s+pr\s+(create|merge)` only
+#        recognized the bare form. gh accepts a global -R/--repo
+#        flag BEFORE the subcommand: `gh -R foo/bar pr merge 65`
+#        and `gh --repo foo/bar pr create ...` would bypass the
+#        hook entirely.
+#
+#   Both bugs trace to the same shape — substring matching on a
+#   string of unknown structure. The fix is to tokenize once at
+#   the top with quote awareness, walk the tokens to identify the
+#   pr subcommand (capturing any global -R/--repo along the way),
+#   and reuse the same TOKENS array in the create and merge
+#   branches.
+#
+# Design notes:
+#
+#   - The CODEX_CLEARED check is a hook-layer defense-in-depth.
+#     The authoritative merge gate is scripts/codex-review-check.sh;
+#     the hook only verifies the agent claims to have run it. An
+#     agent that sets CODEX_CLEARED=1 without actually running the
+#     check is violating policy — the hook is not an integrity
+#     check, it is an ordering check.
+#
+#   - PR selector is parsed from the command tokens: first non-flag
+#     positional argument after `merge`. Accepts <number> | <url> |
+#     <branch> per the gh CLI grammar. If no selector is present,
+#     the hook falls back to `gh pr view --json labels` with no
+#     positional so gh resolves the PR from the current branch.
+#
+#   - Label lookup calls the GitHub API. This is a side effect of
+#     the hook but consistent with the agent's own label-check
+#     behavior elsewhere in the policy flow. Failure to reach the
+#     API (offline, auth issue) fails CLOSED with a diagnostic.
+#
+#   - Bash 3.2 portability: macOS ships bash 3.2 by default. The
+#     hook avoids bash 4+ features (no `mapfile`, no `[[ =~ ]]` in
+#     places where `[[ == ]]` works, etc.).
+#
+# Inline environment assignments:
+#
+#   The bash form `VAR=value command args` sets VAR in the spawned
+#   command's environment but NOT in the hook process. The PreToolUse
+#   hook fires before bash executes the command, so it can't read
+#   inline-prefixed env vars from its own ${VAR} expansion. The
+#   documented happy paths use exactly this form:
+#
+#     CODEX_CLEARED=1 gh pr merge 65 --squash --delete-branch
+#     BREAK_GLASS_ADMIN=1 gh pr merge --admin 65 ...
+#
+#   So the hook must parse env assignments out of the command string
+#   before the `gh` token and treat them as if they were exported.
+#   nathanpayne-codex caught the bypass on PR #66 round 4: with the
+#   round-3 hook, both forms hit the early `^\s*gh(\s|$)` matcher,
+#   missed it, and exited 0 before any guard ran.
+#
+#   Round 4 fix: the early matcher now allows leading prefix material
+#   before `gh`, and the top-level token walk captures CODEX_CLEARED
+#   and BREAK_GLASS_ADMIN from the pre-gh tokens into INLINE_ vars.
+#   The merge guard then uses these as fallbacks if the hook's own
+#   environment doesn't have the corresponding variable set via
+#   `export`.
+#
+# Limitations (documented as known gaps):
+#
+#   - Backslash escapes inside double-quoted strings (`"with
+#     \"escape\""`) are not handled by xargs and will fail closed
+#     with the tokenization error.
+#
+#   - Custom gh aliases (`gh alias set merge ...`) that expand
+#     `merge` to something else are not recognized — the hook
+#     guards a specific literal command grammar.
+#
+#   - Unknown global flags (anything other than `-R/--repo` and
+#     boolean flags like `--help`/`--version`) are assumed boolean.
+#     If gh adds new value-taking globals, the hook needs an
+#     update; misclassifying them as boolean would let the next
+#     token leak through as the subcommand.
+#
+#   - Other env vars in the inline prefix (anything other than
+#     CODEX_CLEARED and BREAK_GLASS_ADMIN) are skipped without
+#     interpretation. This is fine because no other env var is
+#     consulted by hook policy decisions.
 
 set -euo pipefail
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Only inspect gh pr commands
-if ! echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+(create|merge)'; then
+# Quick exit if there's no `gh` token in the command at all. This
+# uses a whitespace-bounded match rather than `^\s*gh` so that
+# leading prefix material (env assignments, `eval`, `time`, `sudo`,
+# compound separators like `;` followed by a space) doesn't bypass
+# the hook entirely. False positives where `gh` appears in the
+# middle of an unrelated command are caught downstream by the token
+# walk, which exits 0 if no `gh pr (create|merge)` subcommand is
+# present.
+if ! echo "$COMMAND" | grep -qE '(^|\s)gh(\s|$)'; then
+  exit 0
+fi
+
+# --- tokenize the command with shell-quote awareness ---
+#
+# Use python3 shlex.split which honors POSIX single and double
+# quoting AND handles multi-line quoted strings. `gh pr merge
+# --body "hello world" 65` tokenizes correctly to (gh, pr, merge,
+# --body, hello world, 65), and `gh pr create --body "Authoring-
+# Agent: claude\n## Self-Review\nok"` (with literal newlines in
+# the body) also tokenizes correctly because shlex.split treats
+# newlines inside quotes as literal characters, not as token
+# separators.
+#
+# Earlier versions used `xargs -n 1` (with the implicit `echo`
+# command), which:
+#   - Silently drops -n / -e / -E (echo's own flags). Codex caught
+#     this on PR #66 round 6 and the workaround was `xargs -n 1
+#     printf '%s\n'`.
+#   - Treats embedded newlines as token separators, breaking
+#     valid `gh pr create --body "...multiline..."` invocations.
+#     Codex caught this on nathanpaynedotcom propagation PR #180
+#     round 4. xargs has no flag to disable this behavior; the
+#     fix is to switch tokenizers entirely.
+#
+# python3 is available on macOS 12+ by default and on every Linux
+# distro the agent flow runs on. Python startup cost is ~50ms per
+# invocation; acceptable for a hook that already does an API call.
+#
+# Fails CLOSED on tokenization error (unmatched quote, bad escape).
+# An agent should fix the malformed command and retry.
+#
+# python3 emits tokens NUL-delimited so bash's read -d '' can
+# preserve embedded newlines. The output goes via a tempfile
+# rather than $(...) command substitution because bash command
+# substitution silently strips NUL bytes from its capture buffer,
+# which would re-jam all tokens together. Earlier versions used
+# newline-delimited output via print(tok), which silently SPLIT
+# any token containing a literal newline (e.g., the body of a
+# `gh pr create --body "Authoring-Agent: claude\n## Self-Review
+# \nok"`) into multiple bash tokens. Codex caught the bash-side
+# split on nathanpaynedotcom propagation PR #180 round 5.
+TMP_TOKENS=$(mktemp)
+TMP_TOKENS_ERR=$(mktemp)
+trap 'rm -f "$TMP_TOKENS" "$TMP_TOKENS_ERR"' EXIT
+# The python preprocessor first converts UNQUOTED newlines into `;`
+# command separators (so that multi-command inputs like
+# `echo ok\ngh pr merge 123 --admin` are split into two commands)
+# while preserving QUOTED newlines as literal characters in the
+# token (so that `gh pr create --body "line1\nline2"` keeps the
+# body as one token). Codex caught the unquoted-newline collapse
+# on swipewatch propagation PR #33 round 6 — privilege escalation
+# via newline-separated prefix command was the same shape as the
+# round-5 echo-prefix env spoof, just on a different separator.
+if ! printf '%s' "$COMMAND" | python3 -c '
+import sys, shlex
+
+def normalize_unquoted_newlines(cmd):
+    """Replace newlines OUTSIDE of single/double quotes with `; `.
+    Preserves newlines inside quoted strings as literal characters."""
+    out = []
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(cmd):
+        c = cmd[i]
+        # Handle backslash-escaped char in double quotes / unquoted
+        if c == "\\" and not in_single and i + 1 < len(cmd):
+            out.append(c)
+            out.append(cmd[i + 1])
+            i += 2
+            continue
+        # chr(39) is a single quote; using chr() avoids embedding a
+        # literal single quote inside the bash heredoc (which would
+        # break the python3 -c '...' surrounding quote).
+        if c == chr(39) and not in_double:
+            in_single = not in_single
+        elif c == chr(34) and not in_single:
+            in_double = not in_double
+        elif c == "\n" and not in_single and not in_double:
+            # Pad with spaces on BOTH sides so shlex parses the
+            # `;` as its own token rather than gluing it to the
+            # preceding word (e.g. "ok;" instead of "ok" + ";").
+            out.append(" ; ")
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+try:
+    cmd = sys.stdin.read()
+    cmd = normalize_unquoted_newlines(cmd)
+    for tok in shlex.split(cmd):
+        sys.stdout.buffer.write(tok.encode("utf-8", errors="replace") + b"\x00")
+except ValueError as e:
+    print(f"shlex error: {e}", file=sys.stderr)
+    sys.exit(1)
+' > "$TMP_TOKENS" 2> "$TMP_TOKENS_ERR"; then
+  echo "BLOCKED: gh-pr-guard could not tokenize the gh command (malformed shell quoting)." >&2
+  echo "  command: $COMMAND" >&2
+  echo "  shlex error: $(cat "$TMP_TOKENS_ERR")" >&2
+  echo "  Fix the quoting and retry, or use BREAK_GLASS_ADMIN=1 + --admin." >&2
+  exit 2
+fi
+# Read NUL-delimited tokens from the tempfile. `read -d ''` means
+# "read until NUL". Each iteration appends one whole token,
+# preserving any embedded newlines.
+TOKENS=()
+while IFS= read -r -d '' tok; do
+  TOKENS+=("$tok")
+done < "$TMP_TOKENS"
+
+# --- detect the pr subcommand, capturing any global -R/--repo ---
+#
+# Walk tokens to find `gh` IN COMMAND POSITION, then identify the
+# subcommand and any global -R/--repo. The pre-gh walk runs as a
+# small state machine so we don't blindly skip ANY pre-gh token —
+# round 5 had that bug, and nathanpayne-codex caught that
+# `echo gh pr merge 66` and `printf %s gh pr merge 66` were treated
+# as real merges.
+#
+# State machine:
+#
+#   AT_COMMAND_POSITION (initial state):
+#     The next token is either the command name or a continuation
+#     that keeps us in command position. Allowed continuations:
+#       - env assignments         VAR=value
+#       - prefix commands         sudo, eval, time, nohup, env,
+#                                 command, exec, nice, ionice
+#       - flags of those prefixes -X
+#       - compound separators     ;  &&  ||  |  &  (
+#       - gh                      → transition to phase 2
+#     Any other token is treated as the START of a non-gh command,
+#     and we transition to IN_UNRELATED_ARGS to skip its arguments.
+#
+#   IN_UNRELATED_ARGS:
+#     We're walking the arguments of a non-gh command. Skip
+#     everything until we hit a compound separator, at which point
+#     we're back in command position. End-of-input without finding
+#     gh in command position falls through to the post-walk check
+#     and exits 0.
+#
+# Tokens BEFORE `gh` (in either state) that match an env assignment
+# pattern are also captured into INLINE_CODEX_CLEARED /
+# INLINE_BREAK_GLASS_ADMIN, even when in IN_UNRELATED_ARGS — the
+# inline-env-prefix support from round 5 should keep working
+# regardless of whether the env assignment turns out to be for a
+# gh command or some other command. (Capturing for non-gh commands
+# is harmless: the EFFECTIVE_* values are only consulted by the
+# create/merge guards, which only run when SAW_GH=1.)
+#
+# Tokens BETWEEN `gh` and `pr` are global gh flags. The only global
+# value-taking flag we explicitly handle is -R/--repo; everything
+# else starting with - is assumed boolean and skipped.
+INLINE_CODEX_CLEARED=""
+INLINE_BREAK_GLASS_ADMIN=""
+GLOBAL_REPO=""
+PR_SUBCOMMAND=""
+PR_SUBCOMMAND_INDEX=-1    # index in TOKENS where the gh pr subcommand was found
+SAW_GH=0
+SAW_PR=0
+SKIP_GLOBAL_AS=""        # "" | "repo"
+AT_COMMAND_POSITION=1    # 1 = at command position, 0 = walking unrelated-command args
+SEGMENT_HAS_COMMAND=0    # 1 = this segment has seen a non-assignment command (echo, cat, etc.)
+SKIP_PREFIX_VALUE=0      # 1 = next token is the value of a prefix-command flag
+CURRENT_PREFIX=""        # name of the most recently seen prefix command (sudo/time/etc.)
+for i in "${!TOKENS[@]}"; do
+  tok="${TOKENS[$i]}"
+  # --- phase 2: walking after gh, looking for pr + subcommand ---
+  if [ "$SAW_GH" -eq 1 ]; then
+    if [ "$SKIP_GLOBAL_AS" = "repo" ]; then
+      GLOBAL_REPO="$tok"
+      SKIP_GLOBAL_AS=""
+      continue
+    fi
+    if [ "$SAW_PR" -eq 0 ]; then
+      case "$tok" in
+        pr)
+          SAW_PR=1
+          continue
+          ;;
+        -R|--repo)
+          SKIP_GLOBAL_AS="repo"
+          continue
+          ;;
+        -R=*)
+          GLOBAL_REPO="${tok#-R=}"
+          continue
+          ;;
+        --repo=*)
+          GLOBAL_REPO="${tok#--repo=}"
+          continue
+          ;;
+        -*)
+          # Unknown global flag — assume boolean (--help,
+          # --version, etc.) and skip. See "Limitations" in the
+          # header for the caveat about future value-taking
+          # globals.
+          continue
+          ;;
+        *)
+          # Non-flag, non-pr token before `pr`. Either gh aliases
+          # are in play (out of scope) or the command isn't a `gh
+          # pr` invocation. Allow.
+          exit 0
+          ;;
+      esac
+    fi
+    # SAW_PR=1 — this token IS the pr subcommand.
+    PR_SUBCOMMAND="$tok"
+    PR_SUBCOMMAND_INDEX=$i
+    break
+  fi
+
+  # --- phase 1: walking pre-gh, looking for gh in command position ---
+
+  # Consume the value of a prefix-command flag (e.g. the `user`
+  # in `sudo -u user gh ...`). Stays in command position because
+  # the prefix command may have additional flags or transition
+  # straight to the actual command.
+  if [ "$SKIP_PREFIX_VALUE" -eq 1 ]; then
+    SKIP_PREFIX_VALUE=0
+    continue
+  fi
+
+  # Compound separators always reset us to command position,
+  # whether we were in command position or skipping unrelated
+  # args. Only standalone `&&` / `||` / `;` / `|` / `&` / `(`
+  # tokens count — separators glommed onto adjacent words by
+  # missing whitespace (e.g. `foo;`) are NOT detected, which is
+  # an acceptable limitation for the agent flow.
+  #
+  # IMPORTANT: separator handling MUST run before the env-assignment
+  # capture below. Otherwise `echo CODEX_CLEARED=1 ; gh pr merge 65`
+  # would capture the literal `CODEX_CLEARED=1` arg of `echo` as a
+  # spoofed inline env var even though it never actually gets exported
+  # to the gh process. nathanpayne-codex caught this on swipewatch
+  # propagation PR #33 round 5 — privilege escalation potential.
+  case "$tok" in
+    "&&"|"||"|";"|"|"|"&"|"("|")")
+      AT_COMMAND_POSITION=1
+      CURRENT_PREFIX=""
+      # Clear inline env vars ONLY when the segment that just ended
+      # contained a non-assignment command. That means the assignment
+      # was a PREFIX scoped to that command, not a standalone
+      # assignment that persists in the shell:
+      #
+      #   BREAK_GLASS_ADMIN=1 echo ok ; gh pr merge --admin 65
+      #     → segment had `echo` (SEGMENT_HAS_COMMAND=1)
+      #     → assignment was prefix to echo → CLEAR at `;`
+      #
+      #   CODEX_CLEARED=1 && gh pr merge 76 --squash
+      #     → segment was ONLY the assignment (SEGMENT_HAS_COMMAND=0)
+      #     → standalone assignment → DON'T clear at `&&`
+      #
+      # nathanpayne-codex caught the over-clearing on template PR #76
+      # round 1 — `CODEX_CLEARED=1 && gh pr merge` was being cleared
+      # even though the assignment was standalone.
+      if [ "$SEGMENT_HAS_COMMAND" -eq 1 ]; then
+        INLINE_CODEX_CLEARED=""
+        INLINE_BREAK_GLASS_ADMIN=""
+      fi
+      SEGMENT_HAS_COMMAND=0
+      continue
+      ;;
+  esac
+
+  # Capture inline env assignments ONLY when AT_COMMAND_POSITION=1.
+  # Tokens in IN_UNRELATED_ARGS are arguments to an unrelated
+  # command (e.g., `echo BREAK_GLASS_ADMIN=1 ; gh pr merge --admin
+  # 65`) and do NOT export to the spawned gh process — capturing
+  # them would let an agent spoof guard variables by prefixing the
+  # command with an echo. Only assignments that are themselves in
+  # command position (e.g., `CODEX_CLEARED=1 gh pr merge 65` or
+  # `CODEX_CLEARED=1 sudo gh pr merge 65`) count.
+  if [ "$AT_COMMAND_POSITION" -eq 1 ]; then
+    case "$tok" in
+      CODEX_CLEARED=*)
+        INLINE_CODEX_CLEARED="${tok#CODEX_CLEARED=}"
+        ;;
+      BREAK_GLASS_ADMIN=*)
+        INLINE_BREAK_GLASS_ADMIN="${tok#BREAK_GLASS_ADMIN=}"
+        ;;
+    esac
+  fi
+
+  if [ "$AT_COMMAND_POSITION" -eq 0 ]; then
+    # Skipping arguments of an unrelated command. Stay until a
+    # separator resets us above.
+    continue
+  fi
+
+  case "$tok" in
+    [A-Za-z_]*=*)
+      # Env assignment. Stay in command position.
+      continue
+      ;;
+    sudo|eval|time|nohup|env|command|exec|nice|ionice)
+      # Known prefix command. Stay in command position so the
+      # next non-flag token is still treated as the command.
+      # Track which prefix we're parsing flags for so we can
+      # tell value-taking flags from boolean ones — short flags
+      # like `-p` mean different things to different commands
+      # (boolean for time, value-taking for ionice/sudo).
+      CURRENT_PREFIX="$tok"
+      continue
+      ;;
+    gh)
+      SAW_GH=1
+      continue
+      ;;
+    -*)
+      # Flag of the most recently seen prefix command. Whether
+      # the next token is a value depends on which prefix command
+      # this flag belongs to. Without this distinction, putting
+      # `-p` on a generic value-flag list would consume `gh` as
+      # the value of `time -p` (which is actually the POSIX
+      # boolean format flag), and putting `-p` on a generic
+      # boolean list would let `ionice -p PID gh ...` walk past
+      # `PID` thinking it's the next command.
+      #
+      # Per-prefix value-flag map. nathanpayne-codex caught the
+      # original bug (sudo -u, time -f, nice -n) on PR #66
+      # round 6; the per-prefix scoping prevents the obvious
+      # over-fix from breaking `time -p`.
+      case "$CURRENT_PREFIX:$tok" in
+        sudo:-u|sudo:-g|sudo:-U|sudo:-h|sudo:-p|sudo:-r|sudo:-s|sudo:-t|sudo:-c|sudo:-D)
+          SKIP_PREFIX_VALUE=1
+          continue
+          ;;
+        time:-f|time:-o)
+          SKIP_PREFIX_VALUE=1
+          continue
+          ;;
+        nice:-n)
+          SKIP_PREFIX_VALUE=1
+          continue
+          ;;
+        ionice:-c|ionice:-n|ionice:-p)
+          SKIP_PREFIX_VALUE=1
+          continue
+          ;;
+        env:-u|env:-S)
+          SKIP_PREFIX_VALUE=1
+          continue
+          ;;
+      esac
+      # Otherwise: boolean flag of the current prefix (or a flag
+      # of an unknown prefix, which we conservatively assume is
+      # boolean to avoid eating `gh`). Stay in command position.
+      continue
+      ;;
+    *)
+      # An unrelated command (echo, printf, cat, find, etc.).
+      # gh-as-an-argument should NOT trigger the hook;
+      # transition to skip mode and walk past the args.
+      # Mark the segment as having a real command so that
+      # separator-clearing of inline env vars fires correctly.
+      AT_COMMAND_POSITION=0
+      SEGMENT_HAS_COMMAND=1
+      continue
+      ;;
+  esac
+done
+
+# Effective env values: hook process env wins (set via `export`),
+# inline-prefix value falls back. Both forms are documented; both
+# must work.
+EFFECTIVE_CODEX_CLEARED="${CODEX_CLEARED:-${INLINE_CODEX_CLEARED:-}}"
+EFFECTIVE_BREAK_GLASS_ADMIN="${BREAK_GLASS_ADMIN:-${INLINE_BREAK_GLASS_ADMIN:-}}"
+
+# Not a pr create/merge command? Allow.
+if [ "$PR_SUBCOMMAND" != "create" ] && [ "$PR_SUBCOMMAND" != "merge" ]; then
   exit 0
 fi
 
 # --- gh pr create ---
-if echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+create'; then
+#
+# Substring grep on the raw command is fine here — the body markers
+# `Authoring-Agent:` and `## Self-Review` are content checks, not
+# structural ones, and they don't depend on argument positions or
+# global flags.
+if [ "$PR_SUBCOMMAND" = "create" ]; then
   MISSING=""
 
   if ! echo "$COMMAND" | grep -qi 'Authoring-Agent:'; then
@@ -33,7 +522,7 @@ if echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+create'; then
     MISSING="${MISSING}  - Missing '## Self-Review' section in PR body\n"
   fi
 
-  if [[ -n "$MISSING" ]]; then
+  if [ -n "$MISSING" ]; then
     echo "BLOCKED: PR description is missing required sections per REVIEW_POLICY.md:" >&2
     echo -e "$MISSING" >&2
     echo "Add these to the PR body before creating." >&2
@@ -43,17 +532,141 @@ if echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+create'; then
   exit 0
 fi
 
-# --- gh pr merge --admin ---
-if echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+merge'; then
-  if echo "$COMMAND" | grep -q '\-\-admin'; then
-    if [[ "${BREAK_GLASS_ADMIN:-}" == "1" ]]; then
-      echo "BREAK-GLASS: --admin merge authorized by human." >&2
-      exit 0
-    fi
-    echo "BLOCKED: --admin merge requires explicit human authorization." >&2
-    echo "Ask the human to confirm break-glass, then retry with BREAK_GLASS_ADMIN=1." >&2
-    exit 2
+# --- gh pr merge ---
+#
+# (PR_SUBCOMMAND must be "merge" and PR_SUBCOMMAND_INDEX must point
+# to the actual `merge` subcommand token in TOKENS by this point.)
+#
+# Walk tokens AFTER the literal `merge` subcommand token to extract:
+#   - PR_SELECTOR (first non-flag positional)
+#   - REPO_ARG (--repo / -R value if present)
+#   - ADMIN_REQUESTED (--admin flag)
+#
+# All three are derived from the SAME tokenized walk so that
+# value-taking flags (--body / --body-file / --subject /
+# --author-email / --match-head-commit / --repo / -R) correctly
+# consume their next token as the value. An earlier round used
+# `grep -q -- --admin` on the raw command string for the admin
+# check, which over-matched any `--admin` substring inside a
+# quoted flag value (e.g., `--subject "--admin follow-up"`).
+# nathanpayne-codex caught that on PR #66 round 6.
+#
+# An even earlier version of this walk used a separate `FOUND_MERGE`
+# scan that latched onto the FIRST `merge` token anywhere in the
+# command, not specifically the gh-context one. With chained inputs
+# like `echo merge ; gh pr merge 65`, the walk would latch onto the
+# echo arg and then capture `;` as the selector. Codex caught that
+# on the swipewatch propagation PR #33; the fix is to use the
+# PR_SUBCOMMAND_INDEX captured during phase 1 as the starting point
+# of the merge walk, eliminating the FOUND_MERGE state entirely.
+#
+# `gh pr merge` accepts the selector as <number> | <url> | <branch>;
+# we don't parse or validate the form, just pass it through to
+# `gh pr view` which accepts the same grammar.
+PR_SELECTOR=""
+REPO_ARG=""
+ADMIN_REQUESTED=0
+SKIP_NEXT_AS=""  # "" | "skip" | "repo"
+merge_walk_start=$((PR_SUBCOMMAND_INDEX + 1))
+for j in "${!TOKENS[@]}"; do
+  if [ "$j" -lt "$merge_walk_start" ]; then
+    continue
   fi
+  tok="${TOKENS[$j]}"
+  if [ "$SKIP_NEXT_AS" = "skip" ]; then
+    SKIP_NEXT_AS=""
+    continue
+  fi
+  if [ "$SKIP_NEXT_AS" = "repo" ]; then
+    REPO_ARG="$tok"
+    SKIP_NEXT_AS=""
+    continue
+  fi
+  case "$tok" in
+    --admin)
+      ADMIN_REQUESTED=1
+      continue
+      ;;
+    --repo|-R)
+      SKIP_NEXT_AS="repo"
+      continue
+      ;;
+    --repo=*)
+      REPO_ARG="${tok#--repo=}"
+      continue
+      ;;
+    -R=*)
+      REPO_ARG="${tok#-R=}"
+      continue
+      ;;
+    --body|-b|--body-file|-F|--subject|-t|--author-email|-A|--match-head-commit)
+      SKIP_NEXT_AS="skip"
+      continue
+      ;;
+  esac
+  case "$tok" in
+    -*)
+      continue
+      ;;
+  esac
+  # First non-flag token after the gh-context `merge` is the
+  # selector. Don't break — keep walking so a `--repo`/`-R` flag or
+  # `--admin` flag appearing AFTER the selector still gets captured.
+  if [ -z "$PR_SELECTOR" ]; then
+    PR_SELECTOR="$tok"
+  fi
+done
+
+# --admin sub-guard: break-glass only. Now token-based: the walk
+# above sets ADMIN_REQUESTED=1 only when `--admin` appears as a
+# REAL flag of `merge`, not as a substring of another flag's value.
+if [ "$ADMIN_REQUESTED" -eq 1 ]; then
+  if [ "$EFFECTIVE_BREAK_GLASS_ADMIN" = "1" ]; then
+    echo "BREAK-GLASS: --admin merge authorized by human." >&2
+    exit 0
+  fi
+  echo "BLOCKED: --admin merge requires explicit human authorization." >&2
+  echo "Ask the human to confirm break-glass, then retry with BREAK_GLASS_ADMIN=1 (export or inline prefix)." >&2
+  exit 2
 fi
+
+# Subcommand-scoped REPO_ARG wins over global GLOBAL_REPO (mirrors
+# gh's typical "more specific flag wins" behavior). Fall back to
+# the global value only if the subcommand didn't specify one.
+if [ -z "$REPO_ARG" ] && [ -n "$GLOBAL_REPO" ]; then
+  REPO_ARG="$GLOBAL_REPO"
+fi
+
+# Fetch labels. `gh pr view` with no positional argument resolves
+# the PR from the current branch; with a positional argument it
+# accepts number / URL / branch forms identically to gh pr merge.
+GH_ARGS=(pr view --json labels --jq '[.labels[].name] | join(",")')
+if [ -n "$PR_SELECTOR" ]; then
+  GH_ARGS=(pr view "$PR_SELECTOR" --json labels --jq '[.labels[].name] | join(",")')
+fi
+if [ -n "$REPO_ARG" ]; then
+  GH_ARGS+=(--repo "$REPO_ARG")
+fi
+
+if ! LABELS=$(gh "${GH_ARGS[@]}" 2>&1); then
+  echo "BLOCKED: gh-pr-guard could not fetch PR labels to verify merge-gate clearance." >&2
+  echo "  error: $LABELS" >&2
+  echo "  command: gh ${GH_ARGS[*]}" >&2
+  echo "  Fix the underlying gh/auth issue and retry, or set BREAK_GLASS_ADMIN=1 + use --admin if this is a break-glass merge." >&2
+  exit 2
+fi
+
+case ",$LABELS," in
+  *,needs-external-review,*)
+    if [ "$EFFECTIVE_CODEX_CLEARED" != "1" ]; then
+      echo "BLOCKED: PR carries 'needs-external-review' and CODEX_CLEARED is not set." >&2
+      echo "  Phase 4a merge gate: run 'scripts/codex-review-check.sh <PR#>' first." >&2
+      echo "  When it exits 0, retry this merge with CODEX_CLEARED=1 (export or inline prefix)." >&2
+      echo "  See REVIEW_POLICY.md § Phase 4a for the full flow." >&2
+      exit 2
+    fi
+    echo "CODEX_CLEARED=1 set; PR is labeled needs-external-review but agent claims merge-gate has passed." >&2
+    ;;
+esac
 
 exit 0


### PR DESCRIPTION
Closes #47 in nathanjohnpayne/ai_agent_repo_template Project #2. Same propagation as swipewatch and nathanpaynedotcom, pulling from the post-back-port template (b820430) with all 17 bug fixes included.

Authoring-Agent: claude

## Self-Review
- ✅ All scripts byte-identical to template main (b820430)
- ✅ Per-repo config customizations applied (coderabbit.enabled, functions/**)
- ✅ bash -n on all scripts, check_codex_scripts passes locally
- ✅ rules/repo_rules.md surgically updated with check_codex_scripts entry