### PR TITLE
fix(codex-review-check): hoist .label so jq doesn't index $required_names

### DIFF
--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -421,6 +421,14 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:
         workflow: (.workflowName // ""),
         result: (.conclusion // .state // "")
       }
+    # Bind .label to a variable so it survives the `$required_names | …`
+    # subexpression below. Inside that pipe, `.` rebinds to
+    # $required_names (an array of strings), and a bare `.label` resolves
+    # against THAT — which throws "Cannot index array with string label"
+    # whenever the required-checks list is non-empty. Hoisting via `as`
+    # keeps the check label addressable from inside any sub-pipeline.
+    # See nathanjohnpayne/mergepath#TBD.
+    | (.label) as $label
     # Filter out the known "expected to fail during Phase 4a" check.
     # Label Gate lives in the "PR Review Policy" workflow and fails by
     # design whenever needs-external-review / needs-human-review /
@@ -428,7 +436,7 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:
     # trying to unblock; we verify clearance separately in gate (c).
     | select(
         (.workflow != "PR Review Policy") or
-        (.label != "Label Gate")
+        ($label != "Label Gate")
       )
     # When branch protection lists required checks, only those
     # checks block the gate. When the list is empty (no branch
@@ -436,7 +444,7 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:
     # prior behavior of treating all checks as required.
     | select(
         ($required_names | length) == 0
-        or ($required_names | index(.label)) != null
+        or ($required_names | index($label)) != null
       )
     # A check passes the gate iff its result is SUCCESS, SKIPPED, or
     # NEUTRAL. Everything else — FAILURE, CANCELLED, TIMED_OUT,


### PR DESCRIPTION
## Summary

Gate (a) in `scripts/codex-review-check.sh` crashes with `jq: error (at <stdin>:1): Cannot index array with string "label"` whenever branch protection returns a non-empty `required_status_checks` list. Discovered while trying to clear Phase 4a on PR #258 — the script aborted before it could verify the merge gate.

**Cause:** inside `($required_names | index(.label))`, the pipe rebinds `.` to `$required_names` (an array of strings), so the bare `.label` resolves against that array instead of the surrounding check object. Indexing an array with a string is a runtime error in jq.

**Fix:** hoist `.label` to a variable via `(.label) as $label` before the sub-pipeline, then reference `$label`. Same change applied to the parallel `.label != "Label Gate"` check for consistency (that one happened to work today because its left-hand side doesn't rebind `.`, but the inconsistency would surprise a future reader).

Authoring-Agent: claude

## Self-Review

**Correctness.** Verified empirically against PR #258 with `required_status_checks` returning `{"contexts": ["lint"], ...}`. Before the fix: gate (a) crashes immediately. After the fix: `gate (a): CI is green (Label Gate failure, if present, is expected during Phase 4a)` and the script proceeds through gates (b) and (c) as designed.

**Regression risk.** Bounded — same scope as the prior expression; we just renamed the variable referenced inside the `index()` argument and updated one consistency reference. The behavior on the empty-required-list path (which previously did not exercise the bug) is unchanged because `($required_names | length) == 0` short-circuits before the buggy clause.

**Style.** Matches surrounding style; added a comment block explaining the scoping pitfall so a future maintainer doesn't reintroduce the same bug.

**Test coverage.** No dedicated unit-test scaffold for `codex-review-check.sh` exists. Manual verification on PR #258:
- Before: `jq: error (at <stdin>:1): Cannot index array with string "label"` → exit nonzero.
- After: gate (a) passes; gate (b) reports `latest-state APPROVED by nathanpayne-claude`; gate (c) reports correctly on Codex clearance state.

**Security / dependency hygiene.** Tightens, not loosens — the gate now actually evaluates, where before it silently aborted.

## Test plan

- [x] `bash -n scripts/codex-review-check.sh` — passes.
- [x] End-to-end against PR #258 — gates progress through (a) → (b) → (c) instead of crashing at (a).

Refs: #256 (surfaced while clearing the Phase 4 gate for #258).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
