### PR TITLE
sync: bulk reconcile to mergepath@ad704ab

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -259,7 +259,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install js-yaml
-        run: npm install js-yaml
+        run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
 
       - name: Check for conflicting reviews
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -366,7 +366,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install js-yaml
-        run: npm install js-yaml
+        run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
 
       - name: Check and dismiss
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install js-yaml
-        run: npm install js-yaml
+        run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
 
       - name: Audit merged PRs for review policy compliance
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -630,6 +630,19 @@ else
   echo "  FAIL: Dependabot auto-merge must check human-hold before queued work, --auto, and fallback squash (got $hold_recheck_count checks)" >&2
 fi
 
+echo "Workflow js-yaml install tests"
+for workflow in .github/workflows/agent-review.yml .github/workflows/pr-audit.yml; do
+  install_count=$(grep -Ec 'run: npm install .*js-yaml' "$workflow" || true)
+  safe_install_count=$(grep -Ec 'run: npm install .*--no-save .*--ignore-scripts .*--legacy-peer-deps .*js-yaml' "$workflow" || true)
+  if [ "$install_count" -gt 0 ] && [ "$install_count" = "$safe_install_count" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $workflow installs js-yaml without mutating package metadata or resolving peer deps"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: $workflow must install js-yaml with --no-save --ignore-scripts --legacy-peer-deps (safe=$safe_install_count total=$install_count)" >&2
+  fi
+done
+
 echo
 if [ "$fail" -gt 0 ]; then
   echo "check_workflow_parsers: $fail FAIL / $pass PASS" >&2


### PR DESCRIPTION
Bulk sync to [mergepath@ad704ab](https://github.com/nathanjohnpayne/mergepath/commit/ad704abd7f1abfc2e2c0e881c8f1ab435fb0005b) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/lib/gh-retry-helpers.sh
  - scripts/coderabbit-wait.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/phase-4b-classifier.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_identity_check.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_op_preflight_check.sh
  - tests/test_op_preflight_token_mode.sh
  - tests/test_helper_autosource.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_daily_feedback_rollup.sh
  - tests/test_template_substitution.sh
  - tests/test_export_consumer_facts.sh
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/daily-feedback-rollup.yml

## Kit paths synced
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.cjs.js)


Authoring-Agent: codex

## Self-Review
- Correctness: mirrors mergepath@ad704ab HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.