### PR TITLE
fix(coderabbit-wait): freshness floor for normal-push case

### DIFF
--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -125,6 +125,13 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 3
 fi
 
+# Capture the true script start epoch up here, before any `gh api` calls.
+# Used downstream as the anchor for the freshness floor — see the
+# anchor-advance block below. Capturing post-API would skew the floor
+# forward by however long the network calls took, potentially excluding a
+# legitimately fresh CodeRabbit comment.
+SCRIPT_START_EPOCH=$(date +%s)
+
 # --- config readers ---------------------------------------------------------
 
 CONFIG=".github/review-policy.yml"
@@ -250,7 +257,9 @@ FRESHNESS_WINDOW_SECONDS=${CODERABBIT_FRESHNESS_WINDOW_SECONDS:-1800}
 if ! [[ "$FRESHNESS_WINDOW_SECONDS" =~ ^[0-9]+$ ]]; then
   die 3 "CODERABBIT_FRESHNESS_WINDOW_SECONDS must be an integer; got '$FRESHNESS_WINDOW_SECONDS'"
 fi
-SCRIPT_START_EPOCH=$(date +%s)
+# SCRIPT_START_EPOCH was captured at the true script start (before any
+# `gh api` calls) so the floor reflects script-start time, not post-API
+# time. See the capture site near the GH_TOKEN check above.
 FRESHNESS_FLOOR_EPOCH=$((SCRIPT_START_EPOCH - FRESHNESS_WINDOW_SECONDS))
 # macOS uses `date -r EPOCH`; GNU uses `date -d @EPOCH`. Try both.
 FRESHNESS_FLOOR=$(date -u -r "$FRESHNESS_FLOOR_EPOCH" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -229,6 +229,38 @@ if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_ANC
   ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
 fi
 
+# Freshness floor. The force-push branch above only fires for
+# `head_ref_force_pushed` timeline events. For an ordinary (non-force)
+# push of a HEAD whose committer date predates a prior CodeRabbit comment
+# — cherry-pick, rebase with --committer-date-is-author-date, or any
+# commit amended from a previously-authored SHA — the anchor stays at the
+# stale committer date and a pre-push bot comment can falsely pass the
+# `>= HEAD_ANCHOR` filter. GitHub does not expose a per-PR push timestamp
+# for ordinary pushes (`committed.created_at` is null; verified against
+# mergepath PR #63 on 2026-04-15), so we cannot derive an exact push
+# time. Instead, cap the anchor at "script start time minus a window".
+# Mirrors the `reaction_freshness_window_seconds` pattern in the codex
+# block of review-policy.yml: signals older than the window are treated
+# as stale regardless of HEAD metadata. Default 1800s (30 min) is
+# comfortably wider than a typical CodeRabbit review cycle (~2-5 min)
+# and the agent retry window, narrow enough that prior-round comments
+# from earlier work sessions are filtered out. See #256 (Codex P2 on
+# PR #227 — anchor freshness for normal-push case).
+FRESHNESS_WINDOW_SECONDS=${CODERABBIT_FRESHNESS_WINDOW_SECONDS:-1800}
+if ! [[ "$FRESHNESS_WINDOW_SECONDS" =~ ^[0-9]+$ ]]; then
+  die 3 "CODERABBIT_FRESHNESS_WINDOW_SECONDS must be an integer; got '$FRESHNESS_WINDOW_SECONDS'"
+fi
+SCRIPT_START_EPOCH=$(date +%s)
+FRESHNESS_FLOOR_EPOCH=$((SCRIPT_START_EPOCH - FRESHNESS_WINDOW_SECONDS))
+# macOS uses `date -r EPOCH`; GNU uses `date -d @EPOCH`. Try both.
+FRESHNESS_FLOOR=$(date -u -r "$FRESHNESS_FLOOR_EPOCH" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+                  || date -u -d "@$FRESHNESS_FLOOR_EPOCH" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+                  || die 3 "could not format freshness floor; check 'date' availability")
+if [[ "$FRESHNESS_FLOOR" > "$HEAD_ANCHOR" ]]; then
+  HEAD_ANCHOR="$FRESHNESS_FLOOR"
+  ANCHOR_SOURCE="freshness floor @ $FRESHNESS_FLOOR (${FRESHNESS_WINDOW_SECONDS}s before script start)"
+fi
+
 log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
 log "anchor = $HEAD_ANCHOR (source: $ANCHOR_SOURCE)"
 log "max_wait = ${MAX_WAIT_SECONDS}s   max_rate_limit_retries = $MAX_RATE_LIMIT_RETRIES"


### PR DESCRIPTION
## Summary

Add a "script start time minus window" floor on `HEAD_ANCHOR` in `scripts/coderabbit-wait.sh` so the comment-freshness filter (`comments.created_at >= HEAD_ANCHOR`) can't accept pre-push CodeRabbit comments as current when a normal (non-force) push lands a HEAD whose committer date predates them.

Closes a gap Codex flagged on PR #227: the existing `head_ref_force_pushed` override only protects against force-push of an older commit. The same exposure remains for ordinary push of cherry-picked / rebased-with-committer-date-is-author-date HEADs — committer date stays old, anchor stays at committer date, prior-round bot comments slip through.

Authoring-Agent: claude

## Self-Review

**Correctness.** GitHub does not expose per-PR push timestamps for ordinary pushes (timeline `committed.created_at` is null — documented in `review-policy.yml` at `codex.reaction_freshness_window_seconds`). So we can't derive an exact push time. The fix mirrors the existing `reaction_freshness_window_seconds` pattern in the Codex flow: cap the anchor at `script_start - 1800s`. The string comparison `[[ "$FRESHNESS_FLOOR" > "$HEAD_ANCHOR" ]]` works because both are ISO-8601 UTC strings (same format, lexicographic order matches chronological order).

The force-push override (`head_ref_force_pushed`) remains intact and runs first. When both fire, the later timestamp wins via the same string-compare — the freshness floor only advances the anchor if it's strictly later.

**Regression risk.** Bounded.
- **Re-run after CodeRabbit reviewed long ago:** if an agent re-invokes the script >30 min after CodeRabbit's most recent review, the freshness floor advances past that review and the script will wait/time-out. Acceptable: this is exactly the stale-signal case the fix wants to catch. Mitigation: agents re-trigger with `@coderabbitai, try again.` (the script does this automatically on rate-limit retry).
- **Default 30 min window** is comfortably wider than a typical CodeRabbit review cycle (2-5 min) plus retry buffer. Tunable via `CODERABBIT_FRESHNESS_WINDOW_SECONDS` env var if a specific environment needs different timing — no new config field in `review-policy.yml`.

**Style.** Block follows the surrounding script conventions: `[[ ]]` conditionals, ISO-8601 anchor strings, `die 3` for usage errors. Cross-platform `date` handling (macOS `-r` then GNU `-d @` fallback) matches the script's posix-flexible style. Comment block explains the rationale, references the documentation in `review-policy.yml`, and cites the failure mode.

**Test coverage.** No unit-test scaffold for `coderabbit-wait.sh` exists in this repo. Verified locally:
- `bash -n scripts/coderabbit-wait.sh` passes.
- `date -u -r 1700000000 '+%Y-%m-%dT%H:%M:%SZ'` produces a valid ISO-8601 string on macOS (where this agent runs). GNU `date -d @EPOCH` is the documented Linux equivalent; both branches probed via `|| die`.

**Security / dependency hygiene.** Tightens the freshness gate (a false "cleared" was the prior failure mode). No deps touched.

## Test plan

- [x] Syntax check (`bash -n`).
- [x] Verified macOS `date -r EPOCH` produces the expected ISO-8601 string.
- [ ] **End-to-end:** When this PR (or a sibling) lands on a branch with CodeRabbit enabled, the script's `[coderabbit-wait] anchor = ... (source: ...)` log line should show `freshness floor` if the committer date was older than `now - 1800s`, or `head_ref_force_pushed` / `HEAD committer date` otherwise. (Visible in CI logs of any future PR that runs the script.)

Refs: #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)