### PR TITLE
chore(sync): propagate agent-review workflow + helpers from mergepath

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -5,7 +5,12 @@ name: Agent Review Pipeline
 
 on:
   pull_request:
-    types: [opened, ready_for_review, labeled]
+    # `synchronize` (every push on an open PR) is in the list so
+    # `load-config` re-parses `.github/review-policy.yml` on every
+    # commit, not just on `opened` / `ready_for_review`. Without it,
+    # a shell-parser regression can land on main and only surface
+    # weeks later when the next PR happens to be opened. See #59.
+    types: [opened, ready_for_review, labeled, synchronize]
   pull_request_review:
     types: [submitted]
 
@@ -19,9 +24,21 @@ jobs:
   # Job 1: Read review-policy.yml configuration
   # ──────────────────────────────────────────────
   load-config:
+    # Runs on opened, ready_for_review, and synchronize so the
+    # parser exercises every commit pushed to an open PR, not just
+    # initial open. Explicitly excludes `labeled`: the `assign` job
+    # allows `labeled` as a trigger, and it depends on this job's
+    # outputs — letting load-config run on labeled would cause
+    # assign to re-fire on every label edit and re-request
+    # reviewers who have already reviewed. Downstream jobs keep
+    # their own action-specific guards; they stay no-ops on
+    # synchronize. See #59 for the SKIPPED-as-SUCCESS miss this
+    # closes and Codex's P2 on PR #131 for why labeled is excluded.
     if: >
       github.event_name == 'pull_request' &&
-      (github.event.action == 'opened' || github.event.action == 'ready_for_review')
+      (github.event.action == 'opened' ||
+       github.event.action == 'ready_for_review' ||
+       github.event.action == 'synchronize')
     runs-on: ubuntu-latest
     outputs:
       threshold: ${{ steps.config.outputs.threshold }}
@@ -29,7 +46,7 @@ jobs:
       reviewers: ${{ steps.config.outputs.reviewers }}
       author_identity: ${{ steps.config.outputs.author_identity }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Parse review-policy.yml
         id: config
@@ -43,16 +60,26 @@ jobs:
           THRESHOLD=$(grep 'external_review_threshold:' "$CONFIG" | awk '{print $2}')
           echo "threshold=$THRESHOLD" >> "$GITHUB_OUTPUT"
 
-          # Extract external_review_paths as JSON array
-          PATHS=$(awk '/^external_review_paths:/,/^[^ ]/' "$CONFIG" \
-            | grep '^ *-' | sed 's/^ *- *"//' | sed 's/"$//' \
-            | jq -R -s 'split("\n") | map(select(length > 0))')
+          # Extract external_review_paths as a JSON array. Delegates to
+          # scripts/workflow/parse_policy_list.sh (unit-tested by
+          # scripts/ci/check_workflow_parsers — see #57). History: the
+          # earlier inline `awk '/^key:/,/^[^ ]/'` range parser silently
+          # dropped all list entries because the range-start pattern
+          # also matched the range-end condition; see #54.
+          #
+          # `jq -c` (compact) is required here: multi-line JSON cannot
+          # be written via the `key=value` GITHUB_OUTPUT format. Before
+          # #54 fixed the awk extractor, PATHS was always `[]` (single-
+          # line) so this latent bug was hidden; PR #58 / #30 tripped it.
+          PATHS=$(bash scripts/workflow/parse_policy_list.sh "$CONFIG" external_review_paths \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "paths=$PATHS" >> "$GITHUB_OUTPUT"
 
-          # Extract available_reviewers as JSON array
-          REVIEWERS=$(awk '/^available_reviewers:/,/^[^ ]/' "$CONFIG" \
-            | grep '^ *-' | sed 's/^ *- *//' \
-            | jq -R -s 'split("\n") | map(select(length > 0))')
+          # Extract available_reviewers as a JSON array via the same
+          # extracted parser. Before #54 this was always `[]`, which
+          # silently broke the assign step's reviewer lookup.
+          REVIEWERS=$(bash scripts/workflow/parse_policy_list.sh "$CONFIG" available_reviewers \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "reviewers=$REVIEWERS" >> "$GITHUB_OUTPUT"
 
           AUTHOR=$(grep 'author_identity:' "$CONFIG" | awk '{print $2}')
@@ -72,7 +99,7 @@ jobs:
     steps:
       - name: Evaluate PR against review-policy.yml
         id: check
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           THRESHOLD: ${{ needs.load-config.outputs.threshold }}
           PROTECTED_PATHS: ${{ needs.load-config.outputs.paths }}
@@ -145,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign reviewer identity based on Authoring-Agent
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           AUTHOR_IDENTITY: ${{ needs.load-config.outputs.author_identity }}
           REVIEWERS_JSON: ${{ needs.load-config.outputs.reviewers }}
@@ -231,7 +258,7 @@ jobs:
     steps:
       - name: Check if this agent is assigned
         id: check-assigned
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
@@ -248,7 +275,7 @@ jobs:
       # ── Claude: headless CLI ──
       - name: Checkout repo
         if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'claude'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -273,7 +300,7 @@ jobs:
       # ── Codex: OpenAI Codex CLI ──
       - name: Checkout repo for Codex
         if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'codex'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -290,7 +317,7 @@ jobs:
       # ── Cursor: no headless mode yet ──
       - name: Notify for manual Cursor review
         if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'cursor'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
@@ -308,13 +335,13 @@ jobs:
     if: github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install js-yaml
         run: npm install js-yaml
 
       - name: Check for conflicting reviews
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
@@ -408,13 +435,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dismiss self-approval from reviewer bot accounts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install js-yaml
         run: npm install js-yaml
 
       - name: Check and dismiss
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
@@ -463,21 +490,52 @@ jobs:
   # ──────────────────────────────────────────────
   # Job 7: Auto-merge on approval (if no external review required)
   # ──────────────────────────────────────────────
+  # Must `needs:` on detect-disagreement and block-self-approval to force
+  # those sibling jobs to COMPLETE before this one starts. Both siblings
+  # can apply blocking labels as a side effect (`needs-human-review` from
+  # detect-disagreement, `policy-violation` from block-self-approval), and
+  # without the ordering constraint they run in parallel with auto-merge.
+  # A sibling applying a label 200ms after the runtime re-verify step
+  # below fetches labels but 100ms before `gh pr merge` dispatches would
+  # still slip through. `always()` in the if: expression keeps auto-merge
+  # running even if a sibling fails — ordering, not gating, is what
+  # `needs:` is for here. See #61 for the cross-event race and this PR
+  # for the same-workflow race nathanpayne-codex caught during review.
   auto-merge-on-approval:
+    needs: [detect-disagreement, block-self-approval]
     if: >
+      always() &&
       github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
       !contains(github.event.pull_request.labels.*.name, 'needs-external-review') &&
       !contains(github.event.pull_request.labels.*.name, 'needs-human-review')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check if CodeRabbit is enabled
         id: cr
         run: |
           CONFIG=".github/review-policy.yml"
-          if sed -n '/^coderabbit:/,$ p' "$CONFIG" | grep -qE '^\s*enabled:\s*true'; then
+          # Parse only the `coderabbit:` block — stop at the next top-level key.
+          # The previous `sed -n '/^coderabbit:/,$ p'` was scope-unsafe: it
+          # captured everything from `coderabbit:` to EOF, so a later top-level
+          # block with `enabled: true` (e.g., the `codex:` block added in #31)
+          # produced a false positive and triggered the CodeRabbit wait loop.
+          #
+          # The end-of-block test is "a new line whose first character is
+          # neither whitespace nor `#`" — which catches the next top-level YAML
+          # key while still permitting column-0 comments (`# ...`) and blank
+          # lines inside the block. The earlier `^[^[:space:]]` regex was
+          # too strict: a YAML-valid column-0 comment prematurely exited the
+          # block and produced a false negative. Fix surfaced by nathanpayne-codex
+          # external review on PR #53.
+          if awk '
+            /^coderabbit:/ {in_block=1; next}
+            in_block && /^[^[:space:]#]/ {in_block=0}
+            in_block && /^[[:space:]]*enabled:[[:space:]]*true([[:space:]]*#.*)?$/ {found=1}
+            END {exit found ? 0 : 1}
+          ' "$CONFIG"; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -485,33 +543,97 @@ jobs:
 
       - name: Wait for CodeRabbit review
         if: steps.cr.outputs.enabled == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const maxWaitMs = 5 * 60 * 1000; // 5 minutes
-            const pollMs = 30 * 1000;         // 30 seconds
-            const start = Date.now();
+        env:
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Delegate to scripts/coderabbit-wait.sh so auto-merge honors the
+          # same semantics the agent-driven flow uses: HEAD-anchored
+          # freshness (#136 — do not merge on a stale review from a prior
+          # HEAD), rate-limit retry (#138 — CodeRabbit does not auto-retry
+          # after its published window elapses), and the coderabbit.*
+          # knobs in .github/review-policy.yml. Exit-code translation:
+          #   0 — cleared on current HEAD, no high-severity markers.
+          #   2 — cleared but findings present (Potential issue / ⚠️).
+          #       Blocks auto-merge per REVIEW_POLICY.md § Phase 2.5,
+          #       which requires every Potential issue / ⚠️ finding to
+          #       be explicitly addressed (fixed or dismissed with
+          #       reasoning) before moving on. The agent-driven flow
+          #       does that in-session; the auto-merge workflow has
+          #       no way to address a finding, so it stops here and
+          #       lets the author push a fix (or post a dismissal
+          #       reply). A new approving review after the fix
+          #       re-triggers this job.
+          #   3 — API / infra error. Block and surface.
+          #   4 — max_wait_seconds grace window elapsed without a review.
+          #       CodeRabbit is advisory; log a warning and proceed.
+          #   5 — rate-limit retry budget exhausted. Do NOT merge —
+          #       block and let the human intervene.
+          set +e
+          bash scripts/coderabbit-wait.sh "$PR_NUMBER" "$REPO"
+          rc=$?
+          set -e
+          case "$rc" in
+            0)
+              echo "CodeRabbit cleared on current HEAD — proceeding to merge."
+              ;;
+            2)
+              echo "::error::CodeRabbit flagged Potential issue / ⚠️ findings on the current HEAD. Per REVIEW_POLICY.md § Phase 2.5, each must be explicitly addressed (fixed or dismissed with reasoning) before merge. Blocking auto-merge; address the findings and request a new approval to re-trigger."
+              exit 1
+              ;;
+            4)
+              echo "::warning::CodeRabbit grace window elapsed without a review. CodeRabbit is advisory — proceeding to merge."
+              ;;
+            5)
+              echo "::error::CodeRabbit rate-limit retry budget exhausted. Blocking auto-merge; human must re-trigger or merge manually."
+              exit 1
+              ;;
+            *)
+              echo "::error::coderabbit-wait.sh failed with exit code $rc. Blocking auto-merge."
+              exit 1
+              ;;
+          esac
 
-            while (Date.now() - start < maxWaitMs) {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-              });
-              const hasCR = comments.some(
-                c => c.user.login === 'coderabbitai[bot]' &&
-                     !c.body.includes('Currently processing')
-              );
-              if (hasCR) {
-                core.info('CodeRabbit review found — proceeding to merge.');
-                return;
-              }
-              core.info(`Waiting for CodeRabbit... (${Math.round((Date.now() - start) / 1000)}s)`);
-              await new Promise(r => setTimeout(r, pollMs));
-            }
-            core.warning('CodeRabbit did not post within 5 minutes — proceeding to merge.');
+      - name: Re-verify blocking labels right before merge
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+        run: |
+          # Guard against the TOCTOU race between the trigger-time label
+          # snapshot and the actual merge. The job's top-level `if:` expression
+          # evaluates labels from the `pull_request_review` event payload at
+          # the moment GitHub Actions dispatched the event. Two things can
+          # make that snapshot stale by the time we reach the merge step:
+          #
+          #   1. Eventual consistency. If a label is applied milliseconds
+          #      before the review event fires, the event payload can still
+          #      be generated without the label attached. Observed on PR #60
+          #      (2026-04-14), where the `needs-external-review` label was
+          #      applied 2 seconds before the review event but the job's
+          #      `if:` check evaluated to true anyway, merging the PR before
+          #      any external review could happen. See #61.
+          #
+          #   2. The "Wait for CodeRabbit review" step above can sleep for
+          #      up to 5 minutes on a coderabbit-enabled repo. During that
+          #      window, an agent can legitimately apply a blocking label
+          #      (e.g., a human spotting something after approval) and the
+          #      job would still merge because the `if:` already evaluated.
+          #
+          # Re-fetch the authoritative label state from the GitHub API
+          # immediately before merging. Abort if any blocking label is now
+          # present. Also check `policy-violation`, which is applied by the
+          # block-self-approval job earlier in this same workflow run (and
+          # again, the `if:` at job start wouldn't have seen it).
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '[.labels[].name] | join(",")')
+          echo "Labels at merge time: [$LABELS]"
+          case ",$LABELS," in
+            *,needs-external-review,*|*,needs-human-review,*|*,policy-violation,*)
+              echo "::error::Blocking label present at merge time: $LABELS. Aborting auto-merge."
+              exit 1
+              ;;
+          esac
+          echo "No blocking labels present — proceeding to merge."
 
       - name: Enable auto-merge
         run: gh pr merge --squash --auto "$PR_URL" || gh pr merge --squash "$PR_URL" || true

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   self-review-check:
     name: Self-Review Required
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check for Self-Review section
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Block merge if blocking labels present
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const blockingLabels = [
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -95,24 +95,38 @@ jobs:
             REASONS="$REASONS- ${LINES_CHANGED} lines changed (threshold: ${THRESHOLD})%0A"
           fi
 
-          # Read protected paths from review-policy.yml and check against diff
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
-          PATHS=$(awk '/^external_review_paths:/,/^[^ ]/' "$CONFIG" \
-            | grep '^ *-' | sed 's/^ *- *"//' | sed 's/"$//')
+          # Extract external_review_paths entries from review-policy.yml.
+          # Delegates to scripts/workflow/parse_policy_list.sh, which is
+          # unit-tested by scripts/ci/check_workflow_parsers (see #57).
+          # History: the earlier inline `awk '/^key:/,/^[^ ]/'` range
+          # parser silently matched only the header line because the
+          # range-start pattern also matched the range-end condition.
+          # See #54 for the post-mortem.
+          PATHS=$(bash scripts/workflow/parse_policy_list.sh "$CONFIG" external_review_paths)
 
-          MATCHED_FILES=""
-          for pattern in $PATHS; do
-            # Convert glob to grep-compatible pattern
-            REGEX=$(echo "$pattern" | sed 's/\*\*/.*/g' | sed 's/\*\//[^\/]*\//g' | sed 's/\*/[^\/]*/g')
-            MATCHES=$(echo "$CHANGED_FILES" | grep -E "$REGEX" || true)
-            if [ -n "$MATCHES" ]; then
-              MATCHED_FILES="$MATCHED_FILES$MATCHES"$'\n'
-            fi
-          done
+          # Match changed files against patterns. Delegates to
+          # scripts/workflow/match_protected_paths.sh (bash `[[ ]]`
+          # pattern matching under the hood), which is unit-tested by
+          # scripts/ci/check_workflow_parsers (see #57). History: the
+          # earlier inline glob-to-regex sed pipeline double-transformed
+          # `*` and silently missed nested paths. See #54 for the
+          # post-mortem.
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+
+          PATTERNS=()
+          while IFS= read -r line; do
+            [ -n "$line" ] && PATTERNS+=("$line")
+          done <<< "$PATHS"
+
+          if [ "${#PATTERNS[@]}" -gt 0 ]; then
+            MATCHED_FILES=$(printf '%s\n' "$CHANGED_FILES" | bash scripts/workflow/match_protected_paths.sh "${PATTERNS[@]}")
+          else
+            MATCHED_FILES=""
+          fi
 
           if [ -n "$MATCHED_FILES" ]; then
             NEEDS_REVIEW=true
-            FILE_LIST=$(echo "$MATCHED_FILES" | sort -u | sed 's/^/  - /' | tr '\n' ',' | sed 's/,/%0A/g')
+            FILE_LIST=$(echo "$MATCHED_FILES" | sort -u | grep -v '^$' | sed 's/^/  - /' | tr '\n' ',' | sed 's/,/%0A/g')
             REASONS="${REASONS}- Protected paths modified:%0A${FILE_LIST}"
           fi
 
@@ -138,11 +152,15 @@ jobs:
 
           FORMATTED_REASONS=$(echo "$REASONS" | sed 's/%0A/\n/g')
 
-          COMMENT_BODY=$(printf '%s\n\n%s\n\n%s\n\n%s\n\n%s' \
-            '**External Review Required**' \
-            'This PR has been labeled `needs-external-review` based on .github/review-policy.yml:' \
-            "$FORMATTED_REASONS" \
-            'Per REVIEW_POLICY.md, the authoring agent must post a handoff message and alert the human. The human will coordinate external review by a different agent.' \
-            '> Automated check per .github/review-policy.yml')
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          **External Review Required**
 
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$COMMENT_BODY"
+          This PR has been labeled \`needs-external-review\` based on .github/review-policy.yml:
+
+          $FORMATTED_REASONS
+
+          Per REVIEW_POLICY.md, the authoring agent must post a handoff message and alert the human. The human will coordinate external review by a different agent.
+
+          > Automated check per .github/review-policy.yml
+          EOF
+          )"

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: make_ci_scripts_executable
         run: chmod +x scripts/ci/*
@@ -47,6 +47,9 @@ jobs:
 
       - name: check_codex_scripts
         run: ./scripts/ci/check_codex_scripts
+
+      - name: check_workflow_parsers
+        run: ./scripts/ci/check_workflow_parsers
 
       - name: check_governance_files
         run: |

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unit-level coverage for the two shell scripts the workflows
+# call to parse `.github/review-policy.yml` and match changed
+# files against protected-path globs:
+#   - scripts/workflow/parse_policy_list.sh
+#   - scripts/workflow/match_protected_paths.sh
+#
+# Covers the failure modes that escaped to prod in #54 / PR #55
+# (documented in mergepath#57):
+#
+#   bug 1: YAML parse failure (awk range self-termination)
+#   bug 2: external_review_paths silently empty
+#   bug 3: glob-to-regex double-transform mismatched nested paths
+#
+# Runs from the repo root. Invoked by .github/workflows/repo_lint.yml.
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+FIXTURE="scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml"
+PARSE="scripts/workflow/parse_policy_list.sh"
+MATCH="scripts/workflow/match_protected_paths.sh"
+
+for f in "$FIXTURE" "$PARSE" "$MATCH"; do
+  if [ ! -f "$f" ]; then
+    echo "check_workflow_parsers: missing required file: $f" >&2
+    exit 1
+  fi
+done
+
+pass=0
+fail=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $desc"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: $desc" >&2
+    # Quote the values when printing so patterns like `**/*secret*`
+    # don't glob-expand in the failure output and mislead whoever
+    # is debugging the regression.
+    echo "    expected:" >&2
+    while IFS= read -r line; do
+      printf '      %s\n' "$line" >&2
+    done <<< "$expected"
+    echo "    actual:" >&2
+    while IFS= read -r line; do
+      printf '      %s\n' "$line" >&2
+    done <<< "$actual"
+  fi
+}
+
+echo "parse_policy_list.sh tests"
+
+# Covers bug 2: the range-based parser silently produced an empty
+# list for external_review_paths. If that regresses, this fails.
+got=$(bash "$PARSE" "$FIXTURE" external_review_paths)
+want='src/auth/**
+src/payments/**
+**/*secret*
+**/*credential*
+.github/**'
+assert_eq "extracts external_review_paths (5 entries, quotes stripped)" "$want" "$got"
+
+got=$(bash "$PARSE" "$FIXTURE" available_reviewers)
+want='nathanpayne-claude
+nathanpayne-cursor
+nathanpayne-codex'
+assert_eq "extracts available_reviewers (3 entries, no quotes to strip)" "$want" "$got"
+
+got=$(bash "$PARSE" "$FIXTURE" nonexistent_key || true)
+assert_eq "returns empty for missing key" "" "$got"
+
+got=$(bash "$PARSE" "$FIXTURE" external_review_paths | wc -l | tr -d ' ')
+assert_eq "line count matches entry count" "5" "$got"
+
+# Inline-comment stripping: fixture has `- "src/payments/**"  # payments
+# code is sensitive`. The extracted pattern must be the bare glob, not
+# the glob with a trailing `# comment`, else the matcher silently breaks.
+got=$(bash "$PARSE" "$FIXTURE" external_review_paths | grep -c 'payments')
+assert_eq "inline comment stripped from payments entry" "1" "$got"
+got=$(bash "$PARSE" "$FIXTURE" external_review_paths | grep 'payments' | head -1)
+assert_eq "payments entry is clean glob, no trailing comment" "src/payments/**" "$got"
+
+echo
+echo "match_protected_paths.sh tests"
+
+# Covers bug 3: the glob-to-regex double-transform silently failed
+# to match nested paths under `.github/**`.
+got=$(printf '%s\n' ".github/workflows/foo.yml" | bash "$MATCH" ".github/**")
+assert_eq "nested .github/** matches .github/workflows/foo.yml" ".github/workflows/foo.yml" "$got"
+
+got=$(printf '%s\n' "src/auth/login.ts" | bash "$MATCH" "src/auth/**")
+assert_eq "src/auth/** matches src/auth/login.ts" "src/auth/login.ts" "$got"
+
+got=$(printf '%s\n' "config/secret.env" | bash "$MATCH" "**/*secret*")
+assert_eq "**/*secret* matches config/secret.env" "config/secret.env" "$got"
+
+got=$(printf '%s\n' "src/payments/billing/invoice.ts" | bash "$MATCH" "src/payments/**")
+assert_eq "src/payments/** matches deeply nested path" "src/payments/billing/invoice.ts" "$got"
+
+got=$(printf '%s\n' "README.md" | bash "$MATCH" ".github/**" "src/auth/**" "**/*secret*")
+assert_eq "README.md matches no protected pattern" "" "$got"
+
+got=$(printf '%s\n' "src/main.ts" | bash "$MATCH" "src/auth/**" "src/payments/**")
+assert_eq "src/main.ts does not match src/auth/** or src/payments/**" "" "$got"
+
+# End-to-end: feed the parse script's output to the match script.
+# Simulates what the workflow does on a real PR diff. We avoid
+# `readarray` / `mapfile` so this runs under macOS's default
+# /bin/bash 3.2 as well as modern bash 4+.
+PATTERNS=()
+while IFS= read -r line; do
+  [ -n "$line" ] && PATTERNS+=("$line")
+done < <(bash "$PARSE" "$FIXTURE" external_review_paths)
+got=$(printf '%s\n' \
+    "README.md" \
+    ".github/workflows/agent-review.yml" \
+    "src/auth/login.ts" \
+    "src/main.ts" \
+    "config/credentials.json" \
+  | bash "$MATCH" "${PATTERNS[@]}" | sort)
+want='.github/workflows/agent-review.yml
+config/credentials.json
+src/auth/login.ts'
+assert_eq "end-to-end: parse output piped into matcher" "$want" "$got"
+
+echo
+if [ "$fail" -gt 0 ]; then
+  echo "check_workflow_parsers: $fail FAIL / $pass PASS" >&2
+  exit 1
+fi
+echo "check_workflow_parsers: PASS ($pass tests)"

--- a/scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml
+++ b/scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml
@@ -1,0 +1,22 @@
+# Fixture — exercises the workflow shell-parser scripts.
+# Mirrors the real .github/review-policy.yml schema closely
+# enough to catch regressions in parse_policy_list.sh and
+# match_protected_paths.sh. See scripts/ci/check_workflow_parsers
+# and mergepath#57.
+external_review_threshold: 300
+
+external_review_paths:
+  - "src/auth/**"
+  - "src/payments/**"  # payments code is sensitive
+  - "**/*secret*"
+  - "**/*credential*"
+  - ".github/**"
+
+# Inline comments inside a block should not break the parser.
+available_reviewers:
+  - nathanpayne-claude
+  # A commented-out entry between list items — still parsable.
+  - nathanpayne-cursor
+  - nathanpayne-codex
+
+author_identity: nathanjohnpayne

--- a/scripts/workflow/match_protected_paths.sh
+++ b/scripts/workflow/match_protected_paths.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print stdin lines (file paths) that match any of the glob
+# patterns passed as positional arguments. Patterns use bash
+# extended pattern matching (`[[ str == pattern ]]`), which — for
+# our purposes — handles `**` cleanly: `.github/**` matches
+# `.github/workflows/foo.yml` without needing `shopt -s globstar`.
+#
+# Usage:
+#   printf '%s\n' file1 file2 ... | scripts/workflow/match_protected_paths.sh <pattern>...
+#
+# Example:
+#   $ printf '%s\n' .github/workflows/foo.yml src/main.ts README.md \
+#       | scripts/workflow/match_protected_paths.sh '.github/**' 'src/auth/**'
+#   .github/workflows/foo.yml
+#
+# Why bash `[[ ]]` instead of an explicit glob-to-regex sed pipeline:
+# the earlier sed implementation in `.github/workflows/pr-review-policy.yml`
+# double-transformed `*` — `.github/**` became `.github/.*` (correct),
+# then a second pass converted the remaining `*` into `[^/]*`, yielding
+# `.github/.[^/]*` which silently failed to match nested paths. See
+# mergepath#54 for the full post-mortem.
+
+if [ "$#" -eq 0 ]; then
+  echo "match_protected_paths.sh: at least one pattern required" >&2
+  echo "usage: printf '%s\\n' <files...> | match_protected_paths.sh <pattern>..." >&2
+  exit 1
+fi
+
+patterns=("$@")
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  for pattern in "${patterns[@]}"; do
+    # shellcheck disable=SC2053  # $pattern is intended to be a glob
+    if [[ "$file" == $pattern ]]; then
+      echo "$file"
+      break
+    fi
+  done
+done

--- a/scripts/workflow/parse_policy_list.sh
+++ b/scripts/workflow/parse_policy_list.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extract the entries of a top-level YAML list from
+# `.github/review-policy.yml` (or any file with the same flat
+# schema). Prints each entry on its own line with surrounding
+# quotes stripped.
+#
+# Usage: scripts/workflow/parse_policy_list.sh <config_path> <key>
+#
+# Example:
+#   $ scripts/workflow/parse_policy_list.sh .github/review-policy.yml external_review_paths
+#   src/auth/**
+#   src/payments/**
+#   **/*secret*
+#   **/*credential*
+#   .github/**
+#
+# Why a state-machine awk parser (not `awk '/^key:/,/^[^ ]/'`):
+# the range-start pattern also matches the range-end condition on
+# the same line — the header line starts with a non-space
+# character, so a naive range parser silently matches only the
+# header line and drops every list entry. See mergepath#54.
+#
+# A real YAML parser would be more correct but brings a dependency
+# (python+PyYAML / ruby yaml / yq) that this script deliberately
+# avoids — GitHub Actions ubuntu-latest runners have bash+awk+sed
+# reliably; YAML parsers are less reliably present across minimal
+# images. The callers already assume a flat structure and quoted
+# list entries; this script is scoped to that narrow shape.
+
+CONFIG="${1:?usage: parse_policy_list.sh <config_path> <key>}"
+KEY="${2:?usage: parse_policy_list.sh <config_path> <key>}"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "parse_policy_list.sh: config file not found: $CONFIG" >&2
+  exit 1
+fi
+
+awk -v key="$KEY" '
+  # Match the header line for the requested key at column 0.
+  $0 ~ "^" key ":" { in_block = 1; next }
+  # Any other line that starts at column 0 (not space, not comment)
+  # ends the block — this is how we detect the next top-level key.
+  in_block && /^[^[:space:]#]/ { in_block = 0 }
+  # Inside the block, list items are indented lines starting with
+  # a `-`. Blank lines and comment-only lines inside the block are
+  # ignored. Inline comments (e.g. `- ".github/**"  # note`) and
+  # surrounding quotes are stripped here so the downstream matcher
+  # receives clean glob patterns.
+  in_block && /^ *-/ {
+    line = $0
+    sub(/^ *- */, "", line)
+    if (line ~ /^"/) {
+      # Quoted entry: strip the leading `"`, then the closing `"`
+      # plus any trailing whitespace and inline comment.
+      sub(/^"/, "", line)
+      sub(/"[[:space:]]*(#.*)?$/, "", line)
+    } else {
+      # Unquoted entry: strip only the trailing whitespace + comment.
+      sub(/[[:space:]]+#.*$/, "", line)
+    }
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+    print line
+  }
+' "$CONFIG"


### PR DESCRIPTION
Authoring-Agent: claude

Brings this repo's agent-review pipeline (workflows + helpers) up to mergepath main after the 2026-04-19 review-tooling session.

## What moves

- `.github/workflows/agent-review.yml` — auto-merge-on-approval now delegates to `scripts/coderabbit-wait.sh` (closing mergepath #136 auto-merge-races-CodeRabbit, picking up #138 rate-limit retry + #147 HEAD-anchored freshness). load-config re-parses `review-policy.yml` on every synchronize (#59). Job ordering via `needs:` on detect-disagreement / block-self-approval (from Codex #131).
- `.github/workflows/pr-review-policy.yml` — self-review + label-gate + external-review-check improvements from #54, #57, #59.
- `.github/workflows/repo_lint.yml` — runs the new workflow-parser check.
- `scripts/workflow/parse_policy_list.sh` + `scripts/workflow/match_protected_paths.sh` — extracted shell helpers used by the workflows.
- `scripts/ci/check_workflow_parsers` + fixture — unit tests the parser helpers (#57).

## Preserving behavior

- `.github/workflows/dependabot-auto-merge.yml`, any repo-specific pipelines, `.github/review-policy.yml`, and anything outside the above list are untouched.
- Action pins match mergepath main at time of sync. If Dependabot in this repo had bumped pins past mergepath main, that bump will need to re-run here post-merge. Dependabot does this automatically on its next cycle; no manual action required.

## Self-Review

- **Correctness.** Mechanical copies from mergepath main. All workflow helpers and fixtures carry together, so the workflows' `bash scripts/workflow/...` invocations have their dependencies on disk.
- **Regression risk.** Moderate. Each downstream repo's CI surface changes at merge time. The `repo_lint.yml` additions add a new check that exercises the parser fixtures; `check_workflow_parsers` expects the fixture file at the exact path included here.
- **Style.** No semantic divergence from the canonical mergepath versions.
- **Test coverage.** Workflows are exercised by CI itself. The fixture unit-test runs on every PR once this merges.
- **Security.** No new secret surfaces. Same `REVIEWER_ASSIGNMENT_TOKEN` and `GITHUB_TOKEN` wiring as before.

## Test plan

- [ ] CI repo_lint job runs green post-merge.
- [ ] First PR after merge triggers the full agent-review.yml pipeline with the new synchronize handling.
- [ ] auto-merge-on-approval invokes scripts/coderabbit-wait.sh on its CodeRabbit wait step (check job logs).
