### PR TITLE
fix(op-preflight): require --agent for deploy + harden dry-run grep

### DIFF
--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -128,8 +128,10 @@ if $PURGE_ALL; then
   exit 0
 fi
 
-if [[ "$MODE" == "review" || "$MODE" == "all" || "$PURGE" == "true" ]] && [[ -z "$AGENT" ]]; then
-  echo "Error: --agent is required for review, all, or --purge mode." >&2
+if [[ "$MODE" == "review" || "$MODE" == "all" || "$MODE" == "deploy" || "$PURGE" == "true" ]] && [[ -z "$AGENT" ]]; then
+  echo "Error: --agent is required for review, deploy, all, or --purge mode." >&2
+  echo "       Cache paths are derived from \$AGENT (op-preflight-\$AGENT.env" >&2
+  echo "       and op-preflight-\$AGENT-adc.json), so deploy mode also requires it." >&2
   echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode all)\"" >&2
   exit 1
 fi
@@ -163,7 +165,10 @@ if $DRY_RUN; then
   echo "# ADC tempfile:   $ADC_TMPFILE" >&2
   echo "# TTL seconds:    $TTL_SECONDS" >&2
   if [[ -f "$SESSION_FILE" ]]; then
-    embedded=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"")
+    # Use `|| true` so a truncated/malformed session file (grep finds no
+    # match → exit 1) doesn't trip `set -eo pipefail`. `${embedded:-0}`
+    # below handles the empty-result case.
+    embedded=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"" || true)
     now=$(date +%s)
     age=$((now - ${embedded:-0}))
     echo "# Session age:    ${age}s (TTL ${TTL_SECONDS}s)" >&2

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -166,11 +166,14 @@ if $DRY_RUN; then
   echo "# TTL seconds:    $TTL_SECONDS" >&2
   if [[ -f "$SESSION_FILE" ]]; then
     # Use `|| true` so a truncated/malformed session file (grep finds no
-    # match → exit 1) doesn't trip `set -eo pipefail`. `${embedded:-0}`
-    # below handles the empty-result case.
+    # match → exit 1) doesn't trip `set -eo pipefail`. The numeric guard
+    # below defends against the related case where the EPOCH line exists
+    # but the value was corrupted to a non-numeric token — without it the
+    # `$((now - embedded))` arithmetic would crash the dry-run.
     embedded=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"" || true)
+    [[ "$embedded" =~ ^[0-9]+$ ]] || embedded=0
     now=$(date +%s)
-    age=$((now - ${embedded:-0}))
+    age=$((now - embedded))
     echo "# Session age:    ${age}s (TTL ${TTL_SECONDS}s)" >&2
   else
     echo "# Session age:    n/a (no session file)" >&2


### PR DESCRIPTION
## Summary

Two surgical fixes to `scripts/op-preflight.sh` flagged by Codex on PR #227 (rounds since merged but not yet resolved):

- **Require `--agent` for `--mode deploy`** (Codex P2). Cache paths derive from `$AGENT` (`op-preflight-$AGENT.env`, `op-preflight-$AGENT-adc.json`); running deploy without `--agent` silently writes to `op-preflight-.env` and bleeds state across agents.
- **Harden the dry-run grep** for `OP_PREFLIGHT_CREATED_AT_EPOCH` (Codex P3). Under `set -eo pipefail`, a missing key in a truncated session file aborts the script before the `${embedded:-0}` default applies. `|| true` lets the fallback run.

Authoring-Agent: claude

## Self-Review

**Correctness.** Both changes are minimal:
- The gate condition gains one disjunct (`|| "$MODE" == "deploy"`). All other branching is unchanged. The error message is updated to mention deploy mode.
- The dry-run grep gains `|| true` so a non-matching pipeline returns 0. The `${embedded:-0}` default below already handles the empty-result case — this just lets it actually execute.

Verified empirically (on the branch):
- `bash scripts/op-preflight.sh --mode deploy` → exits 1 with the new error message.
- `bash scripts/op-preflight.sh --agent claude --mode deploy --dry-run` → succeeds and prints session age.
- Repro of the dry-run abort: with a stripped session file (no EPOCH key), the equivalent grep pipeline under `set -eo pipefail` previously aborted; with `|| true` it returns 0 and `age` uses the fallback `0`.

**Regression risk.** Low.
- The gate change adds a new failure mode (deploy without --agent now errors). Searched call sites: all callers in this repo pass `--agent` explicitly. CI workflows and the deploy script (`scripts/op-firebase-deploy.sh` etc.) thread `--agent` through. External callers (operators running deploy locally) get a clear actionable error rather than silently shared cache state.
- The dry-run change strictly loosens failure: pipelines that previously crashed now succeed with the documented fallback.

**Style.** Matches the surrounding script (POSIX shell, double-bracket conditionals, comments explaining non-obvious behavior). The added comment block explains the `|| true` rationale tied to `set -eo pipefail` so a future reader doesn't drop it.

**Test coverage.** No dedicated unit tests for `op-preflight.sh` exist. Both fixes were verified by hand on the branch. The pre-existing test surface (mostly fixtures under `scripts/ci/fixtures/`) is unrelated.

**Security / dependency hygiene.** Tightens deploy-mode isolation (per-agent cache files actually enforced). No deps touched.

## Test plan

- [x] `bash scripts/op-preflight.sh --mode deploy` errors out with the new message.
- [x] `bash scripts/op-preflight.sh --agent claude --mode deploy --dry-run` succeeds.
- [x] `bash scripts/op-preflight.sh --agent claude --mode review --dry-run` still succeeds (no regression in non-deploy paths).
- [x] Repro of the dry-run abort under `set -eo pipefail` with a session file missing `OP_PREFLIGHT_CREATED_AT_EPOCH` shows the fallback now runs (manual repro on branch).

Refs: #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)