### PR TITLE
fix(editor): immediatelyRender:false to unblock e2e on TipTap 3.23

### DIFF
--- a/src/app/components/SubjectEditor.jsx
+++ b/src/app/components/SubjectEditor.jsx
@@ -87,6 +87,10 @@ const SubjectEditor = forwardRef(function SubjectEditor({ content, onUpdate, rea
     onUpdateRef.current = onUpdate;
 
     const editor = useEditor({
+        // See TemplateEditor.jsx for the rationale — `immediatelyRender:
+        // false` avoids a 3.23.0 destroy-during-mount race that nulls
+        // `schema`/`commandManager` before `useEditorState` selectors run.
+        immediatelyRender: false,
         extensions: [
             StarterKit.configure({
                 heading: false,

--- a/src/app/components/TemplateEditor.jsx
+++ b/src/app/components/TemplateEditor.jsx
@@ -139,6 +139,16 @@ const TemplateEditor = forwardRef(function TemplateEditor({ content, onUpdate, r
     onConfigurePMRef.current = onConfigurePaymentMethods;
 
     const editor = useEditor({
+        // TipTap 3.23.0 changed `Editor.destroy()` to null out `schema`,
+        // `commandManager`, and `extensionManager` (memory-leak fix). The
+        // React hook's `EditorInstanceManager` creates the editor in its
+        // constructor and then calls `scheduleDestroy()` immediately; if
+        // the component isn't marked mounted by the timer, the editor is
+        // destroyed in place. A subsequent render where `useEditorState`'s
+        // selector calls `e.isActive('bold')` then trips on `e.schema`/
+        // `e.commands` being null. Deferring creation until after mount via
+        // `immediatelyRender: false` avoids the race.
+        immediatelyRender: false,
         extensions: [
             StarterKit.configure({
                 heading: false,


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

`tests/e2e/invoicing-editor.spec.js` has been failing on `main` since #252 merged the TipTap 3.22.5 → 3.23.1 bump. All 7 e2e tests time out at `page.waitForSelector('.ProseMirror', { timeout: 10000 })`. Root cause is a destroy-race introduced by TipTap 3.23.0's memory-leak fix, not a real TipTap regression.

### What 3.23.0 changed

[`@tiptap/core` 3.23.0](https://github.com/ueberdosis/tiptap/releases/tag/v3.23.0) release notes:

> Fixed a memory leak where `Editor.destroy()` did not release the Extension parent/child graph. […] The fix also cleans up `ExtensionManager`, `schema`, and `commandManager` references on destroy.

Confirmed in `node_modules/@tiptap/core/dist/index.js:5250-5260`:

```js
destroy() {
  if (this.destroyed) return;
  this.destroyed = true;
  this.emit("destroy");
  this.unmount();
  this.removeAllListeners();
  this.extensionManager.destroy();
  this.extensionManager = null;
  this.schema = null;          // ← new in 3.23
  this.commandManager = null;  // ← new in 3.23
  this.extensionStorage = {};
}
```

### The race

`@tiptap/react`'s `EditorInstanceManager` (used by `useEditor()`) creates the editor synchronously in its constructor and then calls `scheduleDestroy()` on a microtask. If the timer fires before the component has been marked mounted, the editor is destroyed in place. When `useEditor` yields the destroyed instance and the next render runs `useEditorState`'s selector — `({editor: e}) => ({ bold: e.isActive('bold'), italic: e.isActive('italic'), … })` — the `isActive` call dereferences the now-null `schema` and throws.

Errors captured from the failing trace (`test-results/.../trace.zip`):

```
TypeError: Cannot read properties of null (reading 'nodes')
  at Xd.getText (InvoicingTab-…js:85:94)
  at InvoicingTab-…js:145:5096
  at React reconciler …

TypeError: Cannot read properties of null (reading 'commands')
  at get commands (InvoicingTab-…js:83:3360)
  at InvoicingTab-…js:145:1632
  at React reconciler …
```

The React tree throws during render *before* the `.ProseMirror` DOM node is committed, so the Playwright selector never resolves — hence the 10s timeout instead of a CSS-class diff or a missing-element symptom.

### Fix

Set `immediatelyRender: false` on both `useEditor()` call sites (`TemplateEditor.jsx` and `SubjectEditor.jsx`). That defers editor creation until after the component is mounted, so the scheduleDestroy timer never fires against an un-mounted instance.

This is the same toggle TipTap itself relies on — [3.23.2](https://github.com/ueberdosis/tiptap/blob/main/CHANGELOG.md#v3232) auto-defaults `immediatelyRender: false` under SSR to fix exactly this class of bug. We're applying it everywhere in our React client to cover the non-SSR path too.

### Why `npm test` (jsdom) didn't catch this

Our jsdom React tests don't render `FormattingToolbar` / call `useEditorState`, so the null-deref doesn't happen there. The whole class of failure only surfaces against the real browser in playwright — exactly what e2e is for.

## Self-Review

- **Correctness:** All 7 invoicing-editor e2e tests pass locally (~6s, was 100% red on this branch's parent). All 632 jest tests still pass.
- **Regression risk:** Low. `immediatelyRender: false` is a documented TipTap option, the same value TipTap itself sets when it detects SSR. Slight behavioral change: editor is created on first effect rather than during initial render — code already handles `if (!editor) return null` in TemplateEditor, and SubjectEditor's `<EditorContent editor={editor} />` no-ops when editor is null.
- **Test coverage:** e2e suite covers exactly this regression. No new test needed.
- **Style:** Two-line addition (plus comments) in each file. Comments document the *why* for the next person to encounter this.
- **Security/dependency hygiene:** No deps changed. The TipTap 3.23.1 bump from #252 stays.

## Test plan

- [x] `npm run test:e2e` — 7/7 pass locally
- [x] `npm test` — 632/632 pass locally
- [ ] CI green on this PR