### PR TITLE
refactor: rebrand ai_agent_repo_template references to mergepath

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,13 +40,13 @@ gh auth login
 
 ```bash
 # Clone the template repo if not already present
-git clone https://github.com/nathanjohnpayne/ai_agent_repo_template.git ~/Documents/GitHub/ai_agent_repo_template
+git clone https://github.com/nathanjohnpayne/mergepath.git ~/Documents/GitHub/mergepath
 
 # Install canonical helper scripts
 mkdir -p ~/.local/bin
-cp ~/Documents/GitHub/ai_agent_repo_template/scripts/gcloud/gcloud ~/.local/bin/
-cp ~/Documents/GitHub/ai_agent_repo_template/scripts/firebase/op-firebase-deploy ~/.local/bin/
-cp ~/Documents/GitHub/ai_agent_repo_template/scripts/firebase/op-firebase-setup ~/.local/bin/
+cp ~/Documents/GitHub/mergepath/scripts/gcloud/gcloud ~/.local/bin/
+cp ~/Documents/GitHub/mergepath/scripts/firebase/op-firebase-deploy ~/.local/bin/
+cp ~/Documents/GitHub/mergepath/scripts/firebase/op-firebase-setup ~/.local/bin/
 chmod +x ~/.local/bin/gcloud ~/.local/bin/op-firebase-deploy ~/.local/bin/op-firebase-setup
 
 # Ensure PATH includes ~/.local/bin
@@ -449,9 +449,9 @@ Install the canonical helper scripts from the sibling template repo once per mac
 
 ```bash
 mkdir -p ~/.local/bin
-cp ../ai_agent_repo_template/scripts/gcloud/gcloud ~/.local/bin/gcloud
-cp ../ai_agent_repo_template/scripts/firebase/op-firebase-deploy ~/.local/bin/
-cp ../ai_agent_repo_template/scripts/firebase/op-firebase-setup ~/.local/bin/
+cp ../mergepath/scripts/gcloud/gcloud ~/.local/bin/gcloud
+cp ../mergepath/scripts/firebase/op-firebase-deploy ~/.local/bin/
+cp ../mergepath/scripts/firebase/op-firebase-setup ~/.local/bin/
 chmod +x ~/.local/bin/gcloud ~/.local/bin/op-firebase-deploy ~/.local/bin/op-firebase-setup
 hash -r
 ```

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Data is organized per billing year under `/users/{userId}/billingYears/{yearId}`
 
 ### Deploy auth and future-secret flow
 
-- Deploy maintainers need `firebase-tools`, `gcloud`, and the canonical helper scripts from `../ai_agent_repo_template/scripts/`.
+- Deploy maintainers need `firebase-tools`, `gcloud`, and the canonical helper scripts from `../mergepath/scripts/`.
 - The normal maintainer flow reads the shared `Private/GCP ADC` source credential through the 1Password CLI, so routine deploy work does not need browser login once that item exists.
 - The 1Password-first deploy-auth model is intentional for this repo. Do not switch it back to ADC-first or deploy-key-based guidance unless a human explicitly requests that change.
 - `op-firebase-setup friends-and-family-billing` creates the deployer service account, grants deploy roles, and grants the current maintainer impersonation rights.

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -557,7 +557,7 @@ ssh -T git@github-claude        # → Hi nathanpayne-claude!
 ### Switching all repos to SSH remotes
 
 ```bash
-for repo in ai_agent_repo_template swipewatch nathanpaynedotcom \
+for repo in mergepath swipewatch nathanpaynedotcom \
             device-platform-reporting device-source-of-truth \
             overridebroadway friends-and-family-billing docs; do
   cd ~/Documents/GitHub/$repo


### PR DESCRIPTION
## Summary

The upstream template repo renamed from `ai_agent_repo_template` to `mergepath` — the umbrella brand for the reference implementation of the AI Agent Tooling Standard. This PR scrubs the old name from this repo's docs and clone URLs.

GitHub's old-URL auto-redirect has been carrying the old references since the rename; this is consistency cleanup, not a functional fix.

**Tracks:** https://github.com/nathanjohnpayne/mergepath/issues/111 (Phase 4 sub-issue in the [Mergepath Rebrand project](https://github.com/users/nathanjohnpayne/projects/4/views/1)).

## Changes

Global find-and-replace across tracked files:

- `ai_agent_repo_template` → `mergepath`
- `ai-agent-repo-template` → `mergepath`
- `AI Agent Repository Template` → `Mergepath`
- `AI Agent Repo Template` → `Mergepath`

## Verification

```bash
git ls-files | xargs grep -l -E "(ai_agent_repo_template|ai-agent-repo-template|AI Agent Repository Template|AI Agent Repo Template)"
# Expected: zero hits
```

## Authoring-Agent: claude

## Self-Review

**Correctness.** Direct string replacements on four distinct tokens. "AI Agent Tooling Standard" (the neutral methodology name) contains "AI Agent" but not any of the four tokens above, so it is correctly left unchanged.

**Regression risk.** Clone URLs and documentation references only — no code paths, no CI scripts, no secrets. GitHub's URL auto-redirect kept everything functional before this PR; this just makes the canonical form explicit.

**Style.** Mechanical find-replace; no prose edits.

**Test coverage.** No test changes needed — this is a cross-repo documentation update.

**Security / dependency hygiene.** No dependency changes. Updated advisory / reporting URLs point to the canonical `nathanjohnpayne/mergepath` endpoint if they existed in this repo.
