### PR TITLE
chore(review-policy): cover src/lib/** for external review

### DIFF
--- a/.github/review-policy.yml
+++ b/.github/review-policy.yml
@@ -24,6 +24,7 @@ external_review_threshold: 300
 # Glob patterns are supported. If any file in the PR diff matches a pattern
 # listed here, external review is mandatory.
 external_review_paths:
+  - "src/lib/**"
   - "src/auth/**"
   - "src/payments/**"
   - "functions/**"


### PR DESCRIPTION
## Summary

- Add `src/lib/**` to `external_review_paths` in `.github/review-policy.yml` so the repo's billing-logic surface (calculations.js, BillingYearService.js, ShareLinkService.js, invoice.js) triggers mandatory external review regardless of diff size.
- Closes the financial-logic safety gap flagged by Codex on PR #223 round 2: the template defaults (`src/auth/**`, `src/payments/**`) don't match where this repo's sensitive code actually lives.

Authoring-Agent: claude

## Self-Review

**Correctness.** The `external_review_paths` list is consumed by `.github/workflows/agent-review.yml` (line 74) via `scripts/workflow/parse_policy_list.sh` and then by `scripts/workflow/match_protected_paths.sh`. Adding one more glob extends the protected surface — no behavior change for files outside `src/lib/`. Verified by reading both consumer paths.

**Regression risk.** Single-line addition to a YAML list. No new files, no new globs that overlap with existing entries. The path `src/lib/**` is well-defined: it exists at the repo root and only contains billing/business logic. No CI/test infrastructure lives under it.

**Style.** Insertion ordered by specificity (most-specific repo-local path first). Matches the existing convention in the file (template paths follow, then `functions/**`, then wildcard secret/credential globs, then `.github/**`).

**Test coverage.** Config-only change; no runtime code. The fixture at `scripts/ci/fixtures/workflow-parsers/review-policy.sample.yml` is intentionally distinct from production policy and is not updated here — it's a synthetic parser fixture, not a production mirror.

**Security / dependency hygiene.** Tightens, doesn't loosen — every change under `src/lib/` will now route to external review. No deps touched.

## Test plan

- [x] Verified `src/lib/` exists and contains the cited files.
- [x] Verified `src/auth/` and `src/payments/` do NOT exist (leaving template entries in place is harmless, future-proofs against template-aligned restructure).
- [x] Verified the only consumers of `external_review_paths` are the workflow and docs — no script parses it inline assuming a fixed ordering.

Refs: #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)