### PR TITLE
docs: correct test counts across README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Data is organized per billing year under `/users/{userId}/billingYears/{yearId}`
 - ✅ Check payment method type with name, address, phone fields
 - ✅ Bank building icon for Check payment method (branded SVG)
 - ✅ QR code uploads per payment method
-- ✅ 632 React tests + 288 legacy tests + Playwright E2E
+- ✅ ~628 React tests + 290 legacy tests + Playwright E2E
 
 ### React Migration (2026-03) --- COMPLETE
 
@@ -365,7 +365,7 @@ Data is organized per billing year under `/users/{userId}/billingYears/{yearId}`
 - ✅ Code-split lazy loading via React.lazy + Suspense
 - ✅ Vite build with code-split lazy chunks (~238 KB index + ~400 KB TipTap/InvoicingTab)
 - ✅ React Router v7 with SPA fallback rewrites
-- ✅ 632 Vitest + React Testing Library tests
+- ✅ ~628 Vitest + React Testing Library tests
 - ✅ Public share page ported to React route (/share)
 - ✅ Server-side email delivery via Resend Cloud Function
 - ✅ Firebase modular SDK replaces CDN compat libraries

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -116,7 +116,7 @@ Just send them your deployed URL. Each person:
 
 - **Frontend:** React 19 SPA (Vite dev server with HMR)
 - **Backend:** Firebase (Firestore, Cloud Functions, Auth, Hosting, Storage)
-- **Testing:** Vitest + React Testing Library (632 tests) + Playwright E2E
+- **Testing:** Vitest + React Testing Library (~628 React tests) + Playwright E2E
 - **Email:** Server-side delivery via Resend Cloud Function
 - **Rich text:** TipTap WYSIWYG editor for invoice templates
 

--- a/docs/agents/testing-requirements.md
+++ b/docs/agents/testing-requirements.md
@@ -20,7 +20,7 @@ Coverage output lands in `coverage/react/` (text summary printed to terminal, pl
 
 ## Test count
 
-**~632 React tests** (37 test files) covering services, hooks, components, and views. **288 legacy tests** via Node's native test runner. **Playwright E2E tests** in `tests/e2e/`.
+**~628 React test/it declarations** (37 test files) covering services, hooks, components, and views. **290 legacy test/it declarations** via Node's native test runner. **Playwright E2E tests** in `tests/e2e/`.
 
 ```bash
 npm run test:e2e       # Playwright end-to-end tests (builds first, serves at :4174)


### PR DESCRIPTION
Corrects test-count figures to match actual test/it declarations: React ~632 → ~628 and legacy 288 → 290. Docs-only change touching README.md, docs/QUICKSTART.md, and docs/agents/testing-requirements.md.

Authoring-Agent: claude

## Self-Review
- **Correctness:** Documentation-only; figures updated to match actual test/it declaration counts.
- **Regression risk:** None — no code or config touched.
- **Style/conventions:** Matches existing doc phrasing.
- **Test coverage:** N/A (docs only).
- **Security/dependency hygiene:** No dependency or security impact.
