### PR TITLE
sync: bulk reconcile to mergepath@cc3487a

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report broken behavior with enough context to reproduce and fix it
+title: ""
+labels: bug
+assignees: ""
+---
+
+## What broke
+
+Describe the broken behavior and who or what it affects.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+Describe what should have happened instead.
+
+## Actual behavior
+
+Describe what happened, including relevant logs, screenshots, or links.
+
+## Acceptance criteria
+
+- [ ] The bug is reproduced or the failure mode is otherwise confirmed.
+- [ ] The fix covers the reported behavior.
+- [ ] A regression test or equivalent verification is added when practical.
+
+## Notes / risks
+
+Add related context, suspected cause, rollout concerns, or follow-up risks.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,25 @@
+---
+name: Documentation
+about: Request a documentation addition, correction, or canonical-source update
+title: ""
+labels: documentation
+assignees: ""
+---
+
+## What to document
+
+Describe the missing, stale, or confusing documentation.
+
+## Source of truth
+
+Link the code, policy, issue, PR, or decision the documentation should match.
+
+## Acceptance criteria
+
+- [ ] The canonical document is updated.
+- [ ] Related quick-start, example, or policy references are checked for drift.
+- [ ] The updated text names any remaining assumptions or follow-up work.
+
+## Notes / risks
+
+Add migration concerns, affected consumers, or places likely to contain duplicate wording.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Propose a buildable change or workflow improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## What to build
+
+Describe the feature, workflow change, or improvement.
+
+## Acceptance criteria
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Open decisions
+
+- [ ] 
+
+## Notes / risks
+
+Add constraints, rollout concerns, affected consumers, or follow-up work.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,8 @@ Authoring-Agent: <!-- claude | codex | cursor -->
 - Call out any user-visible behavior or deployment notes.
 
 ## Testing
-- [ ] `npm test`
-- [ ] `npm run build`
+- [ ] Tests pass
+- [ ] Build succeeds
 - [ ] Manual verification completed when needed
 
 ## Self-Review

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -66,6 +66,15 @@ permissions:
   # nathanjohnpayne/matchline#233 (#306 propagation canary); see
   # #310 for the full repro + permission scope rationale.
   actions: read
+  # `issues: read` is required because codex-review-check.sh reads
+  # issues-scoped endpoints: /issues/{pr}/reactions (Codex 👍
+  # clearance) and /issues/{pr}/timeline (force-push anchor). On a
+  # restricted-default GITHUB_TOKEN an omitted scope defaults to
+  # `none`, so those reads 403 and the gate aborts with rc=3,
+  # leaving `needs-external-review` stuck even after Codex clears.
+  # Same class as the merge-clearance-gate.yml fix on PR #429; see
+  # #431.
+  issues: read
   # `checks: write` is required so the "Surface infra failure as
   # check-run" step (#324) can POST a failed check-run to the PR's
   # checks tab when this workflow hits an infrastructure error

--- a/.github/workflows/codex-p1-gate.yml
+++ b/.github/workflows/codex-p1-gate.yml
@@ -233,9 +233,15 @@ jobs:
                 ;;
             esac
 
-            # Truncate the summary to ~60KB to stay well under
-            # GitHub's 65535-char limit on check_run.output.summary.
-            summary=$(printf '%s\n' "$output" | head -c 60000)
+            # Truncate to stay under GitHub's 65535-char summary limit.
+            # Bash slice, NOT `printf | head -c`: under `set -euo pipefail`
+            # a >60KB output makes head close the pipe early, printf takes
+            # SIGPIPE (141), pipefail propagates it, and `summary=$(...)`
+            # aborts the sweep BEFORE the check_run POST — fail-open on the
+            # UI-resolve path this sweep exists to close. Slicing is
+            # pipefail-safe + char-based (same fix as merge-clearance-gate.yml;
+            # Codex P2 on the b10671e propagation wave).
+            summary="${output:0:60000}"
 
             # Posting the check_run IS the sweep's whole purpose —
             # it's what supersedes the stale red required-check after

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -250,7 +250,15 @@ jobs:
                 ;;
             esac
 
-            summary=$(printf '%s\n' "$output" | head -c 60000)
+            # Truncate to stay under GitHub's 65535-char summary limit.
+            # Bash slice, NOT `printf | head -c`: under `set -euo pipefail`
+            # a >60KB output makes head close the pipe early, printf takes
+            # SIGPIPE (141), pipefail propagates it, and `summary=$(...)`
+            # aborts the sweep BEFORE the check_run POST — fail-open on the
+            # very no-event path this sweep exists to close (Codex P2 on the
+            # b10671e propagation wave). Slicing is pipefail-safe + char-based
+            # (correct for the char-limit).
+            summary="${output:0:60000}"
 
             # Posting the check_run IS the sweep's whole purpose — it's
             # what supersedes the stale required-check after a no-event

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -101,6 +101,15 @@ jobs:
           #   1. config (enabled / branch_prefix / author_identity) is
           #      read from the BASE commit's review-policy.yml — a PR
           #      cannot self-qualify by editing policy in the PR.
+          #      The lane defaults ON when the propagation_prs block is
+          #      absent (mergepath#434): the enable flag lived only in
+          #      consumer review-policy.yml, which is intentionally NOT
+          #      synced, so no consumer ever had the block and the lane
+          #      was dormant fleet-wide. An explicit `enabled: false`
+          #      remains the opt-out. The default adds no new trust —
+          #      recognition is still gated on the byte-level verify in
+          #      step 3, and a PR cannot grant itself the default
+          #      because it cannot edit its own BASE commit.
           #   2. branch name must start with propagation_prs.branch_prefix
           #      and PR author must be author_identity.
           #   3. the <sha> in the branch name (mergepath-sync/[sync-all-]
@@ -137,7 +146,12 @@ jobs:
             : > "$BASE_POLICY"   # absent on base → lane simply won't match
           fi
           PROP_ENABLED=$(prop_field "$BASE_POLICY" propagation_prs enabled)
+          # Default ON when the key/block is absent (mergepath#434);
+          # explicit `enabled: false` opts out.
+          PROP_ENABLED=${PROP_ENABLED:-true}
           PROP_PREFIX=$(prop_field "$BASE_POLICY" propagation_prs branch_prefix)
+          # Must match SYNC_BRANCH_PREFIX in scripts/sync-to-downstream.sh.
+          PROP_PREFIX=${PROP_PREFIX:-mergepath-sync/}
           AUTHOR_ID=$(grep -m1 '^author_identity:' "$BASE_POLICY" | awk '{print $2}')
           HEAD_REF="${{ github.event.pull_request.head.ref }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"

--- a/scripts/audit-propagation-lane.sh
+++ b/scripts/audit-propagation-lane.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# scripts/audit-propagation-lane.sh
+#
+# Regression net for the propagation PR review lane (#434, Option 3).
+#
+# The lane defaults ON in the synced pr-review-policy.yml workflow, but
+# three per-consumer preconditions can still silently disable it — and
+# a file-level drift audit alone can't see them together:
+#
+#   1. the consumer's live default branch carries the default-ON lane
+#      code in .github/workflows/pr-review-policy.yml (a consumer that
+#      has not received the #434 sync still requires an explicit
+#      propagation_prs.enabled: true it does not have);
+#   2. the consumer's .github/review-policy.yml does not explicitly set
+#      propagation_prs.enabled: false (the intentional opt-out — valid,
+#      but it must be VISIBLE, not a surprise at the next sync wave);
+#   3. the consumer's .github/review-policy.yml has an author_identity
+#      (the lane's PR-author fingerprint check requires it).
+#
+# For each consumer in .mergepath-sync.yml, this script reads BOTH
+# files from the consumer's live default branch via the GitHub contents
+# API and reports lane status. Any consumer where the lane would NOT
+# fire fails the audit.
+#
+# Usage:
+#   scripts/audit-propagation-lane.sh                 # all consumers
+#   scripts/audit-propagation-lane.sh --repos r1,r2   # subset
+#   scripts/audit-propagation-lane.sh --check-files <review-policy.yml> <pr-review-policy.yml>
+#       Offline single-pair mode for tests: prints the same status line
+#       a live consumer would get, using local files instead of the API.
+#
+# Exit codes:
+#   0  lane fires on every audited consumer (explicit opt-outs included
+#      in output but reported as ⚠ and DO fail the audit — an opt-out
+#      should be acknowledged by --repos-excluding it from the audit
+#      invocation, keeping the intent visible in the caller).
+#   1  lane would not fire on at least one consumer.
+#   2  usage error / missing prerequisite.
+#   3  fetch error (could not read a consumer's live files).
+#
+# Bash 3.2 portable. Requires yq (mikefarah v4+) for manifest parsing
+# in live mode; --check-files mode needs no yq.
+
+set -euo pipefail
+
+err() { echo "ERROR: $*" >&2; }
+
+MANIFEST=".mergepath-sync.yml"
+
+# The marker that proves the default-ON lane code is present in a
+# consumer's synced workflow. Single-sourced here; the workflow carries
+# the literal.
+LANE_DEFAULT_MARKER='PROP_ENABLED=${PROP_ENABLED:-true}'
+
+# The branch prefix scripts/sync-to-downstream.sh actually uses for the
+# PRs it opens. A consumer whose review-policy.yml overrides
+# propagation_prs.branch_prefix to anything else has a lane that never
+# matches real sync branches — that's a would-not-fire condition, not a
+# healthy lane (Codex P2 on PR #444).
+SYNC_BRANCH_PREFIX='mergepath-sync/'
+
+# The actor scripts/sync-to-downstream.sh creates consumer PRs under.
+# The lane's fingerprint requires PR author == the consumer's
+# author_identity, so a present-but-wrong value (typo, stale identity,
+# stray quoting that survives the same grep/awk extraction the lane
+# uses) means the lane never matches a real sync PR (Codex P2 on
+# PR #444 r3).
+SYNC_AUTHOR_IDENTITY='nathanjohnpayne'
+
+# Read a 2-space-indented scalar from a named YAML block — same
+# state-machine awk as pr-review-policy.yml's prop_field, so this audit
+# evaluates the exact predicate the lane evaluates.
+prop_field() {  # <file> <block> <key>
+  awk -v blk="$2" -v key="$3" '
+    $0 ~ "^" blk ":" { in_blk = 1; next }
+    in_blk && /^[^[:space:]#]/ { in_blk = 0 }
+    in_blk && $1 == key":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      sub(/[[:space:]]*#.*$/, "", $0)
+      gsub(/^"|"$/, "", $0)
+      print
+      exit
+    }
+  ' "$1"
+}
+
+# Evaluate the lane preconditions for one (review-policy, workflow)
+# file pair. Prints a status line; returns 0 if the lane fires, 1 if
+# not.
+lane_status_for_files() {  # <label> <policy-file-or-empty> <workflow-file-or-empty>
+  local label=$1 policy=$2 workflow=$3
+  local enabled author_id prefix
+
+  if [ -z "$workflow" ] || [ ! -f "$workflow" ]; then
+    echo "  ✗ $label: pr-review-policy.yml ABSENT on the live default branch — lane cannot fire"
+    return 1
+  fi
+  if ! grep -qF "$LANE_DEFAULT_MARKER" "$workflow"; then
+    echo "  ✗ $label: pr-review-policy.yml predates the #434 default-ON lane (marker '$LANE_DEFAULT_MARKER' missing) — lane requires an explicit enabled: true the consumer does not get; re-sync the workflow"
+    return 1
+  fi
+
+  enabled=""
+  author_id=""
+  prefix=""
+  if [ -n "$policy" ] && [ -f "$policy" ]; then
+    enabled=$(prop_field "$policy" propagation_prs enabled)
+    prefix=$(prop_field "$policy" propagation_prs branch_prefix)
+    author_id=$(grep -m1 '^author_identity:' "$policy" | awk '{print $2}' || true)
+  fi
+
+  if [ "$enabled" = "false" ]; then
+    echo "  ⚠ $label: propagation_prs.enabled: false — explicit opt-out; lane will NOT fire (exclude this consumer via --repos if intentional)"
+    return 1
+  fi
+  # The lane enters only when PROP_ENABLED is exactly 'true' after
+  # defaulting (absent → true). Any other present value — TRUE, False,
+  # typos — leaves the lane dark even though YAML may consider it a
+  # boolean; mirror the lane's exact-match semantics here (Codex P2 on
+  # PR #444 r4).
+  if [ -n "$enabled" ] && [ "$enabled" != "true" ]; then
+    echo "  ✗ $label: propagation_prs.enabled is '$enabled' — the lane only fires on exactly 'true' (or an absent key); normalize the value or remove the key"
+    return 1
+  fi
+  # An overridden branch_prefix that doesn't match what
+  # sync-to-downstream.sh actually opens means the lane never matches a
+  # real sync PR — report would-not-fire, not healthy (Codex P2 on
+  # PR #444). Absent defaults to the sync prefix, mirroring the lane.
+  if [ -n "$prefix" ] && [ "$prefix" != "$SYNC_BRANCH_PREFIX" ]; then
+    echo "  ✗ $label: propagation_prs.branch_prefix is '$prefix' but sync-to-downstream.sh opens '$SYNC_BRANCH_PREFIX*' branches — lane will never match a real sync PR"
+    return 1
+  fi
+  if [ -z "$author_id" ]; then
+    echo "  ✗ $label: review-policy.yml has no author_identity — the lane's PR-author fingerprint cannot match"
+    return 1
+  fi
+  if [ "$author_id" != "$SYNC_AUTHOR_IDENTITY" ]; then
+    echo "  ✗ $label: review-policy.yml author_identity is '$author_id' but sync PRs are authored by '$SYNC_AUTHOR_IDENTITY' — the lane's PR-author fingerprint will never match a real sync PR"
+    return 1
+  fi
+
+  if [ -z "$enabled" ]; then
+    echo "  ✓ $label: lane fires (default-ON, author_identity=$author_id)"
+  else
+    echo "  ✓ $label: lane fires (enabled: $enabled, author_identity=$author_id)"
+  fi
+  return 0
+}
+
+# --- offline test mode ------------------------------------------------------
+
+if [ "${1:-}" = "--check-files" ]; then
+  [ $# -eq 3 ] || { err "--check-files needs exactly two file arguments"; exit 2; }
+  if lane_status_for_files "check-files" "$2" "$3"; then
+    exit 0
+  fi
+  exit 1
+fi
+
+# --- live mode --------------------------------------------------------------
+
+FILTER_REPOS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repos)
+      [ -n "${2:-}" ] || { err "missing argument for --repos"; exit 2; }
+      FILTER_REPOS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      err "unknown argument: $1"
+      exit 2
+      ;;
+  esac
+done
+
+command -v yq >/dev/null 2>&1 || { err "yq is required (brew install yq)"; exit 2; }
+yq --version 2>&1 | grep -q "mikefarah/yq" || { err "mikefarah/yq v4+ required"; exit 2; }
+command -v gh >/dev/null 2>&1 || { err "gh is required"; exit 2; }
+[ -f "$MANIFEST" ] || { err "$MANIFEST not found (run from the mergepath root)"; exit 2; }
+
+in_repo_filter() {
+  local name=$1
+  [ -z "$FILTER_REPOS" ] && return 0
+  case ",$FILTER_REPOS," in
+    *",$name,"*) return 0 ;;
+  esac
+  return 1
+}
+
+fetch_live_file() {  # <repo> <path> <dest>; returns 0 fetched, 1 absent (404), 3 error
+  local repo=$1 path=$2 dest=$3 rc=0 out
+  out=$(gh api "repos/$repo/contents/$path" --jq '.content' 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    case "$out" in
+      *"Not Found"*|*"404"*) return 1 ;;
+      *) err "$repo: could not fetch $path: $out"; return 3 ;;
+    esac
+  fi
+  printf '%s' "$out" | base64 -d > "$dest" 2>/dev/null || { err "$repo: could not decode $path"; return 3; }
+  return 0
+}
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/lane-audit.XXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+
+LANE_BROKEN=0
+FETCH_ERROR=0
+
+echo "Propagation lane audit (#434) — live default-branch preconditions per consumer"
+
+while IFS=$'\t' read -r consumer_name consumer_repo; do
+  [ -z "$consumer_name" ] && continue
+  in_repo_filter "$consumer_name" || continue
+
+  policy_file="$WORKDIR/$consumer_name-policy.yml"
+  workflow_file="$WORKDIR/$consumer_name-workflow.yml"
+
+  rc=0
+  fetch_live_file "$consumer_repo" ".github/review-policy.yml" "$policy_file" || rc=$?
+  if [ "$rc" -eq 3 ]; then FETCH_ERROR=1; continue; fi
+  [ "$rc" -eq 1 ] && policy_file=""
+
+  rc=0
+  fetch_live_file "$consumer_repo" ".github/workflows/pr-review-policy.yml" "$workflow_file" || rc=$?
+  if [ "$rc" -eq 3 ]; then FETCH_ERROR=1; continue; fi
+  [ "$rc" -eq 1 ] && workflow_file=""
+
+  if ! lane_status_for_files "$consumer_name" "$policy_file" "$workflow_file"; then
+    LANE_BROKEN=1
+  fi
+done <<EOF
+$(yq -r '.consumers[] | (.name + "\t" + .repo)' "$MANIFEST")
+EOF
+
+if [ "$FETCH_ERROR" -eq 1 ]; then
+  echo "Propagation lane audit: FETCH ERROR (one or more consumers unreadable)"
+  exit 3
+fi
+if [ "$LANE_BROKEN" -eq 1 ]; then
+  echo "Propagation lane audit: FAIL (lane would not fire on at least one consumer)"
+  exit 1
+fi
+echo "Propagation lane audit: PASS (lane fires on every audited consumer)"
+exit 0

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -208,7 +208,13 @@ perm_block=$(
 # expected set below now codifies the single-key shape so re-adding
 # `checks: read` fails this check instead of silently breaking the
 # workflow at runtime.
-expected_perms=$'actions: read\nchecks: write\ncontents: read\npull-requests: write'
+# `issues: read` added in #431 — codex-review-check.sh reads
+# /issues/{pr}/reactions (Codex 👍 clearance) and
+# /issues/{pr}/timeline (force-push anchor). On restricted-default
+# GITHUB_TOKEN repos an omitted scope is `none`, those reads 403,
+# and the gate aborts rc=3 with `needs-external-review` stuck. Same
+# class as the merge-clearance-gate.yml `issues: read` fix (#429).
+expected_perms=$'actions: read\nchecks: write\ncontents: read\nissues: read\npull-requests: write'
 if [ "$perm_block" = "$expected_perms" ]; then
   pass=$((pass + 1))
   echo "  PASS: workflow permissions exactly match the least-privilege set"

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -223,13 +223,15 @@ run_filter() {
   #   $1 = jq filter (gate-b form or gate-c form)
   #   $2 = author login
   #   $3 = same_agent_reviewer login (may be empty)
-  #   $4 = sha (only used by gate-c form; harmless for gate-b)
+  #   $4 = sha (gate-c form, and gate-b HEAD-pin)
   #   $5 = reviews_json
+  #   $6 = require_head ("1" to HEAD-pin gate-b branch 1; default "0")
   echo "$5" | jq -r \
     --argjson reviewers "$REVIEWERS_JSON" \
     --arg author "$2" \
     --arg same_agent_reviewer "$3" \
     --arg sha "$4" \
+    --arg require_head "${6:-0}" \
     "$1"
 }
 
@@ -242,7 +244,7 @@ GATE_B_FILTER='
   ]
   | group_by(.user.login)
   | map(max_by(.submitted_at))
-  | map(select(.state == "APPROVED"))
+  | map(select(.state == "APPROVED" and ($require_head != "1" or .commit_id == $sha)))
   | first
   | if . == null then empty else .user.login end
 '
@@ -364,6 +366,66 @@ if [ -z "$got" ]; then
 else
   fail=$((fail + 1))
   echo "  FAIL: gate (b) used stale APPROVED instead of latest CHANGES_REQUESTED — got '$got'" >&2
+fi
+
+# Case F (#435): cross-agent APPROVED on a STALE commit (not HEAD).
+#   require_head=1 (merge-clearance-gate delegation) → gate (b) rejects it,
+#   so a stale approval can't ride a later push to clearance.
+#   require_head=0 (default / auto-clear path) → accepted, preserving the
+#   existing non-HEAD-pinned behavior.
+REVIEWS_F='[
+  {"user":{"login":"nathanpayne-codex"},"state":"APPROVED","commit_id":"OLDsha999","submitted_at":"2026-05-15T10:00:00Z"}
+]'
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_F" 1)
+if [ -z "$got" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) HEAD-pin rejects stale-commit APPROVED when require_head=1 (#435)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) HEAD-pin accepted stale-commit APPROVED — got '$got'" >&2
+fi
+
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_F" 0)
+if [ "$got" = "nathanpayne-codex" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) default (require_head=0) still accepts stale-commit APPROVED (no regression)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) default path changed behavior — got '$got'" >&2
+fi
+
+# Case G (#435): cross-agent APPROVED ON the current HEAD with require_head=1
+#   → accepted. Confirms HEAD-pin only blocks stale approvals, not fresh ones.
+REVIEWS_G='[
+  {"user":{"login":"nathanpayne-codex"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"}
+]'
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_G" 1)
+if [ "$got" = "nathanpayne-codex" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) HEAD-pin accepts APPROVED on current HEAD when require_head=1 (#435)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) HEAD-pin rejected fresh on-HEAD APPROVED — got '$got'" >&2
+fi
+
+# Case H (#436 Codex P1): reviewer APPROVED on HEAD, then later
+# CHANGES_REQUESTED on a stale/pending non-HEAD commit. Their LATEST
+# opinionated state is CHANGES_REQUESTED, so gate (b) must REJECT — even with
+# require_head=1. Filtering non-HEAD reviews BEFORE the latest-state collapse
+# (the original buggy fix) would discard the blocking CHANGES_REQUESTED and
+# wrongly clear via the stale on-HEAD APPROVED.
+REVIEWS_H='[
+  {"user":{"login":"nathanpayne-codex"},"state":"APPROVED","commit_id":"abc123","submitted_at":"2026-05-15T10:00:00Z"},
+  {"user":{"login":"nathanpayne-codex"},"state":"CHANGES_REQUESTED","commit_id":"OLDsha999","submitted_at":"2026-05-15T12:00:00Z"}
+]'
+got=$(run_filter "$GATE_B_FILTER" "nathanjohnpayne" "nathanpayne-claude" "$HEAD_SHA" "$REVIEWS_H" 1)
+if [ -z "$got" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: gate (b) HEAD-pin honors a LATER non-HEAD CHANGES_REQUESTED over a stale on-HEAD APPROVED (#436)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gate (b) discarded the later CHANGES_REQUESTED and cleared via stale APPROVED — got '$got'" >&2
 fi
 
 echo

--- a/scripts/ci/check_coderabbit_wait
+++ b/scripts/ci/check_coderabbit_wait
@@ -4,18 +4,25 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-TEST="$REPO_ROOT/tests/test_coderabbit_wait_status_probe.sh"
+TESTS=(
+  "$REPO_ROOT/tests/test_coderabbit_wait_status_probe.sh"
+  "$REPO_ROOT/tests/test_coderabbit_wait_identity_derivation.sh"
+)
 
 if [ ! -x "$REPO_ROOT/scripts/coderabbit-wait.sh" ]; then
   echo "check_coderabbit_wait: ERROR scripts/coderabbit-wait.sh missing or not executable" >&2
   exit 1
 fi
 
-if [ ! -x "$TEST" ]; then
-  echo "check_coderabbit_wait: ERROR $TEST missing or not executable" >&2
-  exit 1
-fi
+for TEST in "${TESTS[@]}"; do
+  if [ ! -x "$TEST" ]; then
+    echo "check_coderabbit_wait: ERROR $TEST missing or not executable" >&2
+    exit 1
+  fi
+done
 
 echo "check_coderabbit_wait: running coderabbit-wait status-probe tests"
-"$TEST"
+"${TESTS[0]}"
+echo "check_coderabbit_wait: running coderabbit-wait identity-derivation tests (#438)"
+"${TESTS[1]}"
 echo "check_coderabbit_wait: PASS"

--- a/scripts/ci/check_propagation_lane_audit
+++ b/scripts/ci/check_propagation_lane_audit
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# check_propagation_lane_audit
+#
+# CI wrapper for scripts/audit-propagation-lane.sh (#434). Runs the
+# offline --check-files test matrix, which also pins the audit's
+# default-ON marker to the literal actually present in
+# .github/workflows/pr-review-policy.yml — so a lane-code edit that
+# silently breaks the audit's detection fails here instead of at the
+# next weekly drift run.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST="$REPO_ROOT/tests/test_audit_propagation_lane.sh"
+
+if [ ! -f "$REPO_ROOT/scripts/audit-propagation-lane.sh" ]; then
+  echo "check_propagation_lane_audit: ERROR scripts/audit-propagation-lane.sh missing" >&2
+  exit 1
+fi
+
+if [ ! -f "$TEST" ]; then
+  echo "check_propagation_lane_audit: ERROR $TEST missing" >&2
+  exit 1
+fi
+
+echo "check_propagation_lane_audit: running propagation-lane audit tests"
+bash "$TEST"
+echo "check_propagation_lane_audit: PASS"

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -166,7 +166,23 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 3
 fi
 
-EXPECTED_REVIEWER_IDENTITY="$(gh_default_reviewer_identity)"
+# Expected reviewer identity for helper-comment writes. When any of
+# the explicit identity envs is set, honor it via
+# gh_default_reviewer_identity. Otherwise — e.g. agent-review.yml
+# passes only `GH_TOKEN: secrets.REVIEWER_ASSIGNMENT_TOKEN` with no
+# MERGEPATH_AGENT / OP_PREFLIGHT_AGENT / GH_AS_REVIEWER_IDENTITY —
+# leave it empty so verify_reviewer_write_identity derives the
+# expected login from the token itself, constrained to
+# available_reviewers (#438). The old behavior hard-defaulted to
+# nathanpayne-claude, so a repo whose REVIEWER_ASSIGNMENT_TOKEN is a
+# different allowed reviewer failed identity verification before
+# posting a retry/status-probe comment — a rate-limited CodeRabbit
+# run then exited as infra error instead of retrying.
+if [ -n "${GH_AS_REVIEWER_IDENTITY:-}" ] || [ -n "${MERGEPATH_AGENT:-}" ] || [ -n "${OP_PREFLIGHT_AGENT:-}" ]; then
+  EXPECTED_REVIEWER_IDENTITY="$(gh_default_reviewer_identity)"
+else
+  EXPECTED_REVIEWER_IDENTITY=""   # derived lazily from the token at write time
+fi
 
 gh_reviewer() (
   unset GITHUB_TOKEN
@@ -199,6 +215,29 @@ coderabbit_field() {
       }
     }
   ' "$CONFIG"
+}
+
+# Read the available_reviewers list (one login per line). Same
+# state-machine awk pattern as codex-review-check.sh's reader; handles
+# quoted and unquoted list items. Used by the token-derived expected-
+# identity path (#438) to keep the derivation fail-closed: only a
+# login on this allow-list may become the expected reviewer.
+read_available_reviewers() {
+  [ -f "$CONFIG" ] || return 0
+  awk '
+    /^available_reviewers:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && /^ *-/ {print}
+  ' "$CONFIG" | sed -E "s/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]+#.*\$//; s/^[\"']//; s/[\"']\$//; s/[[:space:]]+\$//"
+}
+
+login_is_available_reviewer() {
+  local login=$1 reviewer
+  [ -n "$login" ] || return 1
+  while IFS= read -r reviewer; do
+    [ "$reviewer" = "$login" ] && return 0
+  done <<< "$(read_available_reviewers)"
+  return 1
 }
 
 MAX_WAIT_SECONDS=$(coderabbit_field max_wait_seconds)
@@ -724,6 +763,25 @@ verify_reviewer_write_identity() {
       echo "       Restore the helper, or opt out via" >&2
       echo "       CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 (dev only)." >&2
       return 1
+    fi
+    # Lazy token-derived expected identity (#438): no explicit identity
+    # env was set at startup, so derive the expected login from the
+    # token that will sign this write — constrained to
+    # available_reviewers. An unconstrained derivation would make the
+    # check below a tautology; the allow-list keeps it fail-closed: a
+    # non-reviewer token falls back to the static default and fails
+    # verification exactly as before. Derived here (write time) rather
+    # than at startup so read-only runs never pay the extra API call.
+    if [ -z "$EXPECTED_REVIEWER_IDENTITY" ]; then
+      local token_login
+      token_login=$(gh_reviewer api user --jq .login 2>/dev/null || true)
+      if login_is_available_reviewer "$token_login"; then
+        EXPECTED_REVIEWER_IDENTITY="$token_login"
+        log "derived expected reviewer identity '$token_login' from GH_TOKEN (allow-listed in available_reviewers)"
+      else
+        EXPECTED_REVIEWER_IDENTITY="$(gh_default_reviewer_identity)"
+        log "GH_TOKEN login '${token_login:-<unresolvable>}' is not in available_reviewers; falling back to default expected reviewer '$EXPECTED_REVIEWER_IDENTITY'"
+      fi
     fi
     GH_TOKEN="$GH_TOKEN" "$checker" --expect-token-identity "$EXPECTED_REVIEWER_IDENTITY" \
       || return 1

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -268,6 +268,22 @@ if [ "${CODEX_REVIEW_CHECK_SKIP_CI:-}" = "1" ]; then
   REQUIRE_CI_GREEN=false
 fi
 
+# Per-invocation gate-(b) HEAD-pin override (#435, the #427/#428 class one
+# layer deeper). By default gate (b) branch 1 accepts each reviewer's
+# latest-state APPROVED on ANY commit — so a reviewer's approval of an
+# earlier head can survive a later push and clear gate (b) while gate (c)
+# clears via a fresh on-HEAD Codex signal, merging a HEAD the reviewer never
+# approved. When this is "1", gate (b) branch 1 additionally requires the
+# APPROVED to be on the current HEAD (commit_id == HEAD_SHA), matching the
+# gate-(c) Phase-4b-substitute's HEAD pinning. scripts/merge-clearance-gate.sh
+# sets it so its REQUIRED check is fully HEAD-pinned (reviewer + Codex/Phase-4b
+# both on HEAD). Unset (default) preserves the auto-clear path's behavior,
+# where branch-protection dismiss_stale_reviews is the intended control.
+REQUIRE_APPROVAL_ON_HEAD=0
+if [ "${CODEX_REVIEW_CHECK_REQUIRE_APPROVAL_ON_HEAD:-}" = "1" ]; then
+  REQUIRE_APPROVAL_ON_HEAD=1
+fi
+
 # Honor codex.allow_phase_4b_substitute. When true (default), gate (c)
 # also accepts an APPROVED review on the current HEAD from an
 # available_reviewers identity != the PR author as a Codex-equivalent
@@ -743,7 +759,9 @@ REVIEWERS_JSON=$(echo "$REVIEWERS" | jq -R . | jq -s .)
 APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
   --argjson reviewers "$REVIEWERS_JSON" \
   --arg author "$PR_AUTHOR" \
-  --arg same_agent_reviewer "$SAME_AGENT_REVIEWER" '
+  --arg same_agent_reviewer "$SAME_AGENT_REVIEWER" \
+  --arg sha "$HEAD_SHA" \
+  --arg require_head "$REQUIRE_APPROVAL_ON_HEAD" '
     [ .[]
       | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
       | select(.user.login as $u | $reviewers | index($u))
@@ -752,7 +770,13 @@ APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
     ]
     | group_by(.user.login)
     | map(max_by(.submitted_at))
-    | map(select(.state == "APPROVED"))
+    # Collapse to each reviewer'\''s LATEST opinionated state FIRST, then require
+    # that latest state to be APPROVED — and, when HEAD-pinned (#435), to be on
+    # the current HEAD. Filtering non-HEAD reviews BEFORE this collapse would
+    # discard a later blocking CHANGES_REQUESTED/DISMISSED on an outdated/pending
+    # commit and let a stale earlier APPROVED still clear gate (b). (Codex P1 on
+    # PR #436.)
+    | map(select(.state == "APPROVED" and ($require_head != "1" or .commit_id == $sha)))
     | first
     | if . == null then empty else .user.login end
 ')

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -185,6 +185,32 @@ codex_field() {
   ' "$CONFIG"
 }
 
+# Extract a top-level scalar (column-0 key, no enclosing block) from
+# review-policy.yml — e.g. author_identity. Same quoting/comment
+# tolerance as codex_field.
+policy_top_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^[^[:space:]#]/ && $1 == field":" {
+      sub(/^[^:]+:[[:space:]]*/, "", $0)
+      # Both YAML quote styles (Codex P2 on PR #442 r9) — matching the
+      # quote-tolerance of the gh-pr-guard expected-author parser.
+      gsub(/^["\x27]/, "", $0)
+      gsub(/["\x27][[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+# Author identity for the trigger comment write (#438): used to decide
+# whether an ambient GH_TOKEN may be bridged into gh-as-author.sh.
+AUTHOR_IDENTITY=$(policy_top_field author_identity)
+AUTHOR_IDENTITY=${AUTHOR_IDENTITY:-nathanjohnpayne}
+
 TIMEOUT_SECONDS=$(codex_field review_timeout_seconds)
 TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-600}
 if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
@@ -498,11 +524,44 @@ post_codex_trigger() {
     die 3 "gh-as-author.sh helper unavailable"
   fi
 
+  # Inline author-PAT bridging (#438): gh-as-author.sh's resolver
+  # intentionally ignores ambient GH_TOKEN — it reads only
+  # OP_PREFLIGHT_AUTHOR_PAT or a stored `gh auth token --user`. In a
+  # CI/fresh shell with no preflight cache and no keyring, the
+  # still-documented `GH_TOKEN=<author PAT> codex-review-request.sh`
+  # invocation shape passed every read-side check and then failed the
+  # trigger write despite holding a valid author token, forcing an
+  # unnecessary Phase 4b fallback. Bridge the ambient token into the
+  # wrapper's preferred env var ONLY after verifying it actually
+  # resolves to the author identity; any other token (the common
+  # reviewer-PAT session shape) is left alone so the wrapper's own
+  # resolution proceeds unchanged and fails closed as before.
+  BRIDGE_AUTHOR_PAT=""
+  if [ -n "${GH_TOKEN:-}" ] && [ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]; then
+    IDENTITY_CHECKER="$__CODEX_REQUEST_DIR/identity-check.sh"
+    if [ -x "$IDENTITY_CHECKER" ] \
+      && GH_TOKEN="$GH_TOKEN" "$IDENTITY_CHECKER" --expect-token-identity "$AUTHOR_IDENTITY" >/dev/null 2>&1; then
+      log "ambient GH_TOKEN verifies as author identity $AUTHOR_IDENTITY — bridging it into gh-as-author.sh as OP_PREFLIGHT_AUTHOR_PAT"
+      BRIDGE_AUTHOR_PAT="$GH_TOKEN"
+    fi
+  fi
+
   # Capture stdout+stderr so a failure surfaces the real gh error
   # (404 / 403 / 422) rather than a bare "failed to post". The comment
   # URL gh prints on success is still extractable downstream.
-  POST_OUTPUT=$("$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
-    || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  # Pass the configured author identity on BOTH invocation branches:
+  # the wrapper's hard default (nathanjohnpayne) would reject a valid
+  # custom-author token in repos that override author_identity —
+  # bridged-token case (Codex P2 on PR #442 r2) AND warm-preflight /
+  # keyring case (Codex P2 on PR #442 r5). review-policy.yml is the
+  # source of truth this script already reads, so it wins.
+  if [ -n "$BRIDGE_AUTHOR_PAT" ]; then
+    POST_OUTPUT=$(OP_PREFLIGHT_AUTHOR_PAT="$BRIDGE_AUTHOR_PAT" GH_AS_AUTHOR_IDENTITY="$AUTHOR_IDENTITY" "$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+      || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  else
+    POST_OUTPUT=$(GH_AS_AUTHOR_IDENTITY="$AUTHOR_IDENTITY" "$AS_AUTHOR" -- gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
+      || die 3 "failed to post '@codex review' comment: $POST_OUTPUT"
+  fi
   TRIGGER_POSTED=true
 
   # Capture the post time so the poll loop can ignore stale signals

--- a/scripts/gh-as-author.sh
+++ b/scripts/gh-as-author.sh
@@ -33,6 +33,29 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 AUTHOR="${GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
 
+# Runtime byline pin (#438): this check runs IN the wrapper process,
+# whose environment is the actual one the write will use — unlike the
+# PreToolUse hook's static command-line analysis, it cannot be evaded
+# by shell environment manipulation (env -u/-i, unset, export forms,
+# eval'd assignments). If the repo declares author_identity in
+# review-policy.yml, the resolved AUTHOR must match it; otherwise the
+# write would land under the wrong byline no matter which token
+# verifies.
+# Resolve the policy from the wrapper's own repo root, not the
+# caller's cwd — a subdirectory invocation must still load the pin
+# (Codex P2 on PR #442 r20). $ROOT is computed from BASH_SOURCE at
+# the top of this script; in consumers the wrapper is synced into the
+# repo it writes to, so script root == target repo root.
+WRAPPER_POLICY_AUTHOR=""
+if [ -f "$ROOT/.github/review-policy.yml" ]; then
+  WRAPPER_POLICY_AUTHOR=$(grep -m1 '^author_identity:' "$ROOT/.github/review-policy.yml" | awk '{print $2}' | sed -E "s/^[\"']//; s/[\"']\$//" || true)
+fi
+if [ -n "$WRAPPER_POLICY_AUTHOR" ] && [ "$AUTHOR" != "$WRAPPER_POLICY_AUTHOR" ]; then
+  echo "gh-as-author: refusing to run as '$AUTHOR' — this repo's review-policy.yml declares author_identity: $WRAPPER_POLICY_AUTHOR (#438 runtime byline pin)." >&2
+  echo "gh-as-author: unset GH_AS_AUTHOR_IDENTITY (or set it to $WRAPPER_POLICY_AUTHOR)." >&2
+  exit 2
+fi
+
 [ "${1:-}" = "--" ] && shift
 
 if [ "$#" -eq 0 ]; then

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -367,7 +367,7 @@ prefix_flag_takes_value() {
     ionice:-c|ionice:-n|ionice:-p)
       return 0
       ;;
-    env:-u|env:-S)
+    env:-u|env:-S|env:--unset)
       return 0
       ;;
   esac
@@ -375,6 +375,29 @@ prefix_flag_takes_value() {
 }
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD_REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
+
+# Locate the governing review-policy.yml without trusting the caller's
+# cwd to BE the repo root (Codex P2 on PR #442 r21): walk upward from
+# the cwd (covers subdirectory invocations and out-of-tree fixture
+# repos), then fall back to the hook's own repo root (the hook is
+# installed at <root>/scripts/hooks/, so script root == project root
+# in production). Echoes the path or nothing.
+guard_policy_file() {
+  local d="$PWD"
+  while [ -n "$d" ] && [ "$d" != "/" ]; do
+    if [ -f "$d/.github/review-policy.yml" ]; then
+      printf '%s\n' "$d/.github/review-policy.yml"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  if [ -f "$GUARD_REPO_ROOT/.github/review-policy.yml" ]; then
+    printf '%s\n' "$GUARD_REPO_ROOT/.github/review-policy.yml"
+    return 0
+  fi
+  return 1
+}
 REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
 CANON_AUTHOR_WRAPPER="$REPO_ROOT/scripts/gh-as-author.sh"
 CANON_REVIEWER_WRAPPER="$REPO_ROOT/scripts/gh-as-reviewer.sh"
@@ -601,6 +624,24 @@ INLINE_BREAK_GLASS_ADMIN=""
 INLINE_BREAK_GLASS_MERGE_STATE=""
 INLINE_GH_AS_AUTHOR_IDENTITY=""
 INLINE_GH_AS_REVIEWER_IDENTITY=""
+# Standalone (own-segment) identity assignments persist as shell
+# variables and — when the name already carries the export attribute in
+# the calling shell — ALSO reach later processes. The hook cannot see
+# the export attribute, so these are tracked separately as
+# possibly-effective candidates that the byline guards must validate
+# alongside the environment value (fail closed on the ambiguity).
+# Codex P1 on PR #442 r4.
+STANDALONE_GH_AS_AUTHOR_IDENTITY=""
+STANDALONE_GH_AS_REVIEWER_IDENTITY=""
+# Set-ness flags: an EMPTY assignment (`GH_AS_AUTHOR_IDENTITY= wrapper`)
+# is NOT absent — it resets the wrapper to its hardcoded default, which
+# in a custom-author repo differs from the expected author (Codex P1 on
+# PR #442 r15). Every capture records both the value and that an
+# assignment happened.
+INLINE_GH_AS_AUTHOR_IDENTITY_SET=0
+INLINE_GH_AS_REVIEWER_IDENTITY_SET=0
+STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=0
+STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=0
 GLOBAL_REPO=""
 PR_SUBCOMMAND=""
 PR_SUBCOMMAND_INDEX=-1    # index in TOKENS where the gh pr subcommand was found
@@ -613,6 +654,14 @@ AT_COMMAND_POSITION=1    # 1 = at command position, 0 = walking unrelated-comman
 SEGMENT_HAS_COMMAND=0    # 1 = this segment has seen a non-assignment command (echo, cat, etc.)
 SKIP_PREFIX_VALUE=0      # 1 = next token is the value of a prefix-command flag
 CURRENT_PREFIX=""        # name of the most recently seen prefix command (sudo/time/etc.)
+IN_EXPORT_SEGMENT=0      # 1 = current segment is an `export` command (its
+                         # assignment args reach all later processes)
+SEGMENT_HAS_EVAL=0       # 1 = current segment ran `eval` — an eval'd
+                         # assignment persists like a bare standalone
+PENDING_PREFIX_FLAG=""   # "<prefix>:<flag>" whose value the next token is
+                         # (lets the consumer recognize `env -u NAME`)
+IDENTITY_ENV_CLEARED_FOR_WRAPPER=0  # 1 = env -i seen: the wrapper sees an
+                         # EMPTY environment (no MERGEPATH_AGENT either)
 for i in "${!TOKENS[@]}"; do
   tok="${TOKENS[$i]}"
   # --- phase 2: walking after gh, looking for pr + subcommand ---
@@ -696,6 +745,24 @@ for i in "${!TOKENS[@]}"; do
   # straight to the actual command.
   if [ "$SKIP_PREFIX_VALUE" -eq 1 ]; then
     SKIP_PREFIX_VALUE=0
+    # `env -u NAME` removes NAME from the wrapped command's
+    # environment: for the identity variables that is exactly the
+    # r15 empty-override semantics — the wrapper falls back to its
+    # hardcoded default, which a custom-author repo must fail closed
+    # on (Codex P2 on PR #442 r17, env --help verified).
+    if [ "$PENDING_PREFIX_FLAG" = "env:-u" ] || [ "$PENDING_PREFIX_FLAG" = "env:--unset" ]; then
+      case "$tok" in
+        GH_AS_AUTHOR_IDENTITY)
+          INLINE_GH_AS_AUTHOR_IDENTITY=""
+          INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
+          ;;
+        GH_AS_REVIEWER_IDENTITY)
+          INLINE_GH_AS_REVIEWER_IDENTITY=""
+          INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+          ;;
+      esac
+    fi
+    PENDING_PREFIX_FLAG=""
     continue
   fi
 
@@ -717,6 +784,7 @@ for i in "${!TOKENS[@]}"; do
       AT_COMMAND_POSITION=1
       CURRENT_PREFIX=""
       WRAPPER_KIND=""
+      IN_EXPORT_SEGMENT=0
       # Clear inline env vars ONLY when the segment that just ended
       # contained a non-assignment command. That means the assignment
       # was a PREFIX scoped to that command, not a standalone
@@ -738,6 +806,44 @@ for i in "${!TOKENS[@]}"; do
         INLINE_BREAK_GLASS_ADMIN=""
         INLINE_BREAK_GLASS_MERGE_STATE=""
       fi
+      # Identity assignments: their consumer is the WRAPPER process
+      # environment, not this hook, and what survives a separator
+      # depends on HOW the assignment appeared (Codex P2s/P1 on PR
+      # #442 r1/r3/r4):
+      #   - PREFIX to an earlier command (`VAR=x echo ok ; wrapper`):
+      #     the shell restores the variable after that command —
+      #     provably ineffective for later segments. Drop it, or a
+      #     stale value falsely blocks later wrapper writes (r1).
+      #   - STANDALONE (`VAR=x ; wrapper` / `VAR=x && wrapper`): the
+      #     value persists as a shell variable, and IF the name
+      #     already carries the export attribute in the calling shell
+      #     it also reaches the wrapper (r4). The hook cannot see the
+      #     export attribute, so the value is stashed as a
+      #     possibly-effective candidate that the byline guards
+      #     validate IN ADDITION to the environment/default value —
+      #     fail closed on the ambiguity (this also covers r3, where
+      #     an unexported standalone value would have masked the
+      #     wrapper falling back to its stock default).
+      if [ "$SEGMENT_HAS_COMMAND" -eq 0 ] || [ "${SEGMENT_HAS_EVAL:-0}" -eq 1 ]; then
+        # Bare standalone segment, or an eval segment — in both, a
+        # captured assignment persists past the separator (eval'd
+        # assignments are standalone-equivalent; assignments that
+        # were prefixes TO the eval are over-captured on purpose,
+        # the fail-closed direction).
+        if [ "$INLINE_GH_AS_AUTHOR_IDENTITY_SET" -eq 1 ]; then
+          STANDALONE_GH_AS_AUTHOR_IDENTITY="$INLINE_GH_AS_AUTHOR_IDENTITY"
+          STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=1
+        fi
+        if [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then
+          STANDALONE_GH_AS_REVIEWER_IDENTITY="$INLINE_GH_AS_REVIEWER_IDENTITY"
+          STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
+        fi
+      fi
+      SEGMENT_HAS_EVAL=0
+      INLINE_GH_AS_AUTHOR_IDENTITY=""
+      INLINE_GH_AS_REVIEWER_IDENTITY=""
+      INLINE_GH_AS_AUTHOR_IDENTITY_SET=0
+      INLINE_GH_AS_REVIEWER_IDENTITY_SET=0
       SEGMENT_HAS_COMMAND=0
       continue
       ;;
@@ -764,16 +870,86 @@ for i in "${!TOKENS[@]}"; do
         ;;
       GH_AS_AUTHOR_IDENTITY=*)
         INLINE_GH_AS_AUTHOR_IDENTITY="${tok#GH_AS_AUTHOR_IDENTITY=}"
+        INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
         ;;
       GH_AS_REVIEWER_IDENTITY=*)
         INLINE_GH_AS_REVIEWER_IDENTITY="${tok#GH_AS_REVIEWER_IDENTITY=}"
+        INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
         ;;
     esac
   fi
 
   if [ "$AT_COMMAND_POSITION" -eq 0 ]; then
+    # Arguments of an `export` command are DEFINITELY-effective
+    # identity assignments: `export GH_AS_AUTHOR_IDENTITY=x ; wrapper`
+    # puts the value in every later process's environment, while this
+    # walk would otherwise skip the token as an unrelated-command
+    # argument and the byline guard would fall back to the default
+    # candidate (Codex P1 on PR #442 r11 — the wrong-byline class).
+    # Capture them into the standalone (possibly-effective) slots the
+    # candidate model already validates.
+    if [ "$IN_EXPORT_SEGMENT" -eq 1 ]; then
+      case "$tok" in
+        GH_AS_AUTHOR_IDENTITY=*)
+          STANDALONE_GH_AS_AUTHOR_IDENTITY="${tok#GH_AS_AUTHOR_IDENTITY=}"
+          STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=1
+          ;;
+        GH_AS_REVIEWER_IDENTITY=*)
+          STANDALONE_GH_AS_REVIEWER_IDENTITY="${tok#GH_AS_REVIEWER_IDENTITY=}"
+          STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
+          ;;
+        GH_AS_AUTHOR_IDENTITY)
+          # Bare name as an `unset` argument: the variable is removed
+          # from the shell AND the child environment — the r15
+          # empty-override semantics, persisting past separators.
+          if [ "${DECLARATION_KIND:-}" = "unset" ]; then
+            STANDALONE_GH_AS_AUTHOR_IDENTITY=""
+            STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=1
+          fi
+          ;;
+        GH_AS_REVIEWER_IDENTITY)
+          if [ "${DECLARATION_KIND:-}" = "unset" ]; then
+            STANDALONE_GH_AS_REVIEWER_IDENTITY=""
+            STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
+          fi
+          ;;
+      esac
+    fi
     # Skipping arguments of an unrelated command. Stay until a
     # separator resets us above.
+    continue
+  fi
+
+  # Declaration builtins (`export`, `declare`, `typeset`, `readonly`,
+  # `local`) at command position: their assignment arguments can reach
+  # all later processes (-x exports; readonly -x verified on PR #442
+  # r14). Flag the segment so the skip-path above captures the
+  # identity assignments that follow. Variants without -x are
+  # over-captured on purpose — the candidate model only blocks
+  # MISMATCHED values, so the cost of the ambiguity is a false block
+  # on a non-exported mismatched declaration, which is the fail-closed
+  # direction for a byline guard.
+  case "$tok" in export|declare|typeset|readonly|local|unset) IS_DECLARATION_BUILTIN=1 ;; *) IS_DECLARATION_BUILTIN=0 ;; esac
+  if [ "$IS_DECLARATION_BUILTIN" -eq 1 ]; then
+    DECLARATION_KIND="$tok"
+    IN_EXPORT_SEGMENT=1
+    SEGMENT_HAS_COMMAND=1
+    AT_COMMAND_POSITION=0
+    # A prefix assignment BEFORE the export command in the same
+    # segment (`VAR=x export VAR`) both persists in the shell and is
+    # exported — bash applies the prefix to the declaration builtin
+    # and the bare-name export then marks the variable. Promote any
+    # already-captured inline identity to the definitely-effective
+    # slots, or the separator path would discard it as an ordinary
+    # command prefix (Codex P1 on PR #442 r12 — wrong-byline class).
+    if [ "$INLINE_GH_AS_AUTHOR_IDENTITY_SET" -eq 1 ]; then
+      STANDALONE_GH_AS_AUTHOR_IDENTITY="$INLINE_GH_AS_AUTHOR_IDENTITY"
+      STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=1
+    fi
+    if [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then
+      STANDALONE_GH_AS_REVIEWER_IDENTITY="$INLINE_GH_AS_REVIEWER_IDENTITY"
+      STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=1
+    fi
     continue
   fi
 
@@ -807,6 +983,16 @@ for i in "${!TOKENS[@]}"; do
       # tell value-taking flags from boolean ones — short flags
       # like `-p` mean different things to different commands
       # (boolean for time, value-taking for ionice/sudo).
+      #
+      # eval is special: it executes its arguments as a NEW command
+      # line, so an assignment argument (`eval VAR=x`) becomes a
+      # STANDALONE assignment persisting in the shell — unlike an
+      # ordinary prefix the shell restores. The separator path
+      # promotes captured identities from eval segments to the
+      # possibly-effective slots instead of discarding them.
+      if [ "$tok" = "eval" ]; then
+        SEGMENT_HAS_EVAL=1
+      fi
       CURRENT_PREFIX="$tok"
       continue
       ;;
@@ -832,7 +1018,39 @@ for i in "${!TOKENS[@]}"; do
       # identically.
       if prefix_flag_takes_value "$CURRENT_PREFIX" "$tok"; then
         SKIP_PREFIX_VALUE=1
+        PENDING_PREFIX_FLAG="$CURRENT_PREFIX:$tok"
         continue
+      fi
+      # env's combined/long forms that drop identity variables from
+      # the wrapped command's environment (same r15 empty-override
+      # semantics as `env -u NAME` above): --unset=NAME, and -i which
+      # clears the whole environment.
+      if [ "$CURRENT_PREFIX" = "env" ]; then
+        case "$tok" in
+          --unset=GH_AS_AUTHOR_IDENTITY|-u=GH_AS_AUTHOR_IDENTITY)
+            INLINE_GH_AS_AUTHOR_IDENTITY=""
+            INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
+            continue
+            ;;
+          --unset=GH_AS_REVIEWER_IDENTITY|-u=GH_AS_REVIEWER_IDENTITY)
+            INLINE_GH_AS_REVIEWER_IDENTITY=""
+            INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+            continue
+            ;;
+          -i|--ignore-environment)
+            INLINE_GH_AS_AUTHOR_IDENTITY=""
+            INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
+            INLINE_GH_AS_REVIEWER_IDENTITY=""
+            INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+            # env -i clears EVERYTHING the wrapper would see —
+            # including MERGEPATH_AGENT — so the reviewer fallback
+            # must be the wrapper's bare hardcoded default, not the
+            # hook environment's agent chain (Codex P1 on PR #442
+            # r19).
+            IDENTITY_ENV_CLEARED_FOR_WRAPPER=1
+            continue
+            ;;
+        esac
       fi
       # Otherwise: boolean flag of the current prefix (or a flag
       # of an unknown prefix, which we conservatively assume is
@@ -989,6 +1207,64 @@ if [ "$WRAPPER_KIND" = "reviewer" ] && [ "$REVIEWER_WRAPPER_ALLOWED" -ne 1 ]; th
   exit 2
 fi
 
+# --- byline guard for author-wrapper writes (#438) --------------------
+#
+# gh-as-author.sh verifies the token for whatever login
+# GH_AS_AUTHOR_IDENTITY names — its default is nathanjohnpayne, but a
+# shell where the variable is exported (or inline-prefixed) as a
+# different login makes the wrapper verify THAT login's token and run
+# `gh pr merge`/`edit`/`create` under it. Pin the wrapper's effective
+# author identity to the expected author, exactly as the reviewer
+# branch below pins the reviewer identity. Without this,
+# `GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh --
+# gh pr merge ...` re-opens the wrong-byline merge/edit path the
+# wrapper migration closed (the #359 class).
+if [ "$WRAPPER_KIND" = "author" ]; then
+  # Expected-author resolution order: explicit env override, then the
+  # repo's review-policy.yml author_identity (so custom-author repos
+  # need no hook-specific variable — Codex P2 on PR #442 round 2),
+  # then the fleet default.
+  EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-}"
+  GUARD_POLICY_FILE="$(guard_policy_file || true)"
+  if [ -z "$EXPECTED_AUTHOR" ] && [ -n "$GUARD_POLICY_FILE" ]; then
+    # Strip surrounding double OR single quotes — both are valid YAML
+    # scalars (`author_identity: "custom-owner"` / `'custom-owner'`),
+    # matching the quote-tolerance of the sibling policy parsers
+    # (Codex P2s on PR #442 r6/r7). Policy located via upward walk +
+    # script-root fallback per r21.
+    EXPECTED_AUTHOR=$(grep -m1 '^author_identity:' "$GUARD_POLICY_FILE" | awk '{print $2}' | sed -E "s/^[\"']//; s/[\"']\$//" || true)
+  fi
+  EXPECTED_AUTHOR="${EXPECTED_AUTHOR:-nathanjohnpayne}"
+  # Candidate model (Codex P1 on PR #442 r4): a same-segment prefix on
+  # the wrapper command is DEFINITIVE (it reaches the wrapper's
+  # environment regardless of export attribute). Otherwise the wrapper
+  # may see EITHER the hook's environment value / the wrapper's hard
+  # default (nathanjohnpayne) OR a standalone assignment from an
+  # earlier segment (effective only if the name carries the export
+  # attribute, which the hook cannot observe). Every possibly-effective
+  # candidate must match the expected author — fail closed on the
+  # ambiguity.
+  if [ "$INLINE_GH_AS_AUTHOR_IDENTITY_SET" -eq 1 ]; then
+    # Same-segment prefix is definitive. An EMPTY override is not
+    # "absent" — it resets the wrapper to its hardcoded default
+    # (Codex P1 on PR #442 r15).
+    AUTHOR_IDENTITY_CANDIDATES="${INLINE_GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
+  else
+    AUTHOR_IDENTITY_CANDIDATES="${GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
+    if [ "$STANDALONE_GH_AS_AUTHOR_IDENTITY_SET" -eq 1 ]; then
+      AUTHOR_IDENTITY_CANDIDATES="$AUTHOR_IDENTITY_CANDIDATES ${STANDALONE_GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
+    fi
+  fi
+  for WRAPPER_AUTHOR_IDENTITY in $AUTHOR_IDENTITY_CANDIDATES; do
+    if [ "$WRAPPER_AUTHOR_IDENTITY" != "$EXPECTED_AUTHOR" ]; then
+      echo "BLOCKED: $cmd_label wrapper may run under author identity '$WRAPPER_AUTHOR_IDENTITY', not expected author '$EXPECTED_AUTHOR'." >&2
+      echo "  gh-as-author.sh verifies whatever login GH_AS_AUTHOR_IDENTITY names; a non-author login here lands the write under the wrong byline (#438)." >&2
+      echo "  Unset GH_AS_AUTHOR_IDENTITY (wrapper default: nathanjohnpayne) and drop any standalone GH_AS_AUTHOR_IDENTITY=... assignment from the command, or set GH_PR_GUARD_EXPECTED_AUTHOR if this repo's author identity genuinely differs." >&2
+      exit 2
+    fi
+  done
+fi
+
 # --- byline guard for pr comment / pr review / issue comment ---
 #
 # These three subcommands share a single policy: reviewer writes must be
@@ -1017,17 +1293,39 @@ else
 fi
 if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ]; then
   if [ "$WRAPPER_KIND" = "reviewer" ]; then
-    WRAPPER_REVIEWER_IDENTITY="${INLINE_GH_AS_REVIEWER_IDENTITY:-${GH_AS_REVIEWER_IDENTITY:-}}"
-    if [ -z "$WRAPPER_REVIEWER_IDENTITY" ] && [ -n "${MERGEPATH_AGENT:-}" ]; then
-      WRAPPER_REVIEWER_IDENTITY="nathanpayne-$MERGEPATH_AGENT"
+    # Same candidate model as the author guard above (Codex P1 on PR
+    # #442 r4): a same-segment prefix is definitive; otherwise both
+    # the env/default resolution AND any standalone assignment from an
+    # earlier segment are possibly effective and must ALL match.
+    # The wrapper resolves an EMPTY GH_AS_REVIEWER_IDENTITY through its
+    # env-free chain (MERGEPATH_AGENT, then nathanpayne-claude) — an
+    # empty-set assignment maps to that, not to "absent" (r15).
+    REVIEWER_EMPTY_FALLBACK="nathanpayne-claude"
+    if [ -n "${MERGEPATH_AGENT:-}" ] && [ "$IDENTITY_ENV_CLEARED_FOR_WRAPPER" -eq 0 ]; then
+      # env -i strips MERGEPATH_AGENT from the wrapper too — in that
+      # case the wrapper's chain bottoms out at its hardcoded default
+      # regardless of the hook environment (r19).
+      REVIEWER_EMPTY_FALLBACK="nathanpayne-$MERGEPATH_AGENT"
     fi
-    WRAPPER_REVIEWER_IDENTITY="${WRAPPER_REVIEWER_IDENTITY:-nathanpayne-claude}"
-    if [ "$WRAPPER_REVIEWER_IDENTITY" != "$EXPECTED_REVIEWER" ]; then
-      echo "BLOCKED: $cmd_label wrapper is configured for '$WRAPPER_REVIEWER_IDENTITY', not expected reviewer '$EXPECTED_REVIEWER'." >&2
-      echo "  Expected reviewer source: $EXPECTED_REVIEWER_SOURCE" >&2
-      echo "  Set GH_AS_REVIEWER_IDENTITY=$EXPECTED_REVIEWER or MERGEPATH_AGENT=<agent> consistently." >&2
-      exit 2
+    if [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then
+      REVIEWER_IDENTITY_CANDIDATES="${INLINE_GH_AS_REVIEWER_IDENTITY:-$REVIEWER_EMPTY_FALLBACK}"
+    else
+      REVIEWER_IDENTITY_CANDIDATES="${GH_AS_REVIEWER_IDENTITY:-}"
+      if [ -z "$REVIEWER_IDENTITY_CANDIDATES" ]; then
+        REVIEWER_IDENTITY_CANDIDATES="$REVIEWER_EMPTY_FALLBACK"
+      fi
+      if [ "$STANDALONE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ]; then
+        REVIEWER_IDENTITY_CANDIDATES="$REVIEWER_IDENTITY_CANDIDATES ${STANDALONE_GH_AS_REVIEWER_IDENTITY:-$REVIEWER_EMPTY_FALLBACK}"
+      fi
     fi
+    for WRAPPER_REVIEWER_IDENTITY in $REVIEWER_IDENTITY_CANDIDATES; do
+      if [ "$WRAPPER_REVIEWER_IDENTITY" != "$EXPECTED_REVIEWER" ]; then
+        echo "BLOCKED: $cmd_label wrapper may run under '$WRAPPER_REVIEWER_IDENTITY', not expected reviewer '$EXPECTED_REVIEWER'." >&2
+        echo "  Expected reviewer source: $EXPECTED_REVIEWER_SOURCE" >&2
+        echo "  Set GH_AS_REVIEWER_IDENTITY=$EXPECTED_REVIEWER or MERGEPATH_AGENT=<agent> consistently, and drop any standalone GH_AS_REVIEWER_IDENTITY=... assignment from the command." >&2
+        exit 2
+      fi
+    done
   fi
 fi
 
@@ -1178,7 +1476,7 @@ if [ "$PR_SUBCOMMAND" = "review" ]; then
         # additions + deletions from the PR JSON; over if sum >= threshold
         # OR threshold can't be determined (fail safe).
         threshold=""
-        policy_path=".github/review-policy.yml"
+        policy_path="$(guard_policy_file || true)"
         if [ -f "$policy_path" ]; then
           threshold=$(grep -oE '^[[:space:]]*external_review_threshold:[[:space:]]*[0-9]+' "$policy_path" | head -1 | grep -oE '[0-9]+$' || true)
         fi

--- a/scripts/merge-clearance-gate.sh
+++ b/scripts/merge-clearance-gate.sh
@@ -475,11 +475,14 @@ if [ "$EXTERNAL_GATE_ENABLED" = "true" ]; then
 
     # Delegate to the shared predicate. CODEX_REVIEW_CHECK_SKIP_CI=1 skips
     # gate (a) for THIS invocation only (avoids the required-check
-    # self-deadlock); gate (b) reviewer-APPROVED + gate (c) Codex/Phase-4b
-    # on HEAD still run. codex-review-check.sh exits: 0 clear, 1 gate fail,
-    # 3 infra. Map 3 → 2 (config/infra error).
+    # self-deadlock). CODEX_REVIEW_CHECK_REQUIRE_APPROVAL_ON_HEAD=1 HEAD-pins
+    # gate (b) so a stale earlier-head reviewer APPROVED can't ride a later
+    # push to clearance (#435) — making this REQUIRED check fully HEAD-pinned
+    # (reviewer + Codex/Phase-4b both on HEAD). codex-review-check.sh exits:
+    # 0 clear, 1 gate fail, 3 infra. Map 3 → 2 (config/infra error).
     set +e
-    CODEX_REVIEW_CHECK_SKIP_CI=1 bash "$CODEX_CHECK_BIN" "$PR_NUMBER" "$REPO"
+    CODEX_REVIEW_CHECK_SKIP_CI=1 CODEX_REVIEW_CHECK_REQUIRE_APPROVAL_ON_HEAD=1 \
+      bash "$CODEX_CHECK_BIN" "$PR_NUMBER" "$REPO"
     crc=$?
     set -e
     case "$crc" in

--- a/tests/test_audit_propagation_lane.sh
+++ b/tests/test_audit_propagation_lane.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Offline coverage for scripts/audit-propagation-lane.sh (#434) via its
+# --check-files mode, which evaluates the same lane predicate the live
+# per-consumer loop evaluates.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/audit-propagation-lane.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "missing or non-executable $SCRIPT" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/lane-audit-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# A workflow file carrying the #434 default-ON lane marker, and one
+# predating it. The marker literal must match the one in the REAL
+# synced workflow — assert that first so the audit can't silently
+# diverge from what pr-review-policy.yml actually ships.
+MARKER='PROP_ENABLED=${PROP_ENABLED:-true}'
+if grep -qF "$MARKER" "$ROOT/.github/workflows/pr-review-policy.yml"; then
+  pass "lane default-ON marker present in the real pr-review-policy.yml"
+else
+  fail "lane default-ON marker missing from .github/workflows/pr-review-policy.yml — audit marker and workflow have diverged"
+fi
+
+WF_NEW="$WORKDIR/wf-new.yml"
+printf 'jobs:\n  x:\n    run: |\n      %s\n' "$MARKER" >"$WF_NEW"
+WF_OLD="$WORKDIR/wf-old.yml"
+printf 'jobs:\n  x:\n    run: |\n      PROP_ENABLED=$(prop_field f propagation_prs enabled)\n' >"$WF_OLD"
+
+POLICY_BARE="$WORKDIR/policy-bare.yml"        # no propagation_prs block (the fleet-wide #434 shape)
+printf 'author_identity: nathanjohnpayne\n' >"$POLICY_BARE"
+POLICY_ON="$WORKDIR/policy-on.yml"            # explicit enabled: true
+printf 'propagation_prs:\n  enabled: true\nauthor_identity: nathanjohnpayne\n' >"$POLICY_ON"
+POLICY_OFF="$WORKDIR/policy-off.yml"          # explicit opt-out
+printf 'propagation_prs:\n  enabled: false\nauthor_identity: nathanjohnpayne\n' >"$POLICY_OFF"
+POLICY_NO_AUTHOR="$WORKDIR/policy-no-author.yml"
+printf 'propagation_prs:\n  enabled: true\n' >"$POLICY_NO_AUTHOR"
+POLICY_ALT_PREFIX="$WORKDIR/policy-alt-prefix.yml"  # prefix that sync never opens
+printf 'propagation_prs:\n  enabled: true\n  branch_prefix: "other-prefix/"\nauthor_identity: nathanjohnpayne\n' >"$POLICY_ALT_PREFIX"
+POLICY_STD_PREFIX="$WORKDIR/policy-std-prefix.yml"  # explicit standard prefix
+printf 'propagation_prs:\n  enabled: true\n  branch_prefix: "mergepath-sync/"\nauthor_identity: nathanjohnpayne\n' >"$POLICY_STD_PREFIX"
+POLICY_WRONG_AUTHOR="$WORKDIR/policy-wrong-author.yml"  # author that sync never uses
+printf 'propagation_prs:\n  enabled: true\nauthor_identity: nathanpayne-claude\n' >"$POLICY_WRONG_AUTHOR"
+POLICY_CASED="$WORKDIR/policy-cased.yml"  # YAML-boolean-ish but not the lane's exact match
+printf 'propagation_prs:\n  enabled: TRUE\nauthor_identity: nathanjohnpayne\n' >"$POLICY_CASED"
+
+run_check() {  # <policy> <workflow> — sets OUT and RC
+  set +e
+  OUT=$("$SCRIPT" --check-files "$1" "$2" 2>&1)
+  RC=$?
+  set -e
+}
+
+run_check "$POLICY_BARE" "$WF_NEW"
+if [ "$RC" = "0" ] && echo "$OUT" | grep -q "default-ON"; then
+  pass "absent propagation_prs block fires the lane under the default-ON workflow"
+else
+  fail "absent block should fire (rc=0, default-ON); got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_ON" "$WF_NEW"
+if [ "$RC" = "0" ]; then
+  pass "explicit enabled: true fires the lane"
+else
+  fail "explicit enabled: true should fire; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_OFF" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "explicit opt-out"; then
+  pass "explicit enabled: false is flagged as an opt-out and fails the audit"
+else
+  fail "explicit enabled: false should fail with opt-out message; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_BARE" "$WF_OLD"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "predates the #434"; then
+  pass "pre-#434 workflow without the default-ON marker fails the audit"
+else
+  fail "pre-#434 workflow should fail with marker message; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_NO_AUTHOR" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "no author_identity"; then
+  pass "missing author_identity fails the audit"
+else
+  fail "missing author_identity should fail; got rc=$RC, out: $OUT"
+fi
+
+run_check "" "$WF_NEW"
+if [ "$RC" = "1" ]; then
+  pass "absent review-policy.yml fails the audit (no author fingerprint)"
+else
+  fail "absent review-policy.yml should fail; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_ALT_PREFIX" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "never match a real sync PR"; then
+  pass "overridden branch_prefix that sync never opens fails the audit"
+else
+  fail "non-sync branch_prefix should fail; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_STD_PREFIX" "$WF_NEW"
+if [ "$RC" = "0" ]; then
+  pass "explicit standard branch_prefix fires the lane"
+else
+  fail "explicit mergepath-sync/ prefix should fire; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_WRONG_AUTHOR" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "sync PRs are authored by"; then
+  pass "author_identity that is not the sync actor fails the audit"
+else
+  fail "non-sync author_identity should fail; got rc=$RC, out: $OUT"
+fi
+
+run_check "$POLICY_CASED" "$WF_NEW"
+if [ "$RC" = "1" ] && echo "$OUT" | grep -q "only fires on exactly"; then
+  pass "non-lowercase enabled value fails the audit (lane matches exactly 'true')"
+else
+  fail "enabled: TRUE should fail; got rc=$RC, out: $OUT"
+fi
+
+echo ""
+echo "test_audit_propagation_lane: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_coderabbit_wait_identity_derivation.sh
+++ b/tests/test_coderabbit_wait_identity_derivation.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# Regression coverage for coderabbit-wait.sh's token-derived expected
+# reviewer identity (#438).
+#
+# Runs the real helper from a temp repo with stubbed gh/date/sleep and a
+# stubbed identity-check.sh. The write path exercised is the timeout
+# status probe (the first reviewer-token write the helper can reach
+# deterministically). Asserts:
+#   1. With NO identity envs set, the expected identity is derived from
+#      the token's login when that login is in available_reviewers —
+#      not hard-defaulted to nathanpayne-claude.
+#   2. A token login NOT in available_reviewers falls back to the
+#      static default (fail-closed: verification then fails and no
+#      write is posted).
+#   3. An explicit GH_AS_REVIEWER_IDENTITY wins and no derivation
+#      lookup (`gh api user`) is made.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/coderabbit-wait-identity.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+make_case() {
+  local name=$1
+  local dir="$WORKDIR/$name"
+
+  mkdir -p "$dir/scripts/lib" "$dir/.github" "$dir/bin" "$dir/state"
+  cp "$ROOT/scripts/coderabbit-wait.sh" "$dir/scripts/coderabbit-wait.sh"
+  cp "$ROOT/scripts/lib/gh-token-resolver.sh" "$dir/scripts/lib/gh-token-resolver.sh"
+  chmod +x "$dir/scripts/coderabbit-wait.sh"
+
+  cat >"$dir/.github/review-policy.yml" <<'EOF'
+available_reviewers:
+  - nathanpayne-claude  # default agent
+  - 'nathanpayne-cursor'
+  - "nathanpayne-codex" # quoted + inline comment
+
+coderabbit:
+  bot_login: "coderabbitai[bot]"
+  max_wait_seconds: 1
+  status_probe_enabled: true
+  status_probe_wait_seconds: 1
+  max_rate_limit_retries: 2
+  wallclock_freshness_window_seconds: 999999999
+  trust_status_context_for_clearance: false
+EOF
+
+  # identity-check stub: records the expected identity it was asked to
+  # verify, succeeds iff that identity matches the stub token's login.
+  cat >"$dir/scripts/identity-check.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+[ "${1:-}" = "--expect-token-identity" ] || exit 2
+printf '%s\n' "${2:-}" >>"$state_dir/identity-args"
+[ "${2:-}" = "${CODERABBIT_TEST_TOKEN_LOGIN:?}" ] || exit 1
+exit 0
+EOF
+  chmod +x "$dir/scripts/identity-check.sh"
+
+  cat >"$dir/bin/date" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+clock_file="$state_dir/fake-time"
+if [ ! -f "$clock_file" ]; then
+  printf '2000000000\n' >"$clock_file"
+fi
+if [ "$#" -eq 1 ] && [ "$1" = "+%s" ]; then
+  cat "$clock_file"
+  exit 0
+fi
+exec /bin/date "$@"
+EOF
+  chmod +x "$dir/bin/date"
+
+  cat >"$dir/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+clock_file="$state_dir/fake-time"
+if [ ! -f "$clock_file" ]; then
+  printf '2000000000\n' >"$clock_file"
+fi
+duration=${1:-0}
+case "$duration" in
+  *.*) duration=${duration%%.*} ;;
+esac
+current=$(cat "$clock_file")
+printf '%s\n' $((current + duration)) >"$clock_file"
+EOF
+  chmod +x "$dir/bin/sleep"
+
+  cat >"$dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+head_time='2026-06-04T00:00:00Z'
+
+if [ "${1:-}" != "api" ]; then
+  echo "unexpected gh command: $*" >&2
+  exit 99
+fi
+shift
+
+method="GET"
+if [ "${1:-}" = "--method" ]; then
+  method=${2:-}
+  shift 2
+fi
+if [ "${1:-}" = "--paginate" ]; then
+  shift
+fi
+
+endpoint=${1:-}
+shift || true
+
+if [ "$method" = "POST" ]; then
+  case "$endpoint" in
+    repos/owner/repo/issues/999/comments)
+      count=0
+      if [ -f "$state_dir/post-count" ]; then
+        count=$(cat "$state_dir/post-count")
+      fi
+      count=$((count + 1))
+      printf '%s\n' "$count" >"$state_dir/post-count"
+      printf '{"id":900%s,"created_at":"%s","body":"probe"}\n' "$count" "$head_time"
+      ;;
+    *)
+      echo "unexpected gh api POST endpoint: $endpoint" >&2
+      exit 99
+      ;;
+  esac
+  exit 0
+fi
+
+case "$endpoint" in
+  user)
+    count=0
+    if [ -f "$state_dir/api-user-count" ]; then
+      count=$(cat "$state_dir/api-user-count")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$state_dir/api-user-count"
+    printf '%s\n' "${CODERABBIT_TEST_TOKEN_LOGIN:?}"
+    ;;
+  repos/owner/repo/pulls/999)
+    printf '{"head":{"sha":"head-sha"}}\n'
+    ;;
+  repos/owner/repo/commits/head-sha)
+    if [ "${1:-}" = "--jq" ]; then
+      printf '%s\n' "$head_time"
+    else
+      printf '{"commit":{"committer":{"date":"%s"}}}\n' "$head_time"
+    fi
+    ;;
+  repos/owner/repo/issues/999/timeline)
+    printf '[]\n'
+    ;;
+  repos/owner/repo/pulls/999/reviews)
+    printf '[]\n'
+    ;;
+  repos/owner/repo/pulls/999/comments)
+    printf '[]\n'
+    ;;
+  repos/owner/repo/issues/999/comments)
+    printf '[]\n'
+    ;;
+  *)
+    echo "unexpected gh api endpoint: $endpoint" >&2
+    exit 99
+    ;;
+esac
+EOF
+  chmod +x "$dir/bin/gh"
+
+  printf '%s\n' "$dir"
+}
+
+run_case() {
+  local dir=$1
+  local token_login=$2
+  local explicit_identity=${3:-}
+  local rc=0
+
+  (
+    cd "$dir"
+    env_args=(
+      PATH="$dir/bin:$PATH"
+      GH_TOKEN=test-token
+      CODERABBIT_TEST_STATE_DIR="$dir/state"
+      CODERABBIT_TEST_TOKEN_LOGIN="$token_login"
+    )
+    if [ -n "$explicit_identity" ]; then
+      env_args+=(GH_AS_REVIEWER_IDENTITY="$explicit_identity")
+    fi
+    env -u MERGEPATH_AGENT -u OP_PREFLIGHT_AGENT -u GH_AS_REVIEWER_IDENTITY \
+      "${env_args[@]}" \
+      ./scripts/coderabbit-wait.sh 999 owner/repo \
+      >"$dir/out.json" 2>"$dir/err.log"
+  ) || rc=$?
+
+  printf '%s\n' "$rc"
+}
+
+state_file() {
+  local dir=$1 name=$2
+  if [ -f "$dir/state/$name" ]; then
+    cat "$dir/state/$name"
+  else
+    printf ''
+  fi
+}
+
+test_derives_identity_from_allow_listed_token() {
+  local dir rc args posts
+  dir=$(make_case "derived-cursor")
+  rc=$(run_case "$dir" nathanpayne-cursor)
+  args=$(state_file "$dir" identity-args)
+  posts=$(state_file "$dir" post-count)
+
+  if [ "$args" != "nathanpayne-cursor" ]; then
+    fail "derived identity: identity-check expected args 'nathanpayne-cursor', got '$args'; stderr=$(cat "$dir/err.log")"
+  elif [ "${posts:-0}" -lt 1 ]; then
+    fail "derived identity: probe write was not posted (post-count='$posts'); stderr=$(cat "$dir/err.log")"
+  elif ! grep -q "derived expected reviewer identity 'nathanpayne-cursor'" "$dir/err.log"; then
+    fail "derived identity: missing derivation log line; stderr=$(cat "$dir/err.log")"
+  else
+    pass "expected identity derived from allow-listed token login (rc=$rc)"
+  fi
+}
+
+test_non_allow_listed_token_fails_closed() {
+  local dir rc args posts
+  dir=$(make_case "mallory")
+  rc=$(run_case "$dir" mallory-user)
+  args=$(state_file "$dir" identity-args)
+  posts=$(state_file "$dir" post-count)
+
+  if [ "$args" != "nathanpayne-claude" ]; then
+    fail "fail-closed: identity-check expected args 'nathanpayne-claude' (static default), got '$args'; stderr=$(cat "$dir/err.log")"
+  elif [ -n "$posts" ]; then
+    fail "fail-closed: a write was posted ($posts) despite identity verification failing"
+  else
+    pass "non-allow-listed token falls back to static default and posts nothing (rc=$rc)"
+  fi
+}
+
+test_explicit_identity_skips_derivation() {
+  local dir rc args user_calls
+  dir=$(make_case "explicit-codex")
+  rc=$(run_case "$dir" nathanpayne-codex nathanpayne-codex)
+  args=$(state_file "$dir" identity-args)
+  user_calls=$(state_file "$dir" api-user-count)
+
+  if [ "$args" != "nathanpayne-codex" ]; then
+    fail "explicit identity: identity-check expected args 'nathanpayne-codex', got '$args'; stderr=$(cat "$dir/err.log")"
+  elif [ -n "$user_calls" ]; then
+    fail "explicit identity: derivation lookup ran ($user_calls api-user calls) despite explicit GH_AS_REVIEWER_IDENTITY"
+  else
+    pass "explicit GH_AS_REVIEWER_IDENTITY wins; no derivation lookup (rc=$rc)"
+  fi
+}
+
+test_derives_identity_from_quoted_commented_entry() {
+  local dir rc args
+  dir=$(make_case "derived-codex-quoted-commented")
+  rc=$(run_case "$dir" nathanpayne-codex)
+  args=$(state_file "$dir" identity-args)
+
+  if [ "$args" != "nathanpayne-codex" ]; then
+    fail "quoted+commented entry: identity-check expected args 'nathanpayne-codex', got '$args'; stderr=$(cat "$dir/err.log")"
+  elif ! grep -q "derived expected reviewer identity 'nathanpayne-codex'" "$dir/err.log"; then
+    fail "quoted+commented entry: missing derivation log line; stderr=$(cat "$dir/err.log")"
+  else
+    pass "allow-list entry with quotes AND inline comment is normalized for derivation (rc=$rc)"
+  fi
+}
+
+test_derives_identity_from_allow_listed_token
+test_derives_identity_from_quoted_commented_entry
+test_non_allow_listed_token_fails_closed
+test_explicit_identity_skips_derivation
+
+echo ""
+echo "test_coderabbit_wait_identity_derivation: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_codex_review_request_ack.sh
+++ b/tests/test_codex_review_request_ack.sh
@@ -58,6 +58,12 @@ fi
 count=$((count + 1))
 printf '%s\n' "$count" >"$state_dir/trigger-count"
 
+# Record the author-PAT and author-identity env the wrapper sees, so
+# the #438 inline-token bridging tests can assert what (if anything)
+# was bridged in.
+printf '%s\n' "${OP_PREFLIGHT_AUTHOR_PAT:-}" >>"$state_dir/author-pat-env"
+printf '%s\n' "${GH_AS_AUTHOR_IDENTITY:-}" >>"$state_dir/author-identity-env"
+
 comment_id=$((1000 + count))
 printf '%s\n' "$comment_id" >>"$state_dir/trigger-comments"
 if [ "${CODEX_TEST_SCENARIO:-}" = "no_comment_id" ]; then
@@ -212,12 +218,13 @@ run_case() {
   local dir=$1
   local scenario=$2
   local fake_clock=${3:-0}
+  local gh_token=${4:-test-token}
   local rc=0
 
   (
     cd "$dir"
     PATH="$dir/bin:$PATH" \
-      GH_TOKEN=test-token \
+      GH_TOKEN="$gh_token" \
       CODEX_TEST_STATE_DIR="$dir/state" \
       CODEX_TEST_FAKE_CLOCK="$fake_clock" \
       CODEX_TEST_SCENARIO="$scenario" \
@@ -414,6 +421,132 @@ test_ack_wait_window_is_bounded() {
   fi
 }
 
+# --- inline author-PAT bridging (#438) --------------------------------
+
+# identity-check stub used by the bridging tests: succeeds iff the
+# ambient GH_TOKEN is the known author PAT and the expected identity
+# is nathanjohnpayne (the policy default).
+write_identity_check_stub() {
+  local dir=$1
+  cat >"$dir/scripts/identity-check.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "--expect-token-identity" ] || exit 2
+[ "${2:-}" = "nathanjohnpayne" ] || exit 1
+[ "${GH_TOKEN:-}" = "author-pat-123" ] || exit 1
+exit 0
+EOF
+  chmod +x "$dir/scripts/identity-check.sh"
+}
+
+bridged_pat() {
+  local dir=$1
+  if [ -f "$dir/state/author-pat-env" ]; then
+    head -1 "$dir/state/author-pat-env"
+  else
+    printf ''
+  fi
+}
+
+test_inline_author_pat_bridged_into_wrapper() {
+  local dir rc pat
+  dir=$(make_case "author-pat-bridged" 0 0)
+  write_identity_check_stub "$dir"
+  rc=$(run_case "$dir" absent 0 author-pat-123)
+  pat=$(bridged_pat "$dir")
+
+  if [ "$(trigger_count "$dir")" -lt 1 ]; then
+    fail "author-pat bridge: no trigger was posted; stderr=$(cat "$dir/err.log")"
+  elif [ "$pat" != "author-pat-123" ]; then
+    fail "author-pat bridge: wrapper saw OP_PREFLIGHT_AUTHOR_PAT='$pat', expected the verified inline token; stderr=$(cat "$dir/err.log")"
+  elif ! grep -q "bridging it into gh-as-author.sh" "$dir/err.log"; then
+    fail "author-pat bridge: missing bridging log line; stderr=$(cat "$dir/err.log")"
+  else
+    pass "verified inline author PAT is bridged into gh-as-author.sh (rc=$rc)"
+  fi
+}
+
+test_bridge_passes_configured_author_identity() {
+  local dir rc pat identity
+  dir=$(make_case "custom-author-bridge" 0 0)
+  # Custom author_identity repo (Codex P2 on PR #442): the wrapper must
+  # be told to verify the configured login, not its stock default.
+  printf 'author_identity: custom-owner\n' >>"$dir/.github/review-policy.yml"
+  cat >"$dir/scripts/identity-check.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "--expect-token-identity" ] || exit 2
+[ "${2:-}" = "custom-owner" ] || exit 1
+[ "${GH_TOKEN:-}" = "author-pat-123" ] || exit 1
+exit 0
+EOF
+  chmod +x "$dir/scripts/identity-check.sh"
+  rc=$(run_case "$dir" absent 0 author-pat-123)
+  pat=$(bridged_pat "$dir")
+  identity=$(head -1 "$dir/state/author-identity-env" 2>/dev/null || printf '')
+
+  if [ "$pat" != "author-pat-123" ]; then
+    fail "custom-author bridge: wrapper saw OP_PREFLIGHT_AUTHOR_PAT='$pat', expected the verified inline token; stderr=$(cat "$dir/err.log")"
+  elif [ "$identity" != "custom-owner" ]; then
+    fail "custom-author bridge: wrapper saw GH_AS_AUTHOR_IDENTITY='$identity', expected 'custom-owner'; stderr=$(cat "$dir/err.log")"
+  else
+    pass "bridge passes the configured author_identity to the wrapper (rc=$rc)"
+  fi
+}
+
+test_non_author_token_is_not_bridged() {
+  local dir rc pat
+  dir=$(make_case "reviewer-pat-not-bridged" 0 0)
+  write_identity_check_stub "$dir"
+  rc=$(run_case "$dir" absent 0 reviewer-pat-456)
+  pat=$(bridged_pat "$dir")
+
+  if [ "$(trigger_count "$dir")" -lt 1 ]; then
+    fail "non-author token: no trigger was posted; stderr=$(cat "$dir/err.log")"
+  elif [ -n "$pat" ]; then
+    fail "non-author token: wrapper saw OP_PREFLIGHT_AUTHOR_PAT='$pat', expected empty (no bridge)"
+  elif grep -q "bridging it into gh-as-author.sh" "$dir/err.log"; then
+    fail "non-author token: bridging log line present for a non-author token"
+  else
+    pass "non-author inline token is NOT bridged; wrapper resolution unchanged (rc=$rc)"
+  fi
+}
+
+test_non_bridge_path_passes_configured_identity() {
+  local dir rc identity
+  dir=$(make_case "custom-author-no-bridge" 0 0)
+  # Custom author_identity, NO bridging (token does not verify) — the
+  # wrapper must still be told the configured login (Codex P2 r5).
+  # Single-quoted on purpose: the parser must strip both YAML quote
+  # styles (Codex P2 r9).
+  printf "author_identity: 'custom-owner'\n" >>"$dir/.github/review-policy.yml"
+  rc=$(run_case "$dir" absent 0 reviewer-pat-456)
+  identity=$(head -1 "$dir/state/author-identity-env" 2>/dev/null || printf '')
+
+  if [ "$(trigger_count "$dir")" -lt 1 ]; then
+    fail "non-bridge identity: no trigger was posted; stderr=$(cat "$dir/err.log")"
+  elif [ "$identity" != "custom-owner" ]; then
+    fail "non-bridge identity: wrapper saw GH_AS_AUTHOR_IDENTITY='$identity', expected 'custom-owner'; stderr=$(cat "$dir/err.log")"
+  else
+    pass "non-bridged invocation passes the configured author_identity (rc=$rc)"
+  fi
+}
+
+test_missing_identity_checker_skips_bridge() {
+  local dir rc pat
+  dir=$(make_case "no-checker-no-bridge" 0 0)
+  rc=$(run_case "$dir" absent 0 author-pat-123)
+  pat=$(bridged_pat "$dir")
+
+  if [ "$(trigger_count "$dir")" -lt 1 ]; then
+    fail "missing checker: no trigger was posted; stderr=$(cat "$dir/err.log")"
+  elif [ -n "$pat" ]; then
+    fail "missing checker: wrapper saw OP_PREFLIGHT_AUTHOR_PAT='$pat', expected empty (bridge requires verification)"
+  else
+    pass "without identity-check.sh the bridge is skipped (verification-gated) (rc=$rc)"
+  fi
+}
+
 test_eyes_ack_does_not_retrigger_or_clear
 test_missing_ack_retriggers_once
 test_retry_cap_respected
@@ -423,6 +556,11 @@ test_retry_missing_comment_id_stops_without_extra_retry
 test_retry_resets_review_deadline
 test_retry_preserves_original_trigger_response
 test_ack_wait_window_is_bounded
+test_inline_author_pat_bridged_into_wrapper
+test_bridge_passes_configured_author_identity
+test_non_author_token_is_not_bridged
+test_non_bridge_path_passes_configured_identity
+test_missing_identity_checker_skips_bridge
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_gh_as_author.sh
+++ b/tests/test_gh_as_author.sh
@@ -165,6 +165,87 @@ else
   fail "empty command: rc=$rc expected 1"
 fi
 
+# --- runtime byline pin (#438) ----------------------------------------
+# Runs IN the wrapper process: environment-manipulation-proof, unlike
+# the PreToolUse hook's static analysis.
+
+# The pin resolves the policy from the WRAPPER's repo root (r20), so
+# each fixture repo gets its own copy of the wrapper + its lib deps.
+install_wrapper_copy() {
+  local dir=$1
+  mkdir -p "$dir/scripts/lib" "$dir/.github"
+  cp "$ROOT/scripts/gh-as-author.sh" "$dir/scripts/gh-as-author.sh"
+  cp "$ROOT/scripts/lib/gh-token-resolver.sh" "$dir/scripts/lib/gh-token-resolver.sh"
+  cp "$ROOT/scripts/identity-check.sh" "$dir/scripts/identity-check.sh"
+  chmod +x "$dir/scripts/gh-as-author.sh" "$dir/scripts/identity-check.sh"
+}
+
+PIN_DIR="$WORKDIR/pin-repo"
+install_wrapper_copy "$PIN_DIR"
+printf 'author_identity: nathanjohnpayne\n' >"$PIN_DIR/.github/review-policy.yml"
+
+reset_log
+set +e
+( cd "$PIN_DIR" && OP_PREFLIGHT_AUTHOR_PAT="author-token" GH_AS_AUTHOR_IDENTITY="nathanpayne-codex" \
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$PIN_DIR/scripts/gh-as-author.sh" -- gh pr merge 9 --squash ) >/dev/null 2>"$WORKDIR/pin.err"
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && grep -q "runtime byline pin" "$WORKDIR/pin.err"; then
+  pass "runtime pin: non-policy identity refused before any gh call"
+else
+  fail "runtime pin: expected rc=2 with pin message; rc=$rc err=$(cat "$WORKDIR/pin.err")"
+fi
+if grep -q $'gh\tpr\tmerge' "$WORKDIR/calls.log"; then
+  fail "runtime pin: wrapped command ran despite the refusal"
+else
+  pass "runtime pin: no wrapped command executed on refusal"
+fi
+
+PIN_DIR2="$WORKDIR/pin-repo-custom"
+install_wrapper_copy "$PIN_DIR2"
+printf "author_identity: 'custom-author'\n" >"$PIN_DIR2/.github/review-policy.yml"
+
+reset_log
+set +e
+( cd "$PIN_DIR2" && GH_AS_AUTHOR_IDENTITY="custom-author" \
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$PIN_DIR2/scripts/gh-as-author.sh" -- gh pr merge 9 --squash ) >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] && grep -q $'GH_TOKEN=fallback-custom-author-token GITHUB_TOKEN= gh\tpr\tmerge\t9\t--squash' "$WORKDIR/calls.log"; then
+  pass "runtime pin: matching custom identity (quoted policy) proceeds with its token"
+else
+  fail "runtime pin: matching custom identity should proceed; rc=$rc calls=$(cat "$WORKDIR/calls.log")"
+fi
+
+# Subdirectory invocation must still load the pin (r20).
+mkdir -p "$PIN_DIR/subdir"
+reset_log
+set +e
+( cd "$PIN_DIR/subdir" && OP_PREFLIGHT_AUTHOR_PAT="author-token" GH_AS_AUTHOR_IDENTITY="nathanpayne-codex" \
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" ../scripts/gh-as-author.sh -- gh pr merge 9 --squash ) >/dev/null 2>"$WORKDIR/pin-sub.err"
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && grep -q "runtime byline pin" "$WORKDIR/pin-sub.err"; then
+  pass "runtime pin: subdirectory invocation still loads the repo-root policy"
+else
+  fail "runtime pin: subdirectory invocation should refuse; rc=$rc err=$(cat "$WORKDIR/pin-sub.err")"
+fi
+
+NO_POLICY_DIR="$WORKDIR/pin-repo-none"
+install_wrapper_copy "$NO_POLICY_DIR"
+rm -rf "$NO_POLICY_DIR/.github"
+reset_log
+set +e
+( cd "$NO_POLICY_DIR" && OP_PREFLIGHT_AUTHOR_PAT="author-token" \
+    PATH="$STUB_DIR:$PATH" GH_CALLS_LOG="$WORKDIR/calls.log" "$NO_POLICY_DIR/scripts/gh-as-author.sh" -- gh pr merge 9 --squash ) >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "runtime pin: absent policy file keeps legacy behavior"
+else
+  fail "runtime pin: absent policy file should not block; rc=$rc"
+fi
+
 echo ""
 echo "test_gh_as_author: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -230,6 +230,260 @@ cd "$ORIG_DIR"
 assert_rc_contains "compound direct guarded write blocked" 2 "#348" \
   'gh issue close 7 && gh pr merge --admin 123'
 
+# --- author-wrapper identity pin (#438) -------------------------------
+
+assert_rc_contains "author wrapper inline non-author identity blocked" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+assert_rc_contains "author wrapper inline matching author identity allowed" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=nathanjohnpayne scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+assert_rc_contains "author wrapper inline non-author identity blocked on pr create" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-cursor scripts/gh-as-author.sh -- gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"'
+
+assert_rc_contains "author wrapper inline non-author identity blocked on codex trigger" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr comment 123 --body "@codex review"'
+
+# A stale inline assignment scoped to an EARLIER command segment must
+# not leak into the author byline guard — the shell would not pass it
+# to the wrapper (Codex P2 on PR #442).
+assert_rc_contains "stale inline author identity from earlier segment does not block" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex echo ok ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# A standalone assignment (no command in its segment) persists as a
+# shell variable, and IF the name carries the export attribute in the
+# calling shell it ALSO reaches the wrapper (Codex P1 on PR #442 r4).
+# The hook cannot observe the export attribute, so a standalone
+# non-author value must fail closed even though it might be inert.
+assert_rc_contains "standalone non-author identity assignment fails closed" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# ...but a standalone assignment of the EXPECTED author is fine either
+# way (exported: wrapper gets the expected value; unexported: wrapper
+# default is the same value).
+assert_rc_contains "standalone matching author identity assignment allowed" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=nathanjohnpayne ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# `export VAR=x ; wrapper` is DEFINITELY effective — the assignment is
+# an argument of the export command, not a bare prefix, and reaches
+# every later process (Codex P1 on PR #442 r11).
+assert_rc_contains "exported-via-export-command non-author identity blocked" 2 "author identity" \
+  'export GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+assert_rc_contains "exported-via-export-command matching author identity allowed" 0 "" \
+  'export GH_AS_AUTHOR_IDENTITY=nathanjohnpayne && scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+assert_rc_contains "exported-via-export-command non-reviewer identity blocked" 2 "expected reviewer" \
+  'export GH_AS_REVIEWER_IDENTITY=nathanpayne-codex ; scripts/gh-as-reviewer.sh -- gh pr comment 123 --body "ping"' "CLEAN" ""
+
+# Prefix-assignment BEFORE the export command in the same segment
+# (`VAR=x export VAR`) persists AND exports (Codex P1 on PR #442 r12).
+assert_rc_contains "prefix-then-export non-author identity blocked" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=nathanpayne-codex export GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr comment 123 --body "@codex review"' "CLEAN" ""
+
+assert_rc_contains "prefix-then-export matching author identity allowed" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=nathanjohnpayne export GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# declare -x is export-equivalent (Codex P1 r12 family, preempted).
+assert_rc_contains "declare -x non-author identity blocked" 2 "author identity" \
+  'declare -x GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# env-prefix on the wrapper command is a definitive same-segment prefix.
+assert_rc_contains "env-prefixed non-author identity blocked" 2 "author identity" \
+  'env GH_AS_AUTHOR_IDENTITY=nathanpayne-codex scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# eval'd assignments persist like bare standalones (preempted, r14
+# family): possibly-effective, so a mismatch fails closed.
+assert_rc_contains "eval'd non-author identity assignment fails closed" 2 "author identity" \
+  'eval GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# readonly -x exports too (Codex P1 on PR #442 r14, hook-verified).
+assert_rc_contains "readonly -x non-author identity blocked" 2 "author identity" \
+  'readonly -x GH_AS_AUTHOR_IDENTITY=nathanpayne-codex ; scripts/gh-as-author.sh -- gh pr create --title "t" --body "Authoring-Agent: claude
+
+## Self-Review
+- ok"' "CLEAN" ""
+
+# The custom-author shape from the r3 finding: standalone assignment of
+# the CUSTOM identity must NOT satisfy the guard — the wrapper would
+# actually verify its stock default.
+mkdir -p "$WORKDIR/repo-custom-author-standalone/.github"
+cat >"$WORKDIR/repo-custom-author-standalone/.github/review-policy.yml" <<'YML'
+author_identity: custom-owner
+YML
+cd "$WORKDIR/repo-custom-author-standalone"
+assert_rc_contains "standalone custom-identity assignment does not mask the wrapper default" 2 "author identity" \
+  'GH_AS_AUTHOR_IDENTITY=custom-owner && scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
+# Exported (non-inline) GH_AS_AUTHOR_IDENTITY must be caught too — the
+# wrapper reads its environment, so the hook must read the same.
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=nathanpayne-codex run_hook 'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "author wrapper exported non-author identity blocked"
+else
+  fail "author wrapper exported non-author identity blocked: rc=$rc; output: $out"
+fi
+
+# The expected author defaults from review-policy.yml author_identity
+# when GH_PR_GUARD_EXPECTED_AUTHOR is unset (Codex P2 on PR #442 r2) —
+# custom-author repos need no hook-specific variable.
+mkdir -p "$WORKDIR/repo-custom-author/.github"
+cat >"$WORKDIR/repo-custom-author/.github/review-policy.yml" <<'YML'
+author_identity: custom-owner
+YML
+cd "$WORKDIR/repo-custom-author"
+assert_rc_contains "author identity from review-policy.yml allows matching wrapper identity" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+assert_rc_contains "author identity from review-policy.yml blocks the stock default" 2 "author identity" \
+  'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
+# An EMPTY inline override resets the wrapper to its hardcoded default
+# (Codex P1 on PR #442 r15): in a custom-author repo that is a
+# wrong-byline reset and must fail closed, even when the hook's own
+# environment carries the correct custom identity.
+mkdir -p "$WORKDIR/repo-custom-author-empty/.github"
+cat >"$WORKDIR/repo-custom-author-empty/.github/review-policy.yml" <<'YML'
+author_identity: custom-owner
+YML
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'GH_AS_AUTHOR_IDENTITY= scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "empty inline author override fails closed in custom-author repo"
+else
+  fail "empty inline author override fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+# env -u / --unset / -i remove the identity from the WRAPPER's
+# environment — the r15 empty-override semantics (Codex P2 r17).
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'env -u GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "env -u identity unset fails closed in custom-author repo"
+else
+  fail "env -u identity unset fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'env --unset=GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "env --unset= identity fails closed in custom-author repo"
+else
+  fail "env --unset= identity fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+assert_rc_contains "env -u identity unset allowed in default repo" 0 "" \
+  'env -u GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# Space-separated long form: `env --unset NAME` (Codex P1 r18) — the
+# value flag must be consumed or the walk loses the wrapper entirely
+# and skips ALL checks.
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'env --unset GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "env --unset NAME (space form) fails closed in custom-author repo"
+else
+  fail "env --unset NAME (space form) fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+# ...and in a default repo the walk must still SEE the wrapper and
+# evaluate the merge-state checks (BLOCKED state proves the walk
+# reached the merge guard rather than bailing at the unset arg).
+assert_rc_contains "env --unset NAME still reaches merge-state checks" 2 "mergeStateStatus is BLOCKED" \
+  'env --unset GH_AS_AUTHOR_IDENTITY scripts/gh-as-author.sh -- gh pr merge 123 --squash' "BLOCKED" ""
+
+# The unset BUILTIN persists past separators (preempted, r17 family).
+cd "$WORKDIR/repo-custom-author-empty"
+set +e
+out=$(GH_AS_AUTHOR_IDENTITY=custom-owner run_hook 'unset GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "unset builtin identity removal fails closed in custom-author repo"
+else
+  fail "unset builtin identity removal fails closed in custom-author repo: rc=$rc; output: $out"
+fi
+cd "$ORIG_DIR"
+
+assert_rc_contains "unset builtin identity removal allowed in default repo" 0 "" \
+  'unset GH_AS_AUTHOR_IDENTITY ; scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# In a DEFAULT repo an empty override is a no-op (wrapper default ==
+# expected) and must not block.
+assert_rc_contains "empty inline author override allowed in default repo" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY= scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+
+# Subdirectory invocation: the policy is found by upward walk (r21).
+mkdir -p "$WORKDIR/repo-custom-author/subdir"
+cd "$WORKDIR/repo-custom-author/subdir"
+assert_rc_contains "author identity policy found from a subdirectory" 2 "author identity" \
+  'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
+# Quoted author_identity is valid YAML — double AND single quotes must
+# be stripped before comparison (Codex P2s on PR #442 r6/r7).
+mkdir -p "$WORKDIR/repo-quoted-author/.github"
+cat >"$WORKDIR/repo-quoted-author/.github/review-policy.yml" <<'YML'
+author_identity: "custom-owner"
+YML
+cd "$WORKDIR/repo-quoted-author"
+assert_rc_contains "double-quoted author_identity allows matching wrapper identity" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
+mkdir -p "$WORKDIR/repo-squoted-author/.github"
+cat >"$WORKDIR/repo-squoted-author/.github/review-policy.yml" <<'YML'
+author_identity: 'custom-owner'
+YML
+cd "$WORKDIR/repo-squoted-author"
+assert_rc_contains "single-quoted author_identity allows matching wrapper identity" 0 "" \
+  'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" ""
+cd "$ORIG_DIR"
+
+# Custom expected author: identity must match the override...
+set +e
+out=$(GH_PR_GUARD_EXPECTED_AUTHOR=custom-owner run_hook 'GH_AS_AUTHOR_IDENTITY=custom-owner scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "author wrapper custom expected author with matching identity allowed"
+else
+  fail "author wrapper custom expected author with matching identity allowed: rc=$rc; output: $out"
+fi
+
+# ...and an UNSET identity fails closed under a custom expected author,
+# because the wrapper would verify its stock default (nathanjohnpayne),
+# not the override.
+set +e
+out=$(GH_PR_GUARD_EXPECTED_AUTHOR=custom-owner run_hook 'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
+  pass "author wrapper unset identity under custom expected author fails closed"
+else
+  fail "author wrapper unset identity under custom expected author fails closed: rc=$rc; output: $out"
+fi
+
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
Bulk sync to [mergepath@cc3487a](https://github.com/nathanjohnpayne/mergepath/commit/cc3487aaf724aa8a3ed37de0c1c4bd89610e59f7) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/lib/gh-retry-helpers.sh
  - scripts/lib/gh-token-resolver.sh
  - scripts/lib/manifest-fact-helpers.sh
  - scripts/coderabbit-wait.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/phase-4b-classifier.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/audit-propagation-lane.sh
  - tests/test_audit_propagation_lane.sh
  - scripts/merge-clearance-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_gh_wrapper_parallel.sh
  - tests/test_identity_check.sh
  - tests/test_coderabbit_wait_identity_derivation.sh
  - tests/test_coderabbit_wait_status_probe.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_codex_review_request_ack.sh
  - tests/test_merge_clearance_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_op_preflight_check.sh
  - tests/test_op_preflight_token_mode.sh
  - tests/test_helper_autosource.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_daily_feedback_rollup.sh
  - tests/test_template_substitution.sh
  - tests/test_export_consumer_facts.sh
  - .github/pull_request_template.md
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/merge-clearance-gate.yml
  - .github/workflows/daily-feedback-rollup.yml

## Kit paths synced
  - .github/ISSUE_TEMPLATE/ (kit, allow-extras)
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.cjs.js)


Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@cc3487a HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.

<!-- lane re-evaluation nudge: advisory labeler raced the lane removal pass -->


<!-- label-gate refresh: label-free payload run after lane removal -->
