### PR TITLE
sync: bulk reconcile to mergepath@b12e7d7

### DIFF
--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -38,11 +38,21 @@ on:
   # Periodic sweep — catches the 👍-after-last-push case (codex
   # reacts on the PR issue but no synchronize / review / workflow_run
   # event fires, so the event-driven path stays inert). Runs every
-  # 15 minutes against any open PR carrying needs-external-review.
+  # 5 minutes against any open PR carrying needs-external-review.
   # Idempotent (no-op when label absent or gate not yet met). Sub-C
   # of #191. See scheduled-sweep job below for the cadence knob.
+  #
+  # Tightened from 15→5 min in mergepath#324 to close the
+  # 👍-after-last-push gap observed across the mergepath#250 Phase D
+  # propagation fanout (3 of 6 consumer PRs needed manual
+  # request-label-removal.sh because no event-driven trigger
+  # fired and the prior 15-min sweep stranded them for up to 15 min
+  # after Codex cleared). 3× the API quota cost, but a meaningfully
+  # shorter blocker window. The PAT-driven label removal added in
+  # #324 also helps — but the sweep is still the only backstop for
+  # the no-event path.
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/5 * * * *'
 
 permissions:
   pull-requests: write
@@ -57,6 +67,14 @@ permissions:
   # nathanjohnpayne/matchline#233 (#306 propagation canary); see
   # #310 for the full repro + permission scope rationale.
   actions: read
+  # `checks: write` is required so the "Surface infra failure as
+  # check-run" step (#324) can POST a failed check-run to the PR's
+  # checks tab when this workflow hits an infrastructure error
+  # (failed label read, failed label removal, codex-review-check.sh
+  # rc=3, contract-drift rc). Without a visible check-run, flake
+  # recurrences are invisible unless someone happens to look at the
+  # workflow run log.
+  checks: write
 
 jobs:
   evaluate-and-clear:
@@ -140,11 +158,27 @@ jobs:
       - name: Re-evaluate gate per PR + remove label on pass
         if: steps.pr.outputs.numbers != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT-driven label removal (#315/#324). GITHUB_TOKEN-driven
+          # events do NOT trigger downstream workflows (recursion
+          # prevention) — pr-review-policy.yml's Label Gate would
+          # stay stuck on the pre-clear failure state until the next
+          # push or label toggle. A PAT-driven event triggers
+          # downstream workflows normally, so Label Gate re-fires and
+          # mergeStateStatus flips to CLEAN within seconds rather
+          # than stalling until something else fires the policy
+          # workflow. Closes mergepath#315. Token is the same
+          # REVIEWER_ASSIGNMENT_TOKEN used by
+          # .github/workflows/daily-feedback-rollup.yml.
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           PR_NUMBERS: ${{ steps.pr.outputs.numbers }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Source the gh-retry helper (#324). with_gh_retry wraps gh
+          # calls in 3×30s retry on transient failures (HTTP 5xx,
+          # rate-limit, "Resource not accessible by integration") so a
+          # flaky read or write doesn't silently leave the label stuck.
+          source scripts/lib/gh-retry-helpers.sh
           # codex-review-check.sh exits:
           #   0 = gate passes
           #   1 = gate fails (one or more of CI/reviewer/codex not met)
@@ -158,13 +192,14 @@ jobs:
           # PR hit it, so the workflow doesn't go green when gate
           # evaluation was actually impossible.
           had_infra_error=0
+          failing_prs=""
           while IFS= read -r PR; do
             [ -z "$PR" ] && continue
             echo "::group::Evaluating PR #$PR"
 
             # Skip if label not present (no-op, common case on
             # synchronize/workflow_run for under-threshold PRs).
-            if ! HAS_LABEL=$(gh pr view "$PR" --repo "$REPO" --json labels \
+            if ! HAS_LABEL=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json labels \
               --jq '[.labels[].name] | contains(["needs-external-review"])'); then
               # Infra error — NOT a warning-only skip. This workflow
               # exists to clear a merge-blocking label; if it can't even
@@ -174,6 +209,7 @@ jobs:
               # Major, #271.)
               echo "::error::Failed to query labels for PR #$PR — cannot evaluate."
               had_infra_error=1
+              failing_prs="$failing_prs $PR"
               echo "::endgroup::"
               continue
             fi
@@ -191,7 +227,7 @@ jobs:
             case "$rc" in
               0)
                 echo "Gate passes — removing needs-external-review label."
-                if ! gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                if ! with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
                   # The gate passed but the removal API call failed —
                   # the label is still stuck. That is an infra error,
                   # not a warning: the job must not report success
@@ -199,6 +235,7 @@ jobs:
                   # Major, #271.)
                   echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck."
                   had_infra_error=1
+                  failing_prs="$failing_prs $PR"
                   echo "::endgroup::"
                   continue
                 fi
@@ -206,7 +243,7 @@ jobs:
                 # delimiter must be column-0 unless using `<<-` with
                 # tabs; YAML run blocks make that brittle).
                 comment_body='**Automated label removal.** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed `needs-external-review` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.'
-                gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                   || echo "::warning::Failed to post attribution comment for PR #$PR"
                 ;;
               1)
@@ -218,6 +255,7 @@ jobs:
                 # PRs on a multi-PR workflow_run trigger. But set
                 # the sentinel so the job exits non-zero at the end.
                 had_infra_error=1
+                failing_prs="$failing_prs $PR"
                 ;;
               *)
                 echo "::error::codex-review-check.sh unexpected rc=$rc on PR #$PR (contract drift — failing job)"
@@ -225,11 +263,73 @@ jobs:
                 # Better to fail loudly than leave the label stuck
                 # behind a silently-broken gate. CR Major on PR #202 r3.
                 had_infra_error=1
+                failing_prs="$failing_prs $PR"
                 ;;
             esac
             echo "::endgroup::"
           done <<<"$PR_NUMBERS"
+          # Surface the infra-error sentinel + per-PR list to the next
+          # step (#324 round 2 codex P2) so the check-run can be posted
+          # with the correct head SHA per PR. failing_prs is space-
+          # separated, may have a leading space — `echo` collapses it.
+          echo "HAD_INFRA_ERROR=$had_infra_error" >> "$GITHUB_ENV"
+          # shellcheck disable=SC2086  # intentional word-splitting to trim
+          echo "HAD_INFRA_ERROR_PRS=$(echo $failing_prs)" >> "$GITHUB_ENV"
           exit "$had_infra_error"
+
+      - name: Surface infra failure as per-PR check-runs
+        # Run even when the prior step failed — `if: always()` + the
+        # HAD_INFRA_ERROR sentinel so we only post failed check-runs
+        # when the prior step actually hit an infra error (not when
+        # everything was clean or only gate-evaluation said "not yet
+        # met").
+        #
+        # Per-PR check-runs (#324 round 2 codex P2): the prior version
+        # used `head_sha: ${{ github.sha }}`, but on workflow_run /
+        # pull_request_target / schedule, github.sha resolves to a
+        # default-branch commit, not the affected PR's head, so the
+        # annotation landed on the wrong commit and missed the target
+        # PR's Checks tab. Posting one check-run per failing PR fixes
+        # both the wrong-commit problem and the lost-visibility
+        # problem, at the cost of one extra `gh pr view` per failure
+        # (cheap, only on the error path).
+        if: always() && env.HAD_INFRA_ERROR == '1'
+        env:
+          # check-run POST works with GITHUB_TOKEN + `checks: write`
+          # (added above). No PAT needed for this annotation surface.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source scripts/lib/gh-retry-helpers.sh
+          REPO='${{ github.repository }}'
+          RUN_URL='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          # HAD_INFRA_ERROR_PRS is a space-separated list set by the
+          # prior step at each had_infra_error=1 site. Empty list →
+          # nothing to surface (defensive: should not happen given
+          # HAD_INFRA_ERROR is set).
+          if [ -z "${HAD_INFRA_ERROR_PRS:-}" ]; then
+            echo "::warning::HAD_INFRA_ERROR=1 but HAD_INFRA_ERROR_PRS is empty — skipping check-run emission."
+            exit 0
+          fi
+          for PR in $HAD_INFRA_ERROR_PRS; do
+            echo "::group::Posting infra-failure check-run for PR #$PR"
+            if ! HEAD_SHA=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid); then
+              echo "::warning::Failed to resolve head SHA for PR #$PR — skipping check-run."
+              echo "::endgroup::"
+              continue
+            fi
+            with_gh_retry gh api "repos/$REPO/check-runs" \
+              -X POST \
+              -f name='auto-clear-blocking-labels' \
+              -f "head_sha=$HEAD_SHA" \
+              -f status='completed' \
+              -f conclusion='failure' \
+              -F "output[title]=Auto-clear hit an infrastructure error" \
+              -F "output[summary]=PR #$PR — see workflow run logs: $RUN_URL" \
+              || echo "::warning::Failed to post check-run for PR #$PR (annotation lost; workflow log still surfaces the failure)."
+            echo "::endgroup::"
+          done
 
   scheduled-sweep:
     name: Periodic sweep for stale needs-external-review labels
@@ -254,10 +354,14 @@ jobs:
       - name: Find PRs carrying needs-external-review
         id: find
         env:
+          # Read-only list query. GITHUB_TOKEN is sufficient here —
+          # the PAT-switch in the next step is what triggers downstream
+          # workflows when the label is actually removed.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          source scripts/lib/gh-retry-helpers.sh
           # Read the per-repo cadence/enable knob from review-policy.yml.
           # Defaults: enabled=true. Operators can opt out by setting
           #   auto_clear_labels:
@@ -301,7 +405,7 @@ jobs:
           # gh failure (auth, rate limit, network) silently became
           # "0 PRs found" and the sweep no-op'd instead of failing
           # loudly.
-          if ! prs_raw=$(gh pr list --repo "$REPO" --state open \
+          if ! prs_raw=$(with_gh_retry gh pr list --repo "$REPO" --state open \
             --label needs-external-review --limit 500 \
             --json number --jq '.[].number'); then
             echo "::error::Failed to list open PRs with needs-external-review on $REPO"
@@ -325,12 +429,22 @@ jobs:
       - name: Re-evaluate gate per PR
         if: steps.find.outputs.prs != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT-driven label removal (#315/#324). See
+          # evaluate-and-clear job above for the rationale; same
+          # secret, same recursion-prevention bypass. Without the
+          # PAT, the scheduled sweep would remove the label but
+          # downstream workflows (pr-review-policy.yml Label Gate)
+          # would not re-fire — so mergeStateStatus would stay
+          # BLOCKED until the next push or manual nudge, defeating
+          # the sweep's purpose.
+          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           PRS: ${{ steps.find.outputs.prs }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          source scripts/lib/gh-retry-helpers.sh
           had_infra_error=0
+          failing_prs=""
           while IFS= read -r PR; do
             [ -z "$PR" ] && continue
             echo "::group::Sweep PR #$PR"
@@ -341,9 +455,9 @@ jobs:
             case "$rc" in
               0)
                 echo "Gate passes — removing needs-external-review label."
-                if gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                if with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
                   comment_body='**Automated label removal (scheduled sweep).** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD between event triggers (typical: Codex 👍 after the last push, with no synchronize / review / workflow_run event to fire the event-driven path). Removed `needs-external-review`. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#197) for the sweep doctrine.'
-                  gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                  with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                     || echo "::warning::Failed to post attribution comment for PR #$PR"
                 else
                   # Gate passed but the removal failed — infra error,
@@ -351,12 +465,55 @@ jobs:
                   # sweep must not report success. (CodeRabbit Major, #271.)
                   echo "::error::Failed to remove needs-external-review on PR #$PR — label still stuck."
                   had_infra_error=1
+                  failing_prs="$failing_prs $PR"
                 fi
                 ;;
               1) echo "Gate not yet met — leaving label in place." ;;
-              3) echo "::error::codex-review-check.sh rc=3 on PR #$PR"; had_infra_error=1 ;;
-              *) echo "::error::unexpected rc=$rc on PR #$PR"; had_infra_error=1 ;;
+              3) echo "::error::codex-review-check.sh rc=3 on PR #$PR"; had_infra_error=1; failing_prs="$failing_prs $PR" ;;
+              *) echo "::error::unexpected rc=$rc on PR #$PR"; had_infra_error=1; failing_prs="$failing_prs $PR" ;;
             esac
             echo "::endgroup::"
           done <<<"$PRS"
+          # Surface the infra-error sentinel + per-PR list to the next
+          # step (#324 round 2 codex P2). See evaluate-and-clear job
+          # for the rationale (correct head SHA per failing PR).
+          echo "HAD_INFRA_ERROR=$had_infra_error" >> "$GITHUB_ENV"
+          # shellcheck disable=SC2086  # intentional word-splitting to trim
+          echo "HAD_INFRA_ERROR_PRS=$(echo $failing_prs)" >> "$GITHUB_ENV"
           exit "$had_infra_error"
+
+      - name: Surface infra failure as per-PR check-runs
+        # Mirrors evaluate-and-clear's surfacing step. See that step's
+        # comments for the per-PR check-run rationale (#324 round 2 P2).
+        if: always() && env.HAD_INFRA_ERROR == '1'
+        env:
+          # check-run POST works with GITHUB_TOKEN + `checks: write`.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source scripts/lib/gh-retry-helpers.sh
+          REPO='${{ github.repository }}'
+          RUN_URL='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          if [ -z "${HAD_INFRA_ERROR_PRS:-}" ]; then
+            echo "::warning::HAD_INFRA_ERROR=1 but HAD_INFRA_ERROR_PRS is empty — skipping check-run emission."
+            exit 0
+          fi
+          for PR in $HAD_INFRA_ERROR_PRS; do
+            echo "::group::Posting infra-failure check-run for PR #$PR (sweep)"
+            if ! HEAD_SHA=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid); then
+              echo "::warning::Failed to resolve head SHA for PR #$PR — skipping check-run."
+              echo "::endgroup::"
+              continue
+            fi
+            with_gh_retry gh api "repos/$REPO/check-runs" \
+              -X POST \
+              -f name='auto-clear-blocking-labels' \
+              -f "head_sha=$HEAD_SHA" \
+              -f status='completed' \
+              -f conclusion='failure' \
+              -F "output[title]=Auto-clear hit an infrastructure error (scheduled sweep)" \
+              -F "output[summary]=PR #$PR — see workflow run logs: $RUN_URL" \
+              || echo "::warning::Failed to post check-run for PR #$PR (annotation lost; workflow log still surfaces the failure)."
+            echo "::endgroup::"
+          done

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,10 @@ module.exports = [
   // Ignore generated / vendored output. Customize per-consumer via
   // a follow-up commit on the propagation PR if a repo needs extras
   // (e.g., functions/lib for cloud-functions repos).
+  //
+  // `.claude/worktrees/**` is the per-agent worktree root that
+  // Claude Code creates for parallel sub-tasks; linting the working
+  // copies inside it is duplicative and noisy on every agent run.
   {
     ignores: [
       "node_modules/**",
@@ -31,24 +35,32 @@ module.exports = [
       ".astro/**",
       ".next/**",
       ".vercel/**",
-      // CONSUMER-LOCAL: ffb's Vite output goes to app/assets/
-      // (hashed bundle filenames) and the assembled deploy lands
-      // at app/. These are build artifacts, not source; linting
-      // them produces hundreds of false-positive findings on the
-      // minified output. Ignoring the whole `app/` tree (the
-      // Vite/esbuild assemble output) is the standard consumer-
-      // local customization for repos with non-default build
-      // output paths. The mergepath template covers the common
-      // `dist/`/`build/` defaults; per-repo overrides land here.
-      "app/**",
-      // CONSUMER-LOCAL: legacy IIFE build at repo root from
-      // `build:legacy` (esbuild → script.js). Same rationale.
-      "script.js",
+      ".claude/worktrees/**",
     ],
   },
 
   // Baseline JS recommended — required by the Mergepath policy floor.
   js.configs.recommended,
+
+  // Baseline rule policy applied to all JS sources. `^_`-prefix
+  // unused-vars is the standard convention for marking intentionally-
+  // unused locals (args, vars, caught errors, destructured-array
+  // leftovers); the `allowEmptyCatch` setting permits the
+  // `catch (_) {}` swallow idiom that appears in legacy code.
+  // Both relaxations were added by hand by 5 of 6 consumers during
+  // the Phase D fanout (#250) — folding them into the baseline
+  // removes the per-consumer churn.
+  {
+    rules: {
+      "no-unused-vars": ["error", {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+        destructuredArrayIgnorePattern: "^_",
+      }],
+      "no-empty": ["error", { allowEmptyCatch: true }],
+    },
+  },
 
   // Apply browser + node globals to all JS sources by default. Narrow
   // these per-file-pattern in a follow-up commit if the repo has a
@@ -83,28 +95,6 @@ module.exports = [
     },
   },
 
-  // ─────────────────────────────────────────────────────────────────
-  // CONSUMER-LOCAL OVERRIDE — legacy CDN-loaded Firebase globals.
-  //
-  // ffb's legacy top-level scripts (auth.js, firebase-config.js,
-  // site/script.js) AND some src/ React code reference `firebase`,
-  // `auth`, and `analytics` as globals — they're loaded by
-  // <script> tags in index.html rather than imported per-module.
-  // Declaring them here keeps lint quiet without forcing a
-  // refactor to import-style; modernization can land separately.
-  // `user` is a similar CDN global used in a few legacy code
-  // paths.
-  {
-    files: ["**/*.{js,jsx,mjs}"],
-    languageOptions: {
-      globals: {
-        firebase: "readonly",
-        auth: "readonly",
-        analytics: "readonly",
-        user: "readonly",
-      },
-    },
-  },
 
 
 
@@ -112,15 +102,8 @@ module.exports = [
   // Detect the React version automatically from package.json. The
   // React 17+ JSX transform makes `react/react-in-jsx-scope` obsolete;
   // turn it off explicitly so the rule doesn't flag every component.
-  // CONSUMER-LOCAL: drop `.tsx` from React block — ffb is JS-only
-  // (zero .tsx files in tree, no @typescript-eslint/parser
-  // installed). Including .tsx would invoke ESLint's default
-  // espree parser on TS syntax and fail. Same template-gap
-  // class as dpr#83 (template defaults to `.tsx` because most
-  // React consumers adopt TS; ffb is the exception). CodeRabbit
-  // P2 on this PR caught it.
   {
-    files: ["**/*.{js,jsx}"],
+    files: ["**/*.{jsx,tsx}"],
     plugins: {
       react,
       "react-hooks": reactHooks,
@@ -134,78 +117,97 @@ module.exports = [
       ...react.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       "react/react-in-jsx-scope": "off",
+      // React Compiler advisories — disabled by default because they
+      // only fire usefully once the React Compiler is adopted; until
+      // then they're noisy on idiomatic React (set-state-in-effect
+      // for init, ref-during-render in TipTap-style editors). Inlined
+      // here (vs a sibling block) so they inherit this entry's
+      // `files:` and `plugins:` scope — codex P1 #327 round 3
+      // caught the standalone block referencing react-hooks/* rules
+      // without a scope, breaking ESLint on .js files of React
+      // consumers (where the plugin isn't loaded for that glob).
+      // React Compiler adopters override locally back to "error".
+      "react-hooks/set-state-in-effect": "off",
+      "react-hooks/preserve-manual-memoization": "off",
+      "react-hooks/refs": "off",
+      "react-hooks/immutability": "off",
     },
     settings: {
       react: { version: "detect" },
     },
   },
 
-  // ─────────────────────────────────────────────────────────────────
-  // CONSUMER-LOCAL POLICY — React-rule overrides. MUST be LAST.
-  //
-  // Same policy as device-platform-reporting#83 — ffb doesn't use
-  // propTypes (Vite + modern React) and `no-unescaped-entities`
-  // is mostly cosmetic noise. The two react-hooks advisories
-  // (set-state-in-effect + preserve-manual-memoization) are
-  // turned off because the codebase uses setState-in-effect
-  // intentionally for initialization (7 occurrences across pages)
-  // and hasn't adopted the React Compiler's manual-memoization
-  // contract.
+  // jsx_in_js variant — an ADDITIONAL React rule entry whose files
+  // glob includes `.js` so repos that babel-/vite-transpile JSX in
+  // plain `.js` files (e.g., device-platform-reporting, friends-and-
+  // family-billing) lint those files under the React rule set.
+  // Renders alongside the default `**/*.{jsx,tsx}` block above for
+  // React consumers that opt in; eslint flat-config merges rules
+  // across overlapping globs so the .js files inherit the React
+  // rules via this second entry. Setting jsx_in_js: true on a
+  // non-React consumer is a manifest misconfiguration — this block
+  // would reference undeclared `react`/`reactHooks` and the
+  // rendered config would fail to load.
   {
-    files: ["**/*.{js,jsx}"],
+    files: ["**/*.{js,jsx,tsx}"],
+    plugins: {
+      react,
+      "react-hooks": reactHooks,
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
     rules: {
-      "react/prop-types": "off",
-      "react/no-unescaped-entities": "off",
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+      // React Compiler advisories — disabled by default because they
+      // only fire usefully once the React Compiler is adopted; until
+      // then they're noisy on idiomatic React (set-state-in-effect
+      // for init, ref-during-render in TipTap-style editors). Inlined
+      // here (vs a sibling block) so they inherit this entry's
+      // `files:` and `plugins:` scope — codex P1 #327 round 3
+      // caught the standalone block referencing react-hooks/* rules
+      // without a scope, breaking ESLint on .js files of React
+      // consumers (where the plugin isn't loaded for that glob).
+      // React Compiler adopters override locally back to "error".
       "react-hooks/set-state-in-effect": "off",
       "react-hooks/preserve-manual-memoization": "off",
-      // Additional React Compiler advisories not in dpr's list —
-      // ffb's TipTap editor integration uses refs-during-render
-      // intentionally (4 sites in TemplateEditor + RichTextEditor)
-      // and has an immutability false-positive on a test helper.
-      // Same policy class: these are React Compiler hints, not
-      // runtime bugs. TODO: revisit when adopting the Compiler.
       "react-hooks/refs": "off",
       "react-hooks/immutability": "off",
-      // CONSUMER-LOCAL: underscore-prefix convention for intentionally
-      // unused vars / args / caught errors. Standard ESLint idiom
-      // (`function (_, value) { ... }`, `catch (_e) {}`). 40+ sites
-      // across src/main.js + src/app/. Allowing the convention is
-      // cheaper than adding 40 disable comments.
-      "no-unused-vars": ["error", {
-        argsIgnorePattern: "^_",
-        varsIgnorePattern: "^_",
-        caughtErrorsIgnorePattern: "^_",
-        destructuredArrayIgnorePattern: "^_",
-      }],
-      // CONSUMER-LOCAL: `catch (_) {}` swallow-pattern is intentional
-      // in the legacy script.js compile-source — same rationale as
-      // the unused-vars relax. allowEmptyCatch matches that idiom.
-      "no-empty": ["error", { allowEmptyCatch: true }],
+    },
+    settings: {
+      react: { version: "detect" },
     },
   },
 
-  // ─────────────────────────────────────────────────────────────────
-  // CONSUMER-LOCAL OVERRIDE — vitest globals for test files.
-  // Placed AFTER the React block so flat-config languageOptions
-  // merge (rather than getting shadowed by the React block which
-  // matches all .js — see #318 for the equivalent dpr fix). ffb
-  // uses vitest (not jest); same template gap tracked as a
-  // mergepath follow-up for `facts.testing: jest|vitest|none|mocha`.
-  //
-  // Pattern covers test files AND test helpers under tests/ (e.g.
-  // tests/react/helpers/*.js use `vi.fn()` to build shared mocks).
-  // Without the broader tests/** match, helpers trip no-undef on
-  // `vi` even though they're only ever imported from test files.
+// React Compiler advisory disables are now INSIDE the React block(s)
+// above (so they inherit the same `files:` and `plugins:` scope and
+// don't reference react-hooks/* on files where the plugin isn't
+// loaded — codex P1 #327 round 3). The standalone block previously
+// at this position has been removed.
+
+  // Vitest globals — applied to common test file patterns. Without
+  // this block, `describe`/`it`/`expect`/`vi`/etc. trigger no-undef
+  // in every test file. Pattern covers __tests__ dirs and *.test.*
+  // files; broaden per-consumer if test helpers live elsewhere.
   {
-    files: [
-      "**/__tests__/**",
-      "**/*.test.{js,jsx,mjs}",
-      "tests/**/*.{js,jsx,mjs}",
-    ],
+    files: ["tests/**", "**/__tests__/**", "**/*.test.{js,jsx,mjs,ts,tsx}"],
     languageOptions: {
       globals: {
-        ...globals.vitest,
+        describe: "readonly",
+        it: "readonly",
+        test: "readonly",
+        expect: "readonly",
+        beforeEach: "readonly",
+        afterEach: "readonly",
+        beforeAll: "readonly",
+        afterAll: "readonly",
+        vi: "readonly",
       },
     },
   },
+
 ];

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -75,12 +75,12 @@ fi
 # any `schedule:` / `cron:` text anywhere) so a comment couldn't
 # satisfy the assertion.
 if grep -qE "^[[:space:]]+schedule:" "$WORKFLOW" && \
-   grep -qF -- "- cron: '*/15 * * * *'" "$WORKFLOW"; then
+   grep -qF -- "- cron: '*/5 * * * *'" "$WORKFLOW"; then
   pass=$((pass + 1))
-  echo "  PASS: schedule trigger configured with 15-min cron (#197)"
+  echo "  PASS: schedule trigger configured with 5-min cron (#197/#324)"
 else
   fail=$((fail + 1))
-  echo "  FAIL: missing schedule trigger or expected cron entry (#197 sub-C of #191)" >&2
+  echo "  FAIL: missing schedule trigger or expected cron entry (5-min cron per #324)" >&2
 fi
 
 # scheduled-sweep job exists and is gated to schedule-only events.
@@ -137,8 +137,9 @@ fi
 # CR Major on PR #213 r2: sweep must capture `gh pr list` exit
 # status separately, not via process substitution into mapfile (which
 # swallows the producer's exit code, silently turning a gh failure
-# into "0 PRs found").
-if grep -qE -- 'if ! prs_raw=\$\(gh pr list' "$WORKFLOW" && \
+# into "0 PRs found"). #324 wrapped the gh call in
+# `with_gh_retry`; tolerate either form.
+if grep -qE -- 'if ! prs_raw=\$\((with_gh_retry )?gh pr list' "$WORKFLOW" && \
    grep -qE -- 'echo "::error::Failed to list open PRs' "$WORKFLOW"; then
   pass=$((pass + 1))
   echo "  PASS: sweep captures gh pr list exit status (no silent failure on gh error)"
@@ -194,7 +195,11 @@ perm_block=$(
 # drill into statusCheckRollup.checkSuite.workflowRun requires it
 # in addition to `checks: read`. See the inline rationale comment
 # next to the new permission in auto-clear-blocking-labels.yml.
-expected_perms=$'actions: read\nchecks: read\ncontents: read\npull-requests: write'
+# `checks: write` added in #324 — the "Surface infra failure as
+# check-run" step posts a failed check-run when this workflow hits
+# an infrastructure error, so flake recurrences are visible on the
+# PR's checks tab without grepping workflow logs.
+expected_perms=$'actions: read\nchecks: read\nchecks: write\ncontents: read\npull-requests: write'
 if [ "$perm_block" = "$expected_perms" ]; then
   pass=$((pass + 1))
   echo "  PASS: workflow permissions exactly match the least-privilege set"

--- a/scripts/ci/check_workflow_verify_propagation_templated
+++ b/scripts/ci/check_workflow_verify_propagation_templated
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# scripts/ci/check_workflow_verify_propagation_templated — CI entry
+# point for the templated-surface arm of the propagation-PR review
+# lane's faithful-mirror verifier (#323).
+#
+# Wraps tests/test_verify_propagation_pr_templated.sh so the repo_lint
+# workflow's enumerated check_* list picks it up. The templated-surface
+# arm of scripts/workflow/verify-propagation-pr.sh closes the
+# propagation-lane gate for type:templated entries (previously routed
+# to normal Phase 4 review per the v1 limitation in
+# docs/agents/templated-propagation.md § Propagation-lane verification).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_verify_propagation_pr_templated.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  # Missing test script is a hard error, not a skip — silent-skip
+  # would let an accidental delete/rename disable this check
+  # without surfacing in CI.
+  echo "check_workflow_verify_propagation_templated: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -98,6 +98,23 @@ if [ -r "$__CODEX_CHECK_DIR/lib/preflight-helpers.sh" ]; then
   preflight_require_token reviewer || true
 fi
 
+# --- gh retry helper (#324) ------------------------------------------------
+# Wrap gh calls (statusCheckRollup read in particular) in 3×30s retry on
+# transient failures (HTTP 5xx, rate-limit, "Resource not accessible by
+# integration"). Permanent 4xx errors break out immediately. The
+# canonical helper lives at scripts/lib/gh-retry-helpers.sh and is
+# declared as a `requires:` dep of this script in .mergepath-sync.yml,
+# so propagated consumers always carry it. The existence-guarded
+# fallback below means a hand-built or partial install still runs
+# (without retry) rather than aborting with "with_gh_retry: command
+# not found" at the call site.
+if [ -r "$__CODEX_CHECK_DIR/lib/gh-retry-helpers.sh" ]; then
+  # shellcheck source=lib/gh-retry-helpers.sh
+  . "$__CODEX_CHECK_DIR/lib/gh-retry-helpers.sh"
+else
+  with_gh_retry() { "$@"; }
+fi
+
 # --- argument parsing -------------------------------------------------------
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
@@ -521,8 +538,15 @@ log "gate (a): checking CI state"
 # state. A check still running (no conclusion yet) is treated as not-green
 # — the caller should wait or retry. SKIPPED is treated as success because
 # many Agent Review Pipeline jobs skip by design when the label is set.
-ROLLUP_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup 2>&1) \
-  || die 3 "failed to fetch statusCheckRollup: $ROLLUP_JSON"
+# Drop `2>&1`: with_gh_retry emits per-attempt diagnostics to stderr on
+# transient failures, and merging those lines into ROLLUP_JSON would
+# corrupt the jq parse below — a transient 5xx + successful retry would
+# look like an infra error (gate (a) fail) when the retry actually
+# recovered. Caught by codex P1 on PR #328 round 1. The retry diagnostics
+# still surface in the workflow log via stderr, so the visibility cost
+# is zero.
+ROLLUP_JSON=$(with_gh_retry gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup) \
+  || die 3 "failed to fetch statusCheckRollup (see stderr above for retry diagnostics)"
 
 # statusCheckRollup mixes two entry types:
 #   - CheckRun (GitHub Actions jobs): uses .name, .workflowName,

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -41,14 +41,17 @@
 #     - gh pr comment <PR#> --body "..."
 #     - gh pr review <PR#> --comment / --approve / --request-changes
 #     - gh issue comment <issue#> --body "..."
+#     - gh issue create --title "..." --body "..."     (#317)
 #
-#   For all three, the keyring's active account must be the agent's
+#   For all four, the keyring's active account must be the agent's
 #   REVIEWER identity (nathanpayne-<agent>, default nathanpayne-claude;
 #   override via GH_PR_GUARD_EXPECTED_REVIEWER). Posting these as the
 #   AUTHOR identity (nathanjohnpayne) breaks the audit-trail
 #   convention REVIEW_POLICY.md depends on — reviewer comments must
-#   attribute to the reviewer. The check fires before the keyring
-#   write so misattributed comments never land.
+#   attribute to the reviewer, and an agent filing their own bug must
+#   attribute to that agent (not to the author identity). The check
+#   fires before the keyring write so misattributed comments / issues
+#   never land.
 #
 #   Additionally, `gh pr review --approve` is blocked when the
 #   target PR is OVER-threshold AND the keyring is the agent's own
@@ -62,12 +65,21 @@
 #   over-threshold so the self-approve block fires on safer side.
 #
 #   These guards are scoped to `gh pr comment` / `gh pr review` /
-#   `gh issue comment` exactly. Raw `gh api -X POST .../comments` is
-#   intentionally NOT covered in this PR — the token/keyring auth
-#   matrix for raw `gh api` writes is not yet precise enough to
-#   block on without false positives. See REVIEW_POLICY.md
-#   § Operation-to-Identity Matrix (graphql write — PAT-attributed)
-#   for the auth-split context and the follow-up tracked under #284.
+#   `gh issue comment` / `gh issue create` exactly. `gh issue create`
+#   was added by #317 after the concrete misattribution of mergepath
+#   #315 — a `nathanpayne-claude` agent session filed a bug, but the
+#   keyring had drifted to `nathanpayne-codex` from the prior Phase
+#   4b CLI run, and the issue landed under the wrong byline. The
+#   guard treats `gh issue create` the same as `gh issue comment`:
+#   keyring active must be the REVIEWER identity (an agent posting
+#   their own work).
+#
+#   Raw `gh api -X POST .../comments` is still intentionally NOT
+#   covered — the token/keyring auth matrix for raw `gh api` writes
+#   is not yet precise enough to block on without false positives.
+#   See REVIEW_POLICY.md § Operation-to-Identity Matrix (graphql
+#   write — PAT-attributed) for the auth-split context and the
+#   follow-up tracked under #284.
 #
 # The identity check (1a) honors a
 # BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1 escape hatch for tests
@@ -576,44 +588,61 @@ EFFECTIVE_CODEX_CLEARED="${CODEX_CLEARED:-${INLINE_CODEX_CLEARED:-}}"
 EFFECTIVE_BREAK_GLASS_ADMIN="${BREAK_GLASS_ADMIN:-${INLINE_BREAK_GLASS_ADMIN:-}}"
 EFFECTIVE_BREAK_GLASS_MERGE_STATE="${BREAK_GLASS_MERGE_STATE:-${INLINE_BREAK_GLASS_MERGE_STATE:-}}"
 
-# Distinguish `gh pr comment` from `gh issue comment` — both share the
-# same subcommand label `comment` but route through different parent
-# tokens. We track this with IS_ISSUE_COMMENT so downstream guard
-# branches can emit the right diagnostic label.
+# Distinguish `gh pr comment` from `gh issue comment` (both share the
+# subcommand label `comment` but route through different parent
+# tokens) AND `gh pr create` from `gh issue create` (same shape, with
+# `gh issue create` added by #317). Downstream guard branches use
+# these flags to pick the right diagnostic label and the right
+# expected-identity policy.
 IS_ISSUE_COMMENT=0
+IS_ISSUE_CREATE=0
 if [ "$SAW_ISSUE" -eq 1 ] && [ "$PR_SUBCOMMAND" = "comment" ]; then
   IS_ISSUE_COMMENT=1
 fi
+if [ "$SAW_ISSUE" -eq 1 ] && [ "$PR_SUBCOMMAND" = "create" ]; then
+  IS_ISSUE_CREATE=1
+fi
 
 # A `gh issue <X>` invocation where X is anything OTHER than `comment`
-# (issue create / close / view / list / etc.) is out of scope for this
-# PR. Allow.
-if [ "$SAW_ISSUE" -eq 1 ] && [ "$IS_ISSUE_COMMENT" -eq 0 ]; then
+# or `create` (issue close / view / list / edit / etc.) is out of
+# scope for this hook. Allow.
+if [ "$SAW_ISSUE" -eq 1 ] && [ "$IS_ISSUE_COMMENT" -eq 0 ] && [ "$IS_ISSUE_CREATE" -eq 0 ]; then
   exit 0
 fi
 
-# Not a covered command? Allow.
+# Not a covered command? Allow. `gh pr create` and `gh issue create`
+# both have PR_SUBCOMMAND=="create"; the IS_ISSUE_CREATE flag is what
+# routes them to different identity expectations below (author for pr,
+# reviewer for issue).
 if [ "$PR_SUBCOMMAND" != "create" ] && \
    [ "$PR_SUBCOMMAND" != "merge" ] && \
    [ "$PR_SUBCOMMAND" != "comment" ] && \
    [ "$PR_SUBCOMMAND" != "review" ] && \
-   [ "$IS_ISSUE_COMMENT" -eq 0 ]; then
+   [ "$IS_ISSUE_COMMENT" -eq 0 ] && \
+   [ "$IS_ISSUE_CREATE" -eq 0 ]; then
   exit 0
 fi
 
-# --- byline guard for pr comment / pr review / issue comment ----------
+# --- byline guard for pr comment / pr review / issue comment / issue create ---
 #
-# These three subcommands share a single policy: the keyring's active
+# These four subcommands share a single policy: the keyring's active
 # account must be the agent's REVIEWER identity (not the author
 # identity). Posting any of them under nathanjohnpayne mis-attributes
 # the byline in a way that breaks the audit-trail invariant
 # REVIEW_POLICY.md depends on.
 #
+# `gh issue create` was added by #317 after mergepath#315 landed
+# under the wrong byline (a nathanpayne-claude agent filed the bug
+# but the keyring had drifted to nathanpayne-codex from a prior
+# Phase 4b CLI session). Same byline-attribution rule as the other
+# three: an agent filing their own bug must attribute to their
+# REVIEWER identity.
+#
 # The `gh pr review --approve` self-approve sub-guard runs after this
 # block — only if we made it past the basic byline check does the
 # self-approve question even arise.
 EXPECTED_REVIEWER="${GH_PR_GUARD_EXPECTED_REVIEWER:-nathanpayne-claude}"
-if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ]; then
+if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ] || [ "$IS_ISSUE_CREATE" -eq 1 ]; then
   if [ "${BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
     ACTIVE_GH_USER=$(gh config get -h github.com user 2>/dev/null || echo "")
     if [ -z "$ACTIVE_GH_USER" ]; then
@@ -635,12 +664,19 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
         review)  cmd_label="gh pr review" ;;
       esac
       [ "$IS_ISSUE_COMMENT" -eq 1 ] && cmd_label="gh issue comment"
+      [ "$IS_ISSUE_CREATE" -eq 1 ] && cmd_label="gh issue create"
       echo "BLOCKED: $cmd_label is about to run under active account '$ACTIVE_GH_USER' (the AUTHOR identity)." >&2
       echo "" >&2
-      echo "  Reviewer-byline commands (pr comment / pr review / issue comment) must attribute to the" >&2
-      echo "  agent's REVIEWER identity ('$EXPECTED_REVIEWER' by default), not the author identity." >&2
-      echo "  Posting as '$EXPECTED_AUTHOR_FOR_BLOCK' breaks the audit-trail convention" >&2
-      echo "  REVIEW_POLICY.md depends on." >&2
+      echo "  Reviewer-byline commands (pr comment / pr review / issue comment / issue create)" >&2
+      echo "  must attribute to the agent's REVIEWER identity ('$EXPECTED_REVIEWER' by default)," >&2
+      echo "  not the author identity. Posting as '$EXPECTED_AUTHOR_FOR_BLOCK' breaks the audit-" >&2
+      echo "  trail convention REVIEW_POLICY.md depends on." >&2
+      if [ "$IS_ISSUE_CREATE" -eq 1 ]; then
+        echo "" >&2
+        echo "  Concrete instance: mergepath#315 landed under nathanpayne-codex despite being" >&2
+        echo "  filed by a nathanpayne-claude agent session, because the keyring had drifted" >&2
+        echo "  from a prior Phase 4b CLI run. This hook closes that gap (#317)." >&2
+      fi
       echo "" >&2
       echo "  Fix once: gh auth switch -u $EXPECTED_REVIEWER" >&2
       echo "  Or wrap the single call: scripts/gh-as-reviewer.sh -- $cmd_label ..." >&2
@@ -648,6 +684,17 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
       exit 2
     fi
   fi
+fi
+
+# --- gh issue create: exit cleanly after the byline check ------------
+#
+# `gh issue create` shares PR_SUBCOMMAND=="create" with `gh pr create`,
+# so without this short-circuit it would fall through into the pr-create
+# branch below (which expects the AUTHOR identity, not the REVIEWER
+# identity — opposite of what `gh issue create` wants). Exit 0 here so
+# downstream pr-create logic doesn't fire.
+if [ "$IS_ISSUE_CREATE" -eq 1 ]; then
+  exit 0
 fi
 
 # --- gh pr review --approve self-approve sub-guard --------------------

--- a/scripts/lib/daily-feedback-rollup-helpers.sh
+++ b/scripts/lib/daily-feedback-rollup-helpers.sh
@@ -92,7 +92,14 @@ extract_tag_class() {
 # (err on surface — future class additions are additive).
 tag_class_action() {
   case "$1" in
-    addressed-elsewhere|canonical-coverage|rebuttal-recorded) echo "skip" ;;
+    # templated-render — verify-propagation-pr.sh re-rendered the
+    # source against mergepath@<sha> with the consumer's facts and
+    # confirmed byte-equality with the PR dest (mergepath#323). Same
+    # "mergepath concern" class as canonical-coverage: a finding on a
+    # templated dest is structurally a mergepath concern (the template
+    # lives in mergepath), so route it to mergepath rather than
+    # surfacing on each consumer's daily rollup.
+    addressed-elsewhere|canonical-coverage|rebuttal-recorded|templated-render) echo "skip" ;;
     nitpick-noted|deferred-to-followup) echo "surface" ;;
     "") echo "" ;;  # no tag → caller falls through to heuristics
     *)  echo "surface" ;;  # unknown → surface

--- a/scripts/lib/gh-retry-helpers.sh
+++ b/scripts/lib/gh-retry-helpers.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/lib/gh-retry-helpers.sh
+#
+# with_gh_retry — wrap a gh/gh-api call in 3-attempt retry with 30s backoff.
+# Distinguishes transient (HTTP 5xx, rate-limit, "Resource not accessible by
+# integration") from permanent (HTTP 4xx other than 429/403, malformed JSON)
+# failures. Only retries the transient class.
+#
+# Usage:
+#   with_gh_retry gh pr view 123 --json statusCheckRollup
+#   with_gh_retry gh api ...
+#
+# Exit codes:
+#   0  — call succeeded on attempt N
+#   non-zero — call failed after 3 attempts or hit a permanent error
+#
+# Env tuning:
+#   GH_RETRY_ATTEMPTS (default 3)
+#   GH_RETRY_BACKOFF_SECONDS (default 30)
+
+set -euo pipefail
+
+with_gh_retry() {
+  local attempts=${GH_RETRY_ATTEMPTS:-3}
+  local backoff=${GH_RETRY_BACKOFF_SECONDS:-30}
+  # Validate env knobs (CR Major #328 round 2, Minor round 3). Non-
+  # numeric or non-positive values previously could skip the loop
+  # entirely (returning success with empty output) or break `sleep`
+  # under `set -e`. Fall back to the defaults with a stderr warning
+  # rather than silently no-op'ing.
+  #
+  # Two-phase validation: first reject non-numeric strings via case
+  # pattern, then reject non-positive integers via arithmetic. The
+  # arithmetic phase closes the leading-zero hole CR caught on round
+  # 2 — `case "00" in 0)` doesn't match (case patterns are literal,
+  # not numeric) but bash arithmetic treats "00" as 0, so the prior
+  # validation passed but the while loop never entered.
+  case "$attempts" in
+    ''|*[!0-9]*) printf '[gh-retry] WARN: GH_RETRY_ATTEMPTS=%q non-numeric; using default 3\n' "$attempts" >&2; attempts=3 ;;
+  esac
+  if [ "$attempts" -le 0 ] 2>/dev/null; then
+    printf '[gh-retry] WARN: GH_RETRY_ATTEMPTS=%q non-positive; using default 3\n' "$attempts" >&2
+    attempts=3
+  fi
+  case "$backoff" in
+    ''|*[!0-9]*) printf '[gh-retry] WARN: GH_RETRY_BACKOFF_SECONDS=%q non-numeric; using default 30\n' "$backoff" >&2; backoff=30 ;;
+  esac
+  # Backoff can legitimately be 0 (no sleep between retries — useful
+  # for tests), so the arithmetic-positivity check applies only to
+  # `attempts`. A negative `backoff` would only occur if a user
+  # passed e.g. `-1`, which fails the case pattern above and is
+  # already caught.
+  local attempt=1
+  local rc=0
+  local output=""
+
+  while [ "$attempt" -le "$attempts" ]; do
+    # Capture stdout+stderr AND the exit code in one shot. Using
+    # `if output=...; then` would discard `$?` after the failed
+    # `if` test (bash resets $? to 0 in that position), so we
+    # invoke + check separately. `|| rc=$?` keeps `set -e` happy
+    # because the `||` short-circuit consumes the non-zero exit.
+    rc=0
+    output=$("$@" 2>&1) || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$output"
+      return 0
+    fi
+
+    # Classify the failure. Permanent failures break out immediately.
+    #
+    # Retry only:
+    #   - HTTP 5xx (server-side, transient)
+    #   - HTTP 429 (rate-limit, always)
+    #   - HTTP 403 with "rate limit" in the body (GitHub rate-limit
+    #     can surface as 403 in some flows)
+    # Fail-fast on:
+    #   - HTTP 4xx other than 429 or rate-limited 403 (auth, perms,
+    #     validation — retrying is futile and costs sweep budget)
+    #   - "Resource not accessible by integration" (token permission
+    #     issue, fixed by adding the perm to the workflow — codex P2
+    #     #328 round 3 caught the prior pattern wasting 2×30s sleeps
+    #     on this surface, missing the auto-clear window)
+    is_permanent=false
+    if printf '%s' "$output" | grep -q 'Resource not accessible by integration'; then
+      is_permanent=true
+    elif printf '%s' "$output" | grep -qE 'HTTP 4[0-9]{2}'; then
+      if printf '%s' "$output" | grep -qE 'HTTP 429'; then
+        : # transient rate-limit
+      elif printf '%s' "$output" | grep -qE 'HTTP 403' \
+           && printf '%s' "$output" | grep -qiE 'rate.?limit'; then
+        : # transient rate-limit surfaced as 403
+      else
+        is_permanent=true
+      fi
+    fi
+    if $is_permanent; then
+      printf '%s' "$output" >&2
+      return "$rc"
+    fi
+
+    if [ "$attempt" -lt "$attempts" ]; then
+      printf '[gh-retry] attempt %d/%d failed (rc=%d), sleeping %ds before retry. tail: %s\n' \
+        "$attempt" "$attempts" "$rc" "$backoff" "$(printf '%s' "$output" | tail -1)" >&2
+      sleep "$backoff"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  printf '%s' "$output" >&2
+  return "$rc"
+}
+
+export -f with_gh_retry

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -634,6 +634,146 @@ path_matches_manifest() {
   return 1
 }
 
+# fetch_manifest_templated_dests — extract dest + eligible consumer
+# slugs for every templated entry in the manifest (#323). Templated
+# entries decouple source from dest (the whole point), so a thread
+# anchored on a templated dest path doesn't match path_matches_manifest
+# above (which reads only .path). Cached.
+#
+# Cache format: one line per entry, `dest<TAB>repo1,repo2,...` where
+# each repoN is the full owner/name slug looked up from
+# `.consumers[].repo` via the entry's `.consumers[] (name)` list. The
+# repo-slug scoping closes the codex P2 from PR #329 round 1: without
+# it, ANY repo whose local file matched the dest path got the
+# `templated-render` class, even repos not opted into that entry —
+# suppressing substantive unresolved feedback on unrelated files in
+# the daily rollup.
+MANIFEST_TEMPLATED_DESTS_CACHE=""
+MANIFEST_TEMPLATED_FETCHED=false
+fetch_manifest_templated_dests() {
+  $MANIFEST_TEMPLATED_FETCHED && return 0
+  MANIFEST_TEMPLATED_FETCHED=true
+  local manifest="$REPO_ROOT_FOR_MANIFEST/.mergepath-sync.yml"
+  [ -f "$manifest" ] || return 0
+  if command -v yq >/dev/null 2>&1; then
+    # Resolve each entry's consumer-name list to repo slugs in one
+    # pass. `. as $root` exposes the top-level consumers table for
+    # the inner lookup. Output: `dest<TAB>repo,repo,...`. The yq
+    # `\t` is a literal tab in the format string.
+    MANIFEST_TEMPLATED_DESTS_CACHE=$(yq -r '
+      . as $root |
+      .paths[] | select(.type == "templated") |
+      [
+        (.dest // .path),
+        (.consumers // [] |
+          map(. as $name |
+            $root.consumers[] | select(.name == $name) | .repo) |
+          join(","))
+      ] | @tsv
+    ' "$manifest" 2>/dev/null || true)
+  else
+    # awk fallback — mirrors the canonical-paths fallback above. Pair
+    # `type:` and `dest:` (or fall back to `path:`) within a `paths:`
+    # block entry. Less precise than yq in two ways, both addressed
+    # below per CR Major #329 round 2:
+    #
+    # 1. Order-independent emission. The prior version emitted on the
+    #    `type: templated` line, which broke when `dest:` appeared
+    #    AFTER `type:` (legal YAML, common in manifest practice). Now
+    #    we emit at entry boundaries (start of next entry / end of
+    #    paths block / EOF) so `dest:` and `type:` can appear in any
+    #    order within an entry.
+    #
+    # 2. Strict no-match instead of loose-match. The prior version
+    #    emitted the dest with an empty consumers field, which
+    #    path_matches_templated_dest interpreted as "match any repo"
+    #    — reintroducing the exact cross-repo misclassification this
+    #    fix is trying to close. Now the awk path emits a sentinel
+    #    `__AWK_NO_CONSUMER_SCOPE__` token in the consumers field,
+    #    which path_matches_templated_dest treats as "no match" (the
+    #    cautious failure mode: under-classify rather than over-
+    #    classify; templated-render is a skip-class, and a missed
+    #    skip just falls back to the rollup's general heuristics).
+    MANIFEST_TEMPLATED_DESTS_CACHE=$(awk '
+      function emit() {
+        if (cur_type == "templated") {
+          out = (cur_dest != "" ? cur_dest : cur_path)
+          if (out != "") {
+            printf "%s\t__AWK_NO_CONSUMER_SCOPE__\n", out
+          }
+        }
+      }
+      /^paths:/ { in_p = 1; next }
+      in_p && /^[^[:space:]#]/ { emit(); in_p = 0 }
+      !in_p { next }
+      /^[[:space:]]*-[[:space:]]*path:/ {
+        emit()
+        cur_path = $0
+        sub(/^[[:space:]]*-[[:space:]]*path:[[:space:]]*/, "", cur_path)
+        sub(/[[:space:]]*#.*$/, "", cur_path)
+        gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_path)
+        cur_dest = ""; cur_type = ""
+      }
+      /^[[:space:]]*dest:/ {
+        cur_dest = $0
+        sub(/^[[:space:]]*dest:[[:space:]]*/, "", cur_dest)
+        sub(/[[:space:]]*#.*$/, "", cur_dest)
+        gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_dest)
+      }
+      /^[[:space:]]*type:[[:space:]]*templated/ {
+        cur_type = "templated"
+      }
+      END { emit() }
+    ' "$manifest")
+  fi
+}
+
+# path_matches_templated_dest <file-path> → exit 0 if it matches a
+# templated entry's dest path AND the current repo ($REPO) is in that
+# entry's consumers list, 1 otherwise. Used by derive_tag_class to
+# emit the `templated-render` class (#323). The consumer-scope check
+# closes codex P2 from PR #329 round 1.
+path_matches_templated_dest() {
+  local file_path="$1"
+  [ -z "$file_path" ] && return 1
+  [ "$file_path" = "(no path)" ] && return 1
+  fetch_manifest_templated_dests
+  [ -z "$MANIFEST_TEMPLATED_DESTS_CACHE" ] && return 1
+  local line dest consumers
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    # Split on the first tab. Two-field TSV: dest<TAB>repo1,repo2,...
+    dest="${line%%$'\t'*}"
+    consumers="${line#*$'\t'}"
+    [ "$file_path" = "$dest" ] || continue
+    # The awk fallback emits this sentinel when it can't resolve
+    # consumer-name → repo-slug (cross-references in awk are
+    # brittle). Treat sentinel as "no scope information available"
+    # and DO NOT match — better to miss the templated-render skip
+    # tag (falling through to other heuristics in the rollup) than
+    # to over-classify and silently suppress substantive feedback
+    # on unrelated files. (CR Major #329 round 2.)
+    if [ "$consumers" = "__AWK_NO_CONSUMER_SCOPE__" ]; then
+      continue
+    fi
+    # Empty consumers field — yq returned no consumer matches for
+    # this entry (entry has no `consumers:` list, or none of the
+    # named consumers resolve to a repo). Treat as no-scope
+    # information, same as the awk sentinel: don't match.
+    if [ -z "$consumers" ]; then
+      continue
+    fi
+    # The current repo ($REPO, populated from --repo arg or origin
+    # remote at module-load) MUST appear in the comma-separated
+    # consumers list. Anchored grep avoids partial-name false hits
+    # (e.g., `owner/matchline` vs `owner/matchline-app`).
+    if printf ',%s,' "$consumers" | grep -qF ",$REPO,"; then
+      return 0
+    fi
+  done <<< "$MANIFEST_TEMPLATED_DESTS_CACHE"
+  return 1
+}
+
 # Module-load-time: pin the manifest base. We resolve REPO_ROOT_FOR_MANIFEST
 # from the script's on-disk location, NOT $REPO (which is the gh repo
 # slug). This intentionally reads the LOCAL working-tree manifest —
@@ -648,6 +788,15 @@ REPO_ROOT_FOR_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Decision ladder (highest-confidence first; matches the
 # spec § Class taxonomy from issue #305):
 #   1. canonical-coverage     anchored path is in the manifest
+#   1b. templated-render      anchored path is a templated dest
+#                             (#323) — same "mergepath concern" class
+#                             as canonical-coverage but on the
+#                             templated surface; emitted only when the
+#                             path is NOT also matched by 1 (the dests
+#                             never appear as .path entries by
+#                             construction — source ≠ dest is the
+#                             point — so the two branches don't
+#                             overlap in practice).
 #   2. addressed-elsewhere    agent-author commit after createdAt
 #                             touching the anchored file
 #   3. rebuttal-recorded      ≥30-char agent-author reply on thread
@@ -672,6 +821,19 @@ derive_tag_class() {
   # 1. canonical-coverage
   if path_matches_manifest "$thread_path"; then
     echo "canonical-coverage"
+    return
+  fi
+
+  # 1b. templated-render (#323) — path matches a templated entry's
+  # dest. Same "mergepath concern" routing as canonical-coverage; the
+  # rendered output came from a template in mergepath, so the fix
+  # should land in mergepath too. We don't (and can't, from here)
+  # re-run verify-propagation-pr.sh to confirm the bytes match — but
+  # the path predicate alone is the right signal: if a thread is
+  # anchored on the templated dest, the durable fix is either in
+  # mergepath's template or in the consumer's facts:* block.
+  if path_matches_templated_dest "$thread_path"; then
+    echo "templated-render"
     return
   fi
 
@@ -796,6 +958,18 @@ synth_rationale() {
         echo "path $thread_path is propagated canonical content (.mergepath-sync.yml)."
       else
         echo "thread is on propagated canonical content (.mergepath-sync.yml)."
+      fi
+      ;;
+    templated-render)
+      # #323 — the dest is rendered from a mergepath template with
+      # consumer facts. verify-propagation-pr.sh re-renders and
+      # byte-compares as part of the propagation-lane gate; if a
+      # thread persists on a templated dest, the durable fix lives in
+      # mergepath's template or the consumer's facts:* block.
+      if [ -n "$thread_path" ] && [ "$thread_path" != "(no path)" ]; then
+        echo "$thread_path is a templated dest rendered from mergepath; fix belongs in the template or consumer facts."
+      else
+        echo "thread is on a templated dest rendered from mergepath; fix belongs in the template or consumer facts."
       fi
       ;;
     nitpick-noted)

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # verify-propagation-pr.sh — authoritative faithful-mirror check for
 # the propagation-PR review lane (REVIEW_POLICY.md § Propagation PR
-# review lane, mergepath#264 / #268).
+# review lane, mergepath#264 / #268 / #323).
 #
 # The lane exempts a sync PR from Phase 4 external review. That is
 # only safe if the PR is PROVABLY a verbatim mirror of mergepath's
@@ -17,6 +17,36 @@ set -euo pipefail
 # mergepath checkout (the immutable, public commit the PR's branch
 # name points at) — never from the PR's own checkout, which the PR
 # could have tampered with.
+#
+# Two verification surfaces:
+#
+#   A. Canonical / kit entries — byte-for-byte equality against
+#      mergepath@<sha>. Implemented as a `git ls-tree` mode+oid
+#      compare so an exec-bit flip is also caught.
+#
+#   B. Templated entries (#323) — render the source template at
+#      mergepath@<sha> with the consumer's facts (loaded from the
+#      mergepath-side manifest via export_consumer_facts) and
+#      byte-compare the rendered output against the PR's dest
+#      content. Drift, template syntax errors, and missing facts in
+#      strict mode all fail the verification with a typed
+#      diagnostic. On pass, a structured line of the form
+#      "[mergepath-verify: templated-render] <dest> <consumer> <source>"
+#      is emitted on stdout so a calling workflow can post it as a
+#      thread tag-reply. This script intentionally stays read-only —
+#      it does NOT post to GitHub.
+#
+# Consumer inference (templated surface only):
+#   1. $MERGEPATH_CONSUMER env override (test/CI escape hatch).
+#   2. consumer_dir's `origin` remote URL → matched against the
+#      manifest's .consumers[].repo field.
+#   3. If neither resolves, the templated surface is SKIPPED with a
+#      stderr note (the canonical/kit surface still runs). This is
+#      conservative: a templated entry whose consumer can't be
+#      identified is just left to the existing path-confinement
+#      check, which will fail because the templated dest doesn't
+#      equal the templated .path — the PR then routes to normal
+#      Phase 4 review, same as the pre-#323 status quo.
 #
 # Usage:
 #   verify-propagation-pr.sh <mergepath_dir> <consumer_dir> <base_sha> <head_sha>
@@ -34,11 +64,12 @@ set -euo pipefail
 # Exit codes:
 #   0  faithful mirror — every changed file is under a manifest path
 #      AND its end-state byte-matches mergepath@<sha> (both-present-
-#      equal, or both-absent). The PR is lane-eligible.
+#      equal, or both-absent), with templated dests matching their
+#      re-rendered output. The PR is lane-eligible.
 #   1  NOT a faithful mirror — at least one changed file is off-
-#      manifest or deviates from mergepath@<sha>. The PR must go
-#      through normal Phase 3/4 review. Deviations are listed on
-#      stderr.
+#      manifest, deviates from mergepath@<sha>, or its templated
+#      re-render diverges. The PR must go through normal Phase 3/4
+#      review. Deviations are listed on stderr.
 #   2  usage / environment error (bad args, missing manifest, etc.).
 #
 # Bash 3.2 portable: no `mapfile`, no associative arrays.
@@ -89,11 +120,258 @@ if [ -z "$CHANGED_FILES" ]; then
   exit 1
 fi
 
+# Failure aggregation. Three typed categories so the summary at exit
+# can distinguish the failure mode for diagnostics:
+#   CANONICAL_FAILURES  — off-manifest / mode-or-blob drift on
+#                         canonical or kit entries.
+#   TEMPLATED_FAILURES  — re-rendered output diverges from PR dest
+#                         content.
+#   TEMPLATED_ERRORS    — render itself failed (malformed template,
+#                         strict-mode unset fact, source missing
+#                         from mergepath@<sha>).
 FAILURES=""
-fail() { FAILURES="${FAILURES}  - $1"$'\n'; }
+CANONICAL_FAILURES=""
+TEMPLATED_FAILURES=""
+TEMPLATED_ERRORS=""
+fail() { FAILURES="${FAILURES}  - $1"$'\n'; CANONICAL_FAILURES="${CANONICAL_FAILURES}  - $1"$'\n'; }
+fail_templated_drift() { FAILURES="${FAILURES}  - $1"$'\n'; TEMPLATED_FAILURES="${TEMPLATED_FAILURES}  - $1"$'\n'; }
+fail_templated_error() { FAILURES="${FAILURES}  - $1"$'\n'; TEMPLATED_ERRORS="${TEMPLATED_ERRORS}  - $1"$'\n'; }
+
+# -------------------------------------------------------------------
+# Templated surface (#323) — handled BEFORE the canonical loop so
+# verified templated dests are exempted from the path-confinement
+# check (the dest doesn't equal any .path and would otherwise fail).
+# -------------------------------------------------------------------
+
+# VERIFIED_TEMPLATED_DESTS — list (newline-separated, sentinel-padded)
+# of consumer-side dest paths whose re-render matched. Checked in the
+# canonical loop below so we don't double-fail-them as off-manifest.
+VERIFIED_TEMPLATED_DESTS=""
+
+# infer_consumer_from_pr_context — determine which consumer this PR
+# belongs to, for templated render. Strategies, in order:
+#   1. $MERGEPATH_CONSUMER env override (test/CI escape hatch).
+#   2. consumer_dir's `origin` remote URL → matched against the
+#      manifest's .consumers[].repo field.
+# Echoes the consumer name on success (sets RC=0), empty on failure
+# (RC=1). The caller treats RC=1 as "skip templated verification" —
+# canonical/kit verification still runs.
+infer_consumer_from_pr_context() {
+  if [ -n "${MERGEPATH_CONSUMER:-}" ]; then
+    printf '%s' "$MERGEPATH_CONSUMER"
+    return 0
+  fi
+  # Read origin URL. `git remote get-url origin` is the modern form;
+  # older gits used `git config remote.origin.url` — both work here.
+  local remote_url
+  remote_url=$(git -C "$CONSUMER_DIR" remote get-url origin 2>/dev/null || \
+               git -C "$CONSUMER_DIR" config remote.origin.url 2>/dev/null || \
+               printf '')
+  [ -z "$remote_url" ] && return 1
+  # Normalize the URL to an "owner/repo" slug so we can string-match
+  # against the manifest's .consumers[].repo field. Handles:
+  #   https://github.com/owner/repo.git → owner/repo
+  #   git@github.com:owner/repo.git     → owner/repo
+  #   ssh://git@github.com/owner/repo   → owner/repo
+  local slug
+  # Strip scheme + host (https://, git@host:, ssh://git@host/).
+  slug=$(printf '%s' "$remote_url" | sed -E '
+    s|^https?://[^/]+/||
+    s|^ssh://git@[^/]+/||
+    s|^git@[^:]+:||
+    s|\.git$||
+  ')
+  # Lookup in the manifest. We don't have yq guaranteed at this
+  # surface (the canonical loop above uses an awk parser), so fall
+  # back to a simple awk-based lookup over the consumers block.
+  if command -v yq >/dev/null 2>&1; then
+    local name
+    name=$(yq -r ".consumers[] | select(.repo == \"$slug\") | .name" "$MANIFEST" 2>/dev/null | head -n1)
+    if [ -n "$name" ]; then
+      printf '%s' "$name"
+      return 0
+    fi
+  fi
+  # awk fallback — pairs `- name:` and `repo:` inside the
+  # `consumers:` block, prints the name when repo matches.
+  local name
+  name=$(awk -v target="$slug" '
+    /^consumers:/ { in_c = 1; next }
+    in_c && /^[^[:space:]#]/ { in_c = 0 }
+    !in_c { next }
+    /^[[:space:]]*-[[:space:]]*name:/ {
+      cur_name = $0
+      sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "", cur_name)
+      sub(/[[:space:]]*#.*$/, "", cur_name)
+      gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_name)
+    }
+    /^[[:space:]]*repo:/ {
+      cur_repo = $0
+      sub(/^[[:space:]]*repo:[[:space:]]*/, "", cur_repo)
+      sub(/[[:space:]]*#.*$/, "", cur_repo)
+      gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_repo)
+      if (cur_repo == target) { print cur_name; exit }
+    }
+  ' "$MANIFEST")
+  if [ -n "$name" ]; then
+    printf '%s' "$name"
+    return 0
+  fi
+  return 1
+}
+
+# Source the template lib and facts helper from the TRUSTED mergepath
+# checkout. Same provenance rule as the parser helpers above — never
+# from the PR's working tree.
+TEMPLATE_LIB="$MERGEPATH_DIR/scripts/lib/template-substitution.sh"
+FACTS_HELPER="$MERGEPATH_DIR/scripts/lib/manifest-fact-helpers.sh"
+
+# Only attempt the templated surface if both trusted helpers are
+# present in mergepath@<sha>. Missing helpers → fall through to the
+# canonical loop (which will fail-closed on the templated dest path).
+TEMPLATED_SURFACE_ACTIVE=0
+if [ -f "$TEMPLATE_LIB" ] && [ -f "$FACTS_HELPER" ] && command -v yq >/dev/null 2>&1; then
+  TEMPLATED_SURFACE_ACTIVE=1
+fi
+
+if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ]; then
+  # Resolve consumer. RC=1 → skip templated surface with a log line.
+  CONSUMER_NAME=""
+  if CONSUMER_NAME=$(infer_consumer_from_pr_context) && [ -n "$CONSUMER_NAME" ]; then
+    :
+  else
+    echo "verify-propagation-pr.sh: cannot infer consumer from PR context (no MERGEPATH_CONSUMER env, no origin remote match in manifest) — skipping templated re-render surface" >&2
+    CONSUMER_NAME=""
+  fi
+fi
+
+if [ "$TEMPLATED_SURFACE_ACTIVE" = "1" ] && [ -n "$CONSUMER_NAME" ]; then
+  # shellcheck disable=SC1090
+  source "$FACTS_HELPER"
+  # shellcheck disable=SC1090
+  source "$TEMPLATE_LIB"
+
+  # Pull templated entries (source, dest, consumers) as TSV.
+  TEMPLATED_TSV=$(yq -r '
+    .paths[]
+    | select(.type == "templated")
+    | [(.source // .path), (.dest // .path), ((.consumers // [] | type == "!!str") | tostring), (.consumers // [] | (select(type == "!!str") // (join(","))) | tostring)]
+    | @tsv
+  ' "$MANIFEST" 2>/dev/null || printf '')
+
+  if [ -n "$TEMPLATED_TSV" ]; then
+    while IFS=$'\t' read -r tpl_source tpl_dest is_str_consumers consumers_csv; do
+      [ -z "$tpl_source" ] && continue
+      [ -z "$tpl_dest" ] && continue
+      # consumers field can be the literal "all" or a CSV of names.
+      # is_str_consumers is "true" when the manifest used a scalar
+      # `consumers: all`, else "false" (i.e. it was a sequence).
+      consumer_matches=0
+      if [ "$is_str_consumers" = "true" ] && [ "$consumers_csv" = "all" ]; then
+        consumer_matches=1
+      elif [ "$is_str_consumers" = "false" ]; then
+        case ",$consumers_csv," in
+          *",$CONSUMER_NAME,"*) consumer_matches=1 ;;
+        esac
+      fi
+      [ "$consumer_matches" -eq 0 ] && continue
+
+      # Templated dest must actually be in the PR's changed files —
+      # otherwise there's nothing to verify for this entry.
+      dest_in_diff=0
+      while IFS= read -r cf; do
+        [ -z "$cf" ] && continue
+        if [ "$cf" = "$tpl_dest" ]; then dest_in_diff=1; break; fi
+      done <<< "$CHANGED_FILES"
+      [ "$dest_in_diff" -eq 0 ] && continue
+
+      # Source must exist in the trusted mergepath checkout.
+      mp_source_abs="$MERGEPATH_DIR/$tpl_source"
+      if [ ! -f "$mp_source_abs" ]; then
+        fail_templated_error "$tpl_dest — templated source '$tpl_source' missing from mergepath@<sha> (consumer=$CONSUMER_NAME)"
+        continue
+      fi
+
+      # Render in a subshell so the facts export + lib sourcing don't
+      # leak between iterations.
+      rendered=$(mktemp "${TMPDIR:-/tmp}/verify-prop-rendered.XXXXXX")
+      render_err=$(mktemp "${TMPDIR:-/tmp}/verify-prop-render-err.XXXXXX")
+      render_rc=0
+      (
+        export_consumer_facts "$CONSUMER_NAME" "$MANIFEST"
+        template_substitution::render "$mp_source_abs"
+      ) > "$rendered" 2> "$render_err" || render_rc=$?
+
+      if [ "$render_rc" != "0" ]; then
+        # Surface the renderer's stderr for diagnostics, then fail.
+        if [ -s "$render_err" ]; then
+          {
+            echo "verify-propagation-pr.sh: template render error for $tpl_source (consumer=$CONSUMER_NAME, rc=$render_rc):"
+            sed 's/^/    /' "$render_err"
+          } >&2
+        fi
+        fail_templated_error "$tpl_dest — templated render failed (source=$tpl_source, consumer=$CONSUMER_NAME, rc=$render_rc)"
+        rm -f "$rendered" "$render_err"
+        continue
+      fi
+      rm -f "$render_err"
+
+      # Pull the PR's dest content at HEAD via `git show`.
+      pr_content=$(mktemp "${TMPDIR:-/tmp}/verify-prop-pr.XXXXXX")
+      if ! git -C "$CONSUMER_DIR" show "${HEAD_SHA}:${tpl_dest}" > "$pr_content" 2>/dev/null; then
+        fail_templated_error "$tpl_dest — templated dest not present at PR HEAD (consumer=$CONSUMER_NAME)"
+        rm -f "$rendered" "$pr_content"
+        continue
+      fi
+
+      if diff -q "$rendered" "$pr_content" >/dev/null 2>&1; then
+        # Byte-compare cleared. Now check the tree entry's mode + type
+        # match the expected `100644 blob` shape — otherwise metadata-
+        # only tampering (chmod +x flip, regular-file ↔ symlink swap)
+        # passes lane verification while changing the consumer's
+        # on-disk file behavior. Codex P1 #329 round 2 caught this:
+        # the templated arm was byte-only while the canonical loop's
+        # tree-entry compare (mode + type + oid via `git ls-tree`)
+        # was being skipped via the VERIFIED_TEMPLATED_DESTS exempt.
+        tpl_consumer_entry=$(git -C "$CONSUMER_DIR" ls-tree "$HEAD_SHA" -- "$tpl_dest" 2>/dev/null | awk '{print $1, $2}')
+        if [ "$tpl_consumer_entry" != "100644 blob" ]; then
+          {
+            echo "verify-propagation-pr.sh: templated dest $tpl_dest has unexpected tree entry [$tpl_consumer_entry], expected [100644 blob] (mode/type tampering — chmod +x flip or symlink swap, not a faithful render)"
+          } >&2
+          fail_templated_drift "$tpl_dest — templated dest tree entry [$tpl_consumer_entry] differs from expected [100644 blob] (source=$tpl_source, consumer=$CONSUMER_NAME)"
+          rm -f "$rendered" "$pr_content"
+          continue
+        fi
+        echo "verify-propagation-pr.sh: templated re-render matches PR content for $tpl_dest (consumer=$CONSUMER_NAME, source=$tpl_source)"
+        # Emit structured tag-reply line for the calling workflow.
+        # Format MUST stay parseable; see CLAUDE.md § resolve-pr-threads
+        # tag class and #323 for the consumer of these lines.
+        printf '[mergepath-verify: templated-render] %s %s %s\n' "$tpl_dest" "$CONSUMER_NAME" "$tpl_source"
+        VERIFIED_TEMPLATED_DESTS="${VERIFIED_TEMPLATED_DESTS}${tpl_dest}"$'\n'
+      else
+        {
+          echo "verify-propagation-pr.sh: templated re-render diverges from PR content for $tpl_dest (consumer=$CONSUMER_NAME, source=$tpl_source). Diff (expected → PR):"
+          diff "$rendered" "$pr_content" | sed 's/^/    /' || true
+        } >&2
+        fail_templated_drift "$tpl_dest — templated re-render diverges from PR content (source=$tpl_source, consumer=$CONSUMER_NAME)"
+      fi
+      rm -f "$rendered" "$pr_content"
+    done <<< "$TEMPLATED_TSV"
+  fi
+fi
 
 while IFS= read -r f; do
   [ -z "$f" ] && continue
+
+  # #323: skip files already verified by the templated re-render
+  # surface above. Their dest path doesn't match any .path glob
+  # (which is the whole point of source ≠ dest), so the canonical
+  # path-confinement check below would false-fail them.
+  if [ -n "$VERIFIED_TEMPLATED_DESTS" ]; then
+    case $'\n'"$VERIFIED_TEMPLATED_DESTS" in
+      *$'\n'"$f"$'\n'*) continue ;;
+    esac
+  fi
 
   # 1. Path confinement: f must be under a manifest-declared path.
   if ! printf '%s\n' "$f" | bash "$MATCH_PATHS" "${MAN_PATTERNS[@]}" | grep -qxF "$f"; then
@@ -155,7 +433,22 @@ done <<< "$CHANGED_FILES"
 
 if [ -n "$FAILURES" ]; then
   echo "verify-propagation-pr.sh: NOT a faithful mirror — the PR is not lane-eligible:" >&2
-  printf '%s' "$FAILURES" >&2
+  # Typed sub-summaries so the reader can tell at a glance whether a
+  # failure is canonical-mismatch, templated-drift, or templated-error
+  # (#323). Categories are mutually exclusive — a given failure lands
+  # in exactly one bucket.
+  if [ -n "$CANONICAL_FAILURES" ]; then
+    echo "  Canonical / kit drift (path confinement + tree-entry compare):" >&2
+    printf '%s' "$CANONICAL_FAILURES" >&2
+  fi
+  if [ -n "$TEMPLATED_FAILURES" ]; then
+    echo "  Templated re-render mismatch (rendered output differs from PR dest):" >&2
+    printf '%s' "$TEMPLATED_FAILURES" >&2
+  fi
+  if [ -n "$TEMPLATED_ERRORS" ]; then
+    echo "  Templated re-render error (malformed template / missing source / strict-mode unset fact):" >&2
+    printf '%s' "$TEMPLATED_ERRORS" >&2
+  fi
   echo "  → this PR must go through normal Phase 3/4 review." >&2
   exit 1
 fi

--- a/tests/test_export_consumer_facts.sh
+++ b/tests/test_export_consumer_facts.sh
@@ -27,8 +27,16 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$ROOT/scripts/sync-to-downstream.sh"
+# The yq filter moved to scripts/lib/manifest-fact-helpers.sh in
+# mergepath#323 so both sync-to-downstream.sh and
+# scripts/workflow/verify-propagation-pr.sh can load consumer facts
+# from a shared helper without duplicating the filter. The regression-
+# guard greps the lib file now; we still confirm sync-to-downstream.sh
+# sources the lib so the wiring can't silently drift.
+LIB="$ROOT/scripts/lib/manifest-fact-helpers.sh"
 
 [[ -r "$SCRIPT" ]] || { echo "missing $SCRIPT" >&2; exit 1; }
+[[ -r "$LIB" ]] || { echo "missing $LIB" >&2; exit 1; }
 command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not available" >&2; exit 0; }
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/export-facts-test.XXXXXX")"
@@ -39,7 +47,11 @@ FAIL=0
 pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
 
-# Fixture manifest with four consumers exercising the value-type matrix.
+# Fixture manifest with consumers exercising the value-type matrix.
+# `with_322_facts` covers the mergepath#322 facts vocabulary (testing
+# scalar, jsx_in_js bool, react_compiler bool) to regression-guard
+# the export pipeline against the bool-as-string serialization that
+# the lib's `<key> == true` / `!<key>` expressions depend on.
 cat > "$WORKDIR/manifest.yml" <<'EOF'
 version: 1
 consumers:
@@ -62,6 +74,14 @@ consumers:
   - name: with_no_facts
     repo: example-org/with-no-facts
     visibility: public
+  - name: with_322_facts
+    repo: example-org/with-322-facts
+    visibility: public
+    facts:
+      frameworks: [react]
+      testing: vitest
+      jsx_in_js: true
+      react_compiler: false
 paths: []
 EOF
 
@@ -117,23 +137,53 @@ else
   fail "Case 4: expected empty output, got:\n$out"
 fi
 
-# Case 5: the lib script's source MUST contain the documented
-# select-fallback idiom. If a future contributor reverts to the
-# `if then else end` form (which mikefarah/yq rejects), this
-# assertion catches it before the broken syntax ships.
-if grep -q 'select(tag == "!!seq") | join(" ")' "$SCRIPT"; then
-  pass "Case 5: lib script uses the select+// idiom (not the broken if/then/else form)"
+# Case 5: the lib MUST contain the documented select-fallback idiom.
+# If a future contributor reverts to the `if then else end` form
+# (which mikefarah/yq rejects), this assertion catches it before the
+# broken syntax ships. The filter moved to manifest-fact-helpers.sh
+# in #323; grep the lib, not the sync script.
+if grep -q 'select(tag == "!!seq") | join(" ")' "$LIB"; then
+  pass "Case 5: lib helper uses the select+// idiom (not the broken if/then/else form)"
 else
-  fail "Case 5: scripts/sync-to-downstream.sh no longer uses the select+// idiom — this regression-guard expects 'select(tag == \"!!seq\") | join(\" \")' in the script"
+  fail "Case 5: scripts/lib/manifest-fact-helpers.sh no longer uses the select+// idiom — this regression-guard expects 'select(tag == \"!!seq\") | join(\" \")' in the helper"
 fi
 
-# Case 6: explicit no-regression check — the script must NOT contain
+# Case 6: explicit no-regression check — the lib must NOT contain
 # the broken form `if (tag == "!!seq") then`. This is the literal
 # substring that caused the bug.
-if ! grep -qF 'if (tag == "!!seq") then' "$SCRIPT"; then
-  pass "Case 6: lib script does not contain the broken yq if/then/else form"
+if ! grep -qF 'if (tag == "!!seq") then' "$LIB"; then
+  pass "Case 6: lib helper does not contain the broken yq if/then/else form"
 else
-  fail "Case 6: lib script contains the broken 'if (tag == \"!!seq\") then ... else ... end' form — mikefarah/yq rejects this at the lexer"
+  fail "Case 6: lib helper contains the broken 'if (tag == \"!!seq\") then ... else ... end' form — mikefarah/yq rejects this at the lexer"
+fi
+
+# Case 7 (#323): sync-to-downstream.sh MUST source the lib so the
+# wiring is not silently lost in a future refactor. A missing source
+# would re-introduce the duplication this extraction was meant to
+# eliminate.
+if grep -q 'source "$MERGEPATH_ROOT/scripts/lib/manifest-fact-helpers.sh"' "$SCRIPT"; then
+  pass "Case 7: sync-to-downstream.sh sources the manifest-fact-helpers lib"
+else
+  fail "Case 7: sync-to-downstream.sh no longer sources scripts/lib/manifest-fact-helpers.sh — wiring lost"
+fi
+
+# Case 7 (mergepath#322): mixed seq + scalar + bool facts serialize
+# correctly. The template lib's expressions for the #322 facts read:
+#   `>>> if testing contains vitest`     → needs "vitest" string
+#   `>>> if jsx_in_js`                   → needs non-empty value (e.g. "true")
+#   `>>> if !react_compiler`             → needs treat-"false"-as-set
+#     (which is what `_fact_value` does — set-but-empty is rare; set
+#     to "false" is a non-empty value so `!react_compiler` evaluates
+#     FALSE, suppressing the disable block as desired).
+# The yq filter MUST emit one tab-separated row per fact, with bool
+# values rendered as the strings "true" / "false" (not YAML-literal
+# variants). Locks in the bool-serialization shape this depends on.
+out=$(run_filter with_322_facts)
+expected="$(printf 'frameworks\treact\ntesting\tvitest\njsx_in_js\ttrue\nreact_compiler\tfalse')"
+if [ "$out" = "$expected" ]; then
+  pass "Case 7 (#322): seq + scalar + bool facts serialize as expected (booleans → 'true'/'false' strings)"
+else
+  fail "Case 7 (#322): expected:\n$expected\ngot:\n$out"
 fi
 
 echo

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -509,18 +509,91 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 23: gh issue close (non-comment issue subcommand) → allowed.
-# Regression: the issue parent recognizer must NOT swallow `close`,
-# `view`, etc.
+# Test 23: gh issue close (non-comment, non-create issue subcommand) →
+# allowed. Regression: the issue parent recognizer must NOT swallow
+# `close`, `view`, `list`, `edit`, etc.
 # ---------------------------------------------------------------------------
 set +e
 out=$(run_hook 'gh issue close 7' "nathanjohnpayne" "0" 2>&1)
 rc=$?
 set -e
 if [ "$rc" -eq 0 ]; then
-  pass "issue close: allowed (only 'issue comment' is guarded)"
+  pass "issue close: allowed (only 'issue comment' and 'issue create' are guarded)"
 else
   fail "issue close: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23a: gh issue create with AUTHOR identity → blocked (#317).
+# Closes the mergepath#315 misattribution gap: a nathanpayne-claude
+# agent session filed an issue, but the keyring had drifted to
+# nathanpayne-codex from the prior Phase 4b CLI run, and the issue
+# landed under the wrong byline. The hook should now catch this:
+# any keyring active = the AUTHOR identity (nathanjohnpayne) is
+# blocked because issue creation should attribute to a REVIEWER
+# (agent) identity.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug report" --body "saw the thing"' "nathanjohnpayne" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "issue create + author identity: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "gh issue create"; then
+  fail "issue create + author identity: diagnostic missing 'gh issue create'; output: $out"
+elif ! echo "$out" | grep -qi "mergepath#315"; then
+  fail "issue create + author identity: diagnostic missing #315 reference; output: $out"
+else
+  pass "issue create + author identity: blocked with #317 diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23b: gh issue create with REVIEWER identity → allowed (#317).
+# The happy path: the keyring is the agent's reviewer identity, the
+# issue posts under that byline, no block.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug report" --body "saw the thing"' "nathanpayne-claude" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "issue create + reviewer identity: allowed"
+else
+  fail "issue create + reviewer identity: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23c: gh issue create with bypass set → allowed even under
+# AUTHOR identity (test/CI escape hatch parity with the other
+# reviewer-byline checks).
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug" --body "..."' "nathanjohnpayne" "1" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "issue create + author identity + bypass: allowed (escape hatch)"
+else
+  fail "issue create + bypass: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23d: gh issue create must NOT fall through to the pr-create
+# branch's body checks. `gh pr create` requires Authoring-Agent: and
+# ## Self-Review in the body; `gh issue create` has neither convention.
+# Regression: PR_SUBCOMMAND=="create" alone is insufficient to decide
+# the branch — the IS_ISSUE_CREATE flag must route correctly.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug" --body "no Authoring-Agent line here"' "nathanpayne-claude" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "issue create: did not fall through to pr-create body checks"
+elif echo "$out" | grep -qi "Authoring-Agent"; then
+  fail "issue create: incorrectly fell through to pr-create body checks; output: $out"
+else
+  fail "issue create: unexpected exit $rc; output: $out"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -608,6 +608,163 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 12. Fact-driven defaults added in mergepath#322 — testing globals,
+#     jsx_in_js React glob extension, react_compiler advisory disables.
+#
+# These mirror the per-fact toggles that the ESLint template (post-#322)
+# uses. Each case exercises one fact in isolation against a minimal
+# template snippet so a regression in the lib's evaluator is caught
+# by a tightly-scoped failure rather than a full-template byte diff.
+# ---------------------------------------------------------------------------
+
+# 12a: testing == vitest renders vitest block, jest block does not.
+r=$(render_case "// >>> if testing contains vitest
+vitest globals
+// <<<
+// >>> if testing contains jest
+jest globals
+// <<<
+" "MERGEPATH_FACT_TESTING=vitest")
+expect_output "12a testing=vitest renders only vitest block" "$r" "vitest globals"
+
+# 12b: testing == jest renders jest block, vitest block does not.
+r=$(render_case "// >>> if testing contains vitest
+vitest globals
+// <<<
+// >>> if testing contains jest
+jest globals
+// <<<
+" "MERGEPATH_FACT_TESTING=jest")
+expect_output "12b testing=jest renders only jest block" "$r" "jest globals"
+
+# 12c: testing unset → neither block renders.
+r=$(render_case "// >>> if testing contains vitest
+vitest globals
+// <<<
+// >>> if testing contains jest
+jest globals
+// <<<
+")
+expect_output "12c testing unset → no testing block" "$r" ""
+
+# 12d: jsx_in_js: true (truthy) → js-included files glob renders.
+r=$(render_case "// >>> if jsx_in_js
+files: js+jsx+tsx
+// <<<
+" "MERGEPATH_FACT_JSX_IN_JS=true")
+expect_output "12d jsx_in_js=true → jsx-in-js block renders" "$r" "files: js+jsx+tsx"
+
+# 12e: jsx_in_js unset → block does NOT render (default behavior).
+r=$(render_case "// >>> if jsx_in_js
+files: js+jsx+tsx
+// <<<
+")
+expect_output "12e jsx_in_js unset → jsx-in-js block omitted" "$r" ""
+
+# 12f: React Compiler disable block gated on `frameworks contains
+# react` ONLY (codex P1 #327 round 2). For non-React consumers, the
+# block must NOT render — otherwise it'd inject react-hooks/* rule
+# IDs whose plugin isn't loaded, breaking ESLint config load with
+# "Definition for rule X was not found".
+r=$(render_case "// >>> if frameworks contains react
+react-hooks/set-state-in-effect: off
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react")
+expect_output "12f React Compiler block renders for React consumers" "$r" "react-hooks/set-state-in-effect: off"
+
+# 12g: For non-React consumers, the React Compiler disable block must
+# NOT render. Codex P1 round 2 caught this concretely on JS/TS-only
+# consumers — the rendered config previously emitted react-hooks/*
+# rules even when the plugin wasn't loaded.
+r=$(render_case "// >>> if frameworks contains react
+react-hooks/set-state-in-effect: off
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=typescript")
+expect_output "12g React Compiler block omitted for non-React consumers" "$r" ""
+
+# 12h: facts.react_compiler is reserved for v2 (when the template lib
+# adds compound expressions or nested conditionals). It currently has
+# no effect on rendering — regression guard for accidental re-use of
+# the fact in template logic.
+r=$(render_case "// >>> if frameworks contains react
+react-hooks/set-state-in-effect: off
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react MERGEPATH_FACT_REACT_COMPILER=true")
+expect_output "12h react_compiler=true does NOT suppress disable block (v1 limitation)" "$r" "react-hooks/set-state-in-effect: off"
+
+# ---------------------------------------------------------------------------
+# 13. ESM/CJS template parity: render the real examples/eslint.config.{js,
+#     cjs.js} files against every meaningful facts combination. The render
+#     itself must succeed (parse-level marker balance is the load-bearing
+#     check) AND the ESM and CJS rendered bodies must match modulo the
+#     import/export shape. Without these guards, an edit that drifts the
+#     CJS template's `>>> if` / `<<<` structure away from the ESM (e.g.
+#     deletes the opener but leaves an orphan closer — observed during
+#     the #327 round-3 cleanup, caught only when sync-to-downstream.sh
+#     --sync-all hit ffb/swipewatch in prod) passes the existing fixture-
+#     based tests but breaks every templated propagation.
+# ---------------------------------------------------------------------------
+TEMPLATE_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ESM_TEMPLATE="$TEMPLATE_REPO_ROOT/examples/eslint.config.js"
+CJS_TEMPLATE="$TEMPLATE_REPO_ROOT/examples/eslint.config.cjs.js"
+
+# Quick parse-level guard: marker counts must match within each file AND
+# between the two files. This is the cheapest check that catches the
+# orphan-`<<<` bug class without needing a renderer.
+ESM_OPEN=$(grep -cE '^// >>> if' "$ESM_TEMPLATE")
+ESM_CLOSE=$(grep -cE '^// <<<' "$ESM_TEMPLATE")
+CJS_OPEN=$(grep -cE '^// >>> if' "$CJS_TEMPLATE")
+CJS_CLOSE=$(grep -cE '^// <<<' "$CJS_TEMPLATE")
+if [ "$ESM_OPEN" -ne "$ESM_CLOSE" ]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: 13a ESM template has $ESM_OPEN open markers vs $ESM_CLOSE close markers" >&2
+elif [ "$CJS_OPEN" -ne "$CJS_CLOSE" ]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: 13a CJS template has $CJS_OPEN open markers vs $CJS_CLOSE close markers" >&2
+elif [ "$ESM_OPEN" -ne "$CJS_OPEN" ]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: 13a ESM/CJS templates drifted (ESM: $ESM_OPEN markers, CJS: $CJS_OPEN markers)" >&2
+else
+  echo "PASS: 13a ESM/CJS template markers balanced + matched ($ESM_OPEN open + $ESM_OPEN close in each)"
+  PASS=$((PASS + 1))
+fi
+
+# Render-level guard: run template_substitution::render on each template
+# under every load-bearing facts combination from the manifest. Render
+# success (rc=0) is the actual proof that the markers parse cleanly. We
+# don't byte-compare ESM vs CJS bodies here — the import/export shape
+# differs by design — but a render failure on either file is a regression
+# that would have caught the orphan-`<<<` bug.
+RENDER_CASES=(
+  "react"                    # ffb / dpr / matchline / swipewatch family
+  "react typescript"         # matchline
+  "typescript"               # nathanpaynedotcom (Astro+TS subset)
+  "astro typescript"         # nathanpaynedotcom full
+  ""                         # swipewatch + overridebroadway (no frameworks)
+)
+RENDER_FAIL=0
+for facts in "${RENDER_CASES[@]}"; do
+  for tpl in "$ESM_TEMPLATE" "$CJS_TEMPLATE"; do
+    (
+      reset_facts
+      export MERGEPATH_FACT_FRAMEWORKS="$facts"
+      # shellcheck disable=SC1090
+      source "$LIB"
+      template_substitution::render "$tpl" >/dev/null 2>&1
+    ) || {
+      RENDER_FAIL=1
+      echo "FAIL: 13b render failed for $(basename "$tpl") with frameworks='$facts'" >&2
+    }
+  done
+done
+if [ "$RENDER_FAIL" -eq 0 ]; then
+  echo "PASS: 13b ESM + CJS templates render cleanly under all ${#RENDER_CASES[@]} fact combos"
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Bulk sync to [mergepath@b12e7d7](https://github.com/nathanjohnpayne/mergepath/commit/b12e7d76b79ba404b081670720846b2ada9fac87) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/lib/gh-retry-helpers.sh
  - scripts/coderabbit-wait.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/phase-4b-classifier.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_identity_check.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_op_preflight_check.sh
  - tests/test_helper_autosource.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_daily_feedback_rollup.sh
  - tests/test_template_substitution.sh
  - tests/test_export_consumer_facts.sh
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/daily-feedback-rollup.yml

## Kit paths synced
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.cjs.js)


Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@b12e7d7 HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.