### PR TITLE
sync: bulk reconcile to mergepath@5c4bc76

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,10 +38,20 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
-      - name: Approve and merge patch/minor updates
+      - name: Approve and merge patch/minor + dev-dependency-group updates
+        # Single patch/minor updates, plus the `dev-dependencies` GROUP
+        # (whatever its highest bump — dev tooling major bumps are
+        # low-risk and still gated by CI-green + the reviewer-identity
+        # approval + the available_reviewers allowlist below). Grouped
+        # dev updates whose highest member is major were previously
+        # skipped here (update-type=major), fell through to a manual
+        # merge with no reviewer approval, and tripped the weekly audit
+        # (#374 Pattern A — matchline#245). Production groups + non-group
+        # major bumps still require manual review.
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.dependency-group == 'dev-dependencies'
         run: |
           set -euo pipefail
 
@@ -172,7 +182,26 @@ jobs:
               echo "::notice::PR carries human-hold immediately before fallback squash; skipping Dependabot auto-merge until the human removes the label."
               exit 0
             fi
-            gh pr merge --squash "$PR_URL"
+            # The immediate (no --auto) squash does NOT wait for CI. That's
+            # acceptable for single patch/minor bumps (the long-standing
+            # behavior), but the broadened dev-dependencies-group gate
+            # (#374) can route a semver-MAJOR group here — and the safety
+            # case for auto-merging dev groups is explicitly "CI is green".
+            # Merging a major group before CI in a no-branch-protection
+            # repo would break that (Codex P2 on #405). So only
+            # immediate-squash patch/minor; for anything else (a major dev
+            # group) leave the PR APPROVED but unmerged — --auto will merge
+            # it once branch protection/required checks are configured, or a
+            # human merges after CI. The approval is already recorded, so
+            # the weekly audit's "no reviewer approval" gate is satisfied
+            # either way.
+            if [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || \
+               [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
+              gh pr merge --squash "$PR_URL"
+            else
+              echo "::notice::update-type='$UPDATE_TYPE' (dependency-group='$DEPENDENCY_GROUP') is not patch/minor and --auto is unavailable; leaving the PR approved-but-unmerged to preserve the CI-green safety case. Configure branch protection/auto-merge or merge manually after CI."
+              exit 0
+            fi
           else
             echo "::error::gh pr merge --auto failed for a non-auto-merge-unavailable reason. See stderr above. Not falling back to immediate squash; surface to audit."
             exit "$AUTO_RC"
@@ -185,4 +214,8 @@ jobs:
           # Dependabot PR is never `nathanjohnpayne`). (CodeRabbit
           # Major, #271.)
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          # Dependabot metadata — used by the immediate-squash fallback to
+          # keep major dev-group bumps behind CI (#374 / Codex P2 on #405).
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}
           GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -84,6 +84,35 @@ if [ "${MERGEPATH_RUN_INTEGRATION:-0}" != "1" ]; then
   exit 0
 fi
 
+# mergepath-specific gate (#398). This is an integration test for
+# mergepath's OWN scripts/firebase/op-firebase-deploy, which is NOT
+# propagated (mergepath-canonical). The scripts/ci/ KIT does propagate,
+# so this check ships to consumers — but downstream it would FAIL under
+# MERGEPATH_RUN_INTEGRATION=1 against a consumer's own/stale deploy
+# script (the #398 / Codex P2 on tadlockpsychiatry#68). Identify the
+# canonical repo by its FULL owner/repo SLUG, not a file marker (a
+# bootstrap-mirrored consumer can transiently carry copied files — Codex
+# P2 on #405) and not a bare repo name (a different owner's fork named
+# `*/mergepath` must NOT run this check against its own deploy script —
+# Codex r2 on #405). In CI GITHUB_REPOSITORY is authoritative; locally
+# fall back to the origin remote. If neither resolves (no remote / no
+# env) the slug is empty → SKIP, the safe default for a mergepath-only
+# check we can't confirm we're running in.
+CANONICAL_REPO="${MERGEPATH_CANONICAL_REPO:-nathanjohnpayne/mergepath}"
+REPO_SLUG="${GITHUB_REPOSITORY:-}"
+if [ -z "$REPO_SLUG" ]; then
+  # `|| true`: in a worktree with no `origin` remote, `git config --get`
+  # exits 1; under `set -euo pipefail` that would ABORT the assignment
+  # instead of falling through to the empty-slug skip below (Codex P2 on
+  # #405). Swallow it so REPO_SLUG ends up empty → SKIP (the safe default).
+  REPO_SLUG=$(git -C "$REPO_ROOT" config --get remote.origin.url 2>/dev/null \
+    | sed -E 's#\.git$##; s#^.*[:/]([^/]+/[^/]+)$#\1#' || true)
+fi
+if [ "$REPO_SLUG" != "$CANONICAL_REPO" ]; then
+  echo "check_op_firebase_deploy_integration: SKIPPED — repo '${REPO_SLUG:-unknown}' is not the canonical $CANONICAL_REPO; this integration check exercises mergepath-only scripts/firebase/op-firebase-deploy."
+  exit 0
+fi
+
 DEPLOY_SCRIPT="$REPO_ROOT/scripts/firebase/op-firebase-deploy"
 if [ ! -x "$DEPLOY_SCRIPT" ]; then
   echo "check_op_firebase_deploy_integration: FAIL — $DEPLOY_SCRIPT not found or not executable" >&2

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -447,35 +447,39 @@ TRIGGER_POST_TIME=""
 if has_cleared_signal "$INITIAL_SCAN"; then
   log "Codex has already cleared on HEAD (reaction or no-P0/P1 review) — skipping trigger comment"
 else
-  # Identity check (#284): `gh pr comment` is a keyring-byline write
-  # — fail closed BEFORE posting if the keyring drifted from the
-  # agent's reviewer identity. Opt-out via
-  # CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 for test harnesses.
-  #
-  # r3 (#284): fail CLOSED if the helper is missing or non-executable.
-  # The previous shape ANDed the opt-out and `[ -x "$CHECKER" ]` so a
-  # rename / delete / chmod -x silently skipped the gate. Helper
-  # presence is now a hard error inside the opt-out branch.
-  if [ "${CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
-    CHECKER="$(dirname "${BASH_SOURCE[0]}")/identity-check.sh"
-    if [ ! -x "$CHECKER" ]; then
-      echo "ERROR: identity-check helper missing or non-executable: $CHECKER" >&2
-      echo "       Refusing to post '@codex review' without identity verification." >&2
+  # The Codex GitHub App ONLY monitors '@codex review' comments authored
+  # by the repo's AUTHOR/human identity (nathanjohnpayne). A trigger
+  # posted by a reviewer/bot identity (nathanpayne-claude/-codex/-cursor)
+  # is silently ignored: empirically a reviewer-posted trigger sat
+  # unanswered to the full 600s timeout while an author-posted one drew a
+  # Codex review in ~20s (PR #405). `gh pr comment` is a keyring-byline
+  # write, so post it through gh-as-author.sh, which switches the keyring
+  # to nathanjohnpayne for the write (verifying the switch landed) and
+  # restores the prior active account on exit. This SUPERSEDES the #284
+  # `identity-check --expect-reviewer` guard, which fail-closed on the
+  # WRONG identity for this particular write. Opt out via
+  # CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 for test harnesses that
+  # PATH-shim gh (the stub records argv; no real keyring switch).
+  log "posting '@codex review' trigger comment (as author identity nathanjohnpayne)"
+  if [ "${CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK:-0}" = "1" ]; then
+    POST_OUTPUT=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+      || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  else
+    AS_AUTHOR="$(dirname "${BASH_SOURCE[0]}")/gh-as-author.sh"
+    if [ ! -x "$AS_AUTHOR" ]; then
+      echo "ERROR: gh-as-author.sh helper missing or non-executable: $AS_AUTHOR" >&2
+      echo "       Refusing to post '@codex review' without author-identity attribution" >&2
+      echo "       (Codex ignores reviewer/bot-authored triggers — see comment above)." >&2
       echo "       Restore the helper, or opt out via" >&2
       echo "       CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 (dev only)." >&2
-      die 3 "identity-check helper unavailable"
+      die 3 "gh-as-author.sh helper unavailable"
     fi
-    "$CHECKER" --expect-reviewer \
-      || die 3 "identity-check failed before posting '@codex review'; see stderr above."
+    # Capture stdout+stderr so a failure surfaces the real gh error
+    # (404 / 403 / 422) rather than a bare "failed to post". The comment
+    # URL gh prints on success is still extractable downstream.
+    POST_OUTPUT=$("$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+      || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   fi
-  log "posting '@codex review' trigger comment"
-  # Capture stderr (and stdout) into a diagnostic variable so a failure
-  # here surfaces the actual gh error — e.g. "404" from a nonexistent
-  # PR, "403" from a token without comment scope, or "422" from a closed
-  # PR — rather than a bare "failed to post". CodeRabbit non-blocking
-  # note on PR #64.
-  POST_OUTPUT=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
-    || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
   TRIGGER_POSTED=true
   # Capture the post time so the poll loop can ignore stale signals
   # that were already on HEAD before the trigger fired. Without this,


### PR DESCRIPTION
Bulk sync to [mergepath@5c4bc76](https://github.com/nathanjohnpayne/mergepath/commit/5c4bc7662ceca90afccd8f4d411a95b38c30bea8) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/lib/gh-retry-helpers.sh
  - scripts/coderabbit-wait.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/phase-4b-classifier.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_identity_check.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_op_preflight_check.sh
  - tests/test_op_preflight_token_mode.sh
  - tests/test_helper_autosource.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_daily_feedback_rollup.sh
  - tests/test_template_substitution.sh
  - tests/test_export_consumer_facts.sh
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/daily-feedback-rollup.yml

## Kit paths synced
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.cjs.js)


Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@5c4bc76 HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.