### PR TITLE
style(settlement-summary): bump mobile label font-size

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3501,7 +3501,7 @@ img, svg { display: block; max-width: 100%; }
     }
 
     .settlement-summary-label {
-        font-size: 0.6rem;
+        font-size: 0.7rem;
     }
 
     .settlement-summary-value {


### PR DESCRIPTION
## Summary

Bump `.settlement-summary-label` font-size from `0.6rem` to `0.7rem` inside the existing mobile media query at `src/app/shell.css:3503-3505`. Closes a CodeRabbit nitpick on PR #201 — 0.6rem (≈9.6px at default root) is borderline unreadable for a label.

Authoring-Agent: claude

## Self-Review

**Correctness.** One-line, mobile-scoped change. Desktop styles at `shell.css:1410-1417` are unaffected (still 0.65rem). The new mobile size (0.7rem) is slightly larger than desktop label (0.65rem), which is intentional — mobile users benefit from larger labels on smaller screens, and the increase doesn't cross the value/label hierarchy line (value is 0.8rem).

**Regression risk.** Minimal. The font-size change is +0.1rem (~1.6px). The label is in a flex/box layout with `min-width: 0` and `flex: 1` on the parent box; no horizontal overflow risk. Surrounding rules (`.settlement-summary-value` 0.8rem, `.settlement-expand-toggle` 0.7rem) preserve the relative visual hierarchy.

**Style.** Matches the existing rule structure (single declaration block, 4-space indentation, mobile media query scope). No new rules added.

**Test coverage.** CSS visual change — no unit tests apply. Verified by reading the surrounding mobile block to confirm no layout-dependent rule keys off the prior 0.6rem value.

**Security / dependency hygiene.** No-op.

## Test plan

- [ ] Open the app on a narrow viewport (≤640px) and confirm the settlement card summary labels are legible without overflow.
- [ ] Spot-check on desktop that the desktop label (0.65rem) is unchanged.

Refs: #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)