### PR TITLE
docs: domain glossary and ADRs for the adjustment model

### DIFF
--- a/.ai_context.md
+++ b/.ai_context.md
@@ -29,6 +29,8 @@ React SPA is the primary app; the legacy vanilla JS build is retained at `/site/
 | `src/lib/firebase.js` | Modular Firebase init (reads from `window.__FIREBASE_CONFIG__`) |
 | `functions/index.js` | Cloud Functions v2 — processMailQueue, resolveShareToken, submitDispute, getEvidenceUrl, submitDisputeDecision |
 | `AGENTS.md` | AI agent instructions and behavioral rules |
+| `CONTEXT.md` | Ubiquitous-language glossary for the billing/settlement domain |
+| `docs/adr/` | Architecture decision records (the why behind the model) |
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Agent instructions are organized into focused sub-files under `docs/agents/`. Read the relevant file(s) before taking action in this repository.
 
+**Domain model:** before working on billing, settlement, refunds, or charges, read [`CONTEXT.md`](CONTEXT.md) (the ubiquitous-language glossary) and the decision records in [`docs/adr/`](docs/adr/).
+
 ## Sections
 
 1. **[Repository Overview](docs/agents/repository-overview.md)** --- Project description, tech stack, agent role

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,108 @@
+# Friends & Family Billing
+
+The shared context for splitting recurring bills among family and friends,
+invoicing them, and settling who has paid what across a billing year.
+
+## Language
+
+### People & money
+
+**Administrator**:
+The account owner (a Firebase-auth user) who manages bills, members, and
+settlement for their own billing years.
+_Avoid_: User, owner, admin
+
+**Member**:
+A person who owes a share of the bills and against whom payments are recorded.
+The canonical money record is always per individual member.
+_Avoid_: User, payer, family member
+
+**Primary Member**:
+The member at the head of a household—the one other members link to.
+Settlement and the close-gate count primary and independent members, never
+individuals within a household.
+_Avoid_: Parent member, head of household
+
+**Linked Member**:
+A member attached to a primary member's household via the primary's
+`linkedMembers` list. Has their own per-member balance but settles as part of
+the household.
+_Avoid_: Child member, sub-member, dependent
+
+**Household**:
+A primary member plus their linked members, treated as one settlement unit.
+Not a stored entity—it is computed from a primary member and their
+`linkedMembers`. The unit that a credit is owned by and a refund clears.
+_Avoid_: Group, family, linked group
+
+**Credit**:
+The net amount a household has overpaid—household paid minus household owed,
+when positive. Owned at the household level; internal imbalance between members
+is invisible to it (the primary member's concern, not the administrator's).
+_Avoid_: Overpayment (as the amount), negative balance
+
+**Refund**:
+A recorded outgoing disbursement that returns a household's credit. The money
+moves out-of-band (Venmo, Zelle, …); the app only records that it was sent.
+*Recording* a refund—not the member confirming it—is what clears the credit
+for settlement.
+_Avoid_: Reversal, payout, reimbursement
+
+**Carry-forward**:
+Applying a household's credit to its next billing year instead of sending it
+back—the household starts next year owing that much less. One of the two ways
+(with Refund) to clear a credit. There is deliberately no path for the
+administrator to simply keep or write off an overpayment.
+_Avoid_: Roll-over, waiver, write-off
+
+**Net Contribution**:
+What a household has actually paid toward its bills, net of money
+returned—gross payments minus recorded refunds and carried-forward credits. A household's
+settlement status (outstanding / settled / overpaid) is computed from this, not
+from gross payments, so a refunded household reads "Settled" even though its
+gross "Paid" still exceeds what it owed.
+_Avoid_: Paid (when precision matters), gross paid
+
+**Usage Charge**:
+A per-member ad-hoc debit for something one member incurred mid-year (e.g. a
+roaming overage), recorded against that member for transparency but settled,
+gated, and carried forward at the household grain—the debit mirror of a Credit.
+Recorded without immediately billing it; defaults to deferred.
+_Avoid_: Fee, surcharge, overage (as the record)
+
+**Service Credit**:
+A reduction in what members owe because a service was canceled, reduced,
+discounted, or had an issue—the −owed mirror of a Usage Charge, recorded against
+a bill (split among its members) so the bill's history stays honest. Distinct
+from a Credit: a Service Credit lowers owed and, when the member has already
+paid, *produces* a Credit.
+_Avoid_: Credit (the overpayment balance), discount, write-down
+
+### Requests
+
+**Request**:
+The umbrella for any record that rides the shared member-communication rails:
+a member-facing share view, an email, and an optional confirmation round-trip.
+Distinguished by its kind and direction (inbound from a member, or outbound
+from the administrator).
+_Avoid_: Dispute (as the umbrella term)
+
+**Review Request**:
+A member-initiated, inbound Request contesting a bill—a message, an optional
+proposed correction, and evidence—which the administrator resolves or rejects
+and the member may then accept or reject.
+_Avoid_: Dispute
+
+**Refund Notice**:
+An administrator-initiated, outbound Request informing a member that a credit
+is being returned, with the reason and payment details. The member confirms
+receipt or reports non-receipt; it never reuses the Review Request resolution
+vocabulary.
+_Avoid_: Refund dispute, refund request
+
+**Charge Notice**:
+The outbound Request the administrator sends when off-cycle-billing a member's
+deferred Usage Charges as a single invoice—the debit mirror of a Refund Notice.
+It raises the member's owed (settled via the normal payments ledger); the member
+pays it or contests it via a Review Request. Excluded from the Open Reviews KPI.
+_Avoid_: Invoice (generic), charge request

--- a/docs/adr/0001-household-is-the-unit-of-credit-and-refund.md
+++ b/docs/adr/0001-household-is-the-unit-of-credit-and-refund.md
@@ -1,0 +1,21 @@
+# Credit and refunds operate at the household level
+
+Money is recorded per individual member, and each member carries their own
+"Overpaid" badge in the settlement board—so per-member refunds look like the
+obvious model. We rejected that.
+
+A **Credit** is the *net household position* (household paid − household owed),
+one **Refund** is issued per household, and the close-gate checks households.
+This stays consistent with the existing settlement gate, which already counts
+households not individuals (`calculateSettlementMetrics`, `src/lib/calculations.js`),
+and with the reality that the administrator makes one payout to one human.
+
+Internal imbalance between members in a household—one member under-paid while
+another over-paid—is deliberately invisible to credit, refund, and the gate.
+It is the primary member's concern, not the administrator's.
+
+## Considered options
+
+- **Per-member credit and refund**—rejected: inconsistent with the
+  household-based gate, and implies multiple payouts where one happens.
+- **Household net position**—chosen.

--- a/docs/adr/0002-refunds-reuse-the-requests-substrate.md
+++ b/docs/adr/0002-refunds-reuse-the-requests-substrate.md
@@ -1,0 +1,36 @@
+# Refunds reuse the Requests substrate as a distinct kind
+
+The member-communication machinery—a member-facing share view, an email, and
+a confirmation round-trip—currently serves member-initiated disputes. Rather
+than build parallel plumbing, an administrator-initiated **Refund Notice**
+reuses it as a second *kind* of **Request**, alongside the renamed **Review
+Request** (formerly "dispute").
+
+The two are distinct domain concepts—inbound/adversarial vs outbound/
+cooperative—so they do **not** share confirmation vocabulary. Refund Notices
+use `confirmed_by_member` / `not_received`; they never reuse the Review
+Request's `approved_by_user` / `rejected_by_user`.
+
+This is why a future reader will find refund records living in the `disputes`
+subcollection: it is the shared Request substrate, not a claim that a refund is
+a dispute.
+
+## Considered options
+
+- **A separate subcollection + parallel Cloud Functions**—rejected:
+  duplicates the share-token, email, and confirmation plumbing.
+- **Reuse the Review Request resolution states verbatim**—rejected: overloads
+  `approved`/`rejected_by_user` with an unrelated "received / not received"
+  meaning.
+- **Shared substrate, distinct kind, distinct confirmation vocabulary**—chosen.
+
+## Scope note
+
+Renaming the existing machinery (the `disputes` subcollection, `useDisputes`,
+`DisputeDetailDialog`, the `/manage/reviews` route, and the `submitDispute*`
+Cloud Functions) to match this language is **deliberately deferred** to a
+separate, behavior-free PR. Refunds ship as a `refund_notice` *kind* under the
+existing `disputes` collection name; new code uses the glossary terms while the
+legacy `dispute*` names stay put. Do not "fix" the mismatch as a drive-by—the
+deferral is intentional, to keep this feature's (already Phase-4-sized) PR
+reviewable and to avoid a live subcollection migration.

--- a/docs/adr/0003-recording-clears-the-gate-confirmation-is-advisory.md
+++ b/docs/adr/0003-recording-clears-the-gate-confirmation-is-advisory.md
@@ -1,0 +1,39 @@
+# Recording a refund clears the close-gate; confirmation is a non-blocking trust signal
+
+> **Amended by ADR 0006:** an undisposed credit now auto-carries at close instead of blocking; everything else here stands.
+
+#314 decision 4 originally held that a Refund Notice had to be *confirmed by the
+member* before it cleared the close-gate. We reversed this.
+
+Closing a billing year asserts "I have **sent** everyone their money," not "I
+have **been confirmed** to have paid everyone back." Since the app only ever
+records out-of-band transfers (Venmo, Zelle) and never moves money itself, the
+administrator's recorded refund is the honest settlement signal—and this
+matches the literal requirement in #314 ("until an outgoing payment has been
+**recorded**").
+
+Therefore **recording a Refund (or a Waiver) clears a household's credit and the
+gate, optimistically.** Member confirmation (`confirmed_by_member`) is a
+positive trust signal that changes nothing about the gate.
+
+One exception preserves member protection: an **active, unresolved
+`not_received`** report re-opens that household's credit and re-blocks the gate
+*while the year is still open*. The administrator resolves it by re-sending (a
+new recorded refund), cancelling-and-waiving, or dismissing it as false with a
+logged reason (which keeps the member's objection in the audit trail). Silence
+never blocks—only active denial does—so there is no deadlock. A
+`not_received` arriving after the year has closed is a non-blocking follow-up; it
+does not auto-reopen a read-only year.
+
+## Considered options
+
+- **"Paid everyone back" (confirmation gates)**—rejected: a member can hold the
+  year open indefinitely by never responding, forcing a manual-override escape
+  hatch and a silence-vs-denial distinction.
+- **"Sent everyone their money" (recording gates)**—chosen, with the active-
+  denial re-block as the one concession to member protection.
+
+## Supersedes
+
+- #314 decision 4 ("member confirmation holds the gate"). The issue text is now
+  stale and should be reconciled.

--- a/docs/adr/0004-credits-flow-back-to-the-member.md
+++ b/docs/adr/0004-credits-flow-back-to-the-member.md
@@ -1,0 +1,35 @@
+# Credits flow back to the member: refund or carry-forward, never write-off
+
+> **Amended by ADR 0006:** an undisposed credit now auto-carries at close instead of blocking; carry-forward becomes the default, refund the active alternative.
+
+A household credit has exactly two exits, and both return the value to the
+member:
+
+- **Refund**—send it back out-of-band now.
+- **Carry-forward**—apply it to the household's next billing year.
+
+We deliberately removed any "waiver" / "write-off" path where the administrator
+keeps the overpaid cash. In a friends-and-family tool the administrator must
+never silently pocket an overpayment; every credit is returned—now, or against
+next year's invoice. A member who says "just keep it" gets next-year credit
+anyway; there is no machinery for the administrator to accept an overpayment as
+a gift. A future reader will not find a "forgive credit" action—its absence is
+intentional.
+
+Carry-forward is recorded as a **pending household credit, applied lazily**:
+choosing it clears the close-gate immediately (consistent with ADR 0003—the
+disposition is *recorded*, not contingent on a future year existing), and
+`buildNewYearData` seeds the opening credit whenever the household's next year is
+created. If no next year is ever created, the pending credit is preserved in the
+record (recoverable), never destroyed.
+
+**Refund is the universal fallback**—always available regardless of whether a
+next year will exist, so a credit is never trapped.
+
+## Considered options
+
+- **Waiver (administrator keeps it) + refund**—rejected: lets the administrator
+  pocket overpayments; wrong for a trust-based tool.
+- **Carry-forward requiring the next year to already exist (eager)**—rejected:
+  would block closing this year until a next year is created.
+- **Refund + lazily-applied carry-forward, no write-off**—chosen.

--- a/docs/adr/0005-symmetric-owed-adjustment-model.md
+++ b/docs/adr/0005-symmetric-owed-adjustment-model.md
@@ -1,0 +1,57 @@
+# Off-cycle adjustments: the symmetric owed-modifier model
+
+Members incur ad-hoc debits mid-year (e.g. roaming overages), and services get
+canceled or cheaper mid-year. Billing each debit as it happens means a stream of
+tiny Venmo asks and awkward heads-up texts; rewriting a bill's amount to reflect
+a cancellation lies about what the bill was. Both are modeled instead as
+**owed-adjustments**.
+
+- **Usage Charge**—a `+owed`, per-member ad-hoc debit (the roaming overage).
+- **Service Credit**—a `−owed`, bill-level reduction (a service canceled,
+  discounted, or with an issue), split among the bill's members so the bill's
+  history stays honest.
+
+**Grain follows ADR 0001.** Adjustments are recorded per-member for transparency
+(a linked member sees their own pending charges on their share page) but settle,
+gate, and carry forward at the household grain. The household remains the
+settlement unit.
+
+**Settlement.** A billed Usage Charge raises the member's owed and is settled
+through the existing `payments[]` ledger—incoming money, unlike a refund, which
+leaves and stays out of the ledger (#314). A Service Credit lowers owed and, when
+the member has already paid, produces an overpayment **Credit** that rides #314's
+refund/carry pipeline. Neither needs a new disposition path, and the debit gate
+is just the existing Outstanding check once billed charges land in owed.
+
+**Data model: two arrays split by layer, not direction.**
+
+- `owedAdjustments[]`—Usage Charges (`+`) and Service Credits (`−`): both
+  signed modifiers of owed, grain- and reason-tagged.
+- `creditAdjustments[]`—refund/carry, the disposition of a resulting balance
+  (#314). Kept separate because a disposition is not an owed-modifier.
+
+The carry-forward seam takes two feeds—still-deferred items from
+`owedAdjustments[]` and carried credits from `creditAdjustments[]`—and nets
+them to one household opening balance. Designed once; used by both directions.
+
+**Communication.** Off-cycle billing emits a **Charge Notice** (outbound Request,
+the debit mirror of a Refund Notice), fire-and-forget. The member pays it
+(`payments[]`) or contests it via the existing **Review Request** path—no new
+acknowledgment Cloud Function. Charge Notices are excluded from the "Open
+Reviews" KPI, like Refund Notices.
+
+Append-only integrity, single source of truth on the adjustment, and the
+lossless-serialization discipline all carry over from #314.
+
+## Considered options
+
+- **Bill each charge as incurred**—rejected: this is the social problem the
+  feature exists to remove.
+- **Edit or remove the bill for a cancellation/reduction**—rejected: the flat
+  annual/monthly bill model can't prorate, it rewrites bill history, and it loses
+  the reason.
+- **One unified `adjustments[]` for everything** (charges + credits +
+  dispositions)—rejected: mixes owed-modifiers with balance-dispositions and
+  muddies the gate math.
+- **Fully per-member charges** (reopen ADR 0001)—rejected: keeps the household
+  as the settlement unit.

--- a/docs/adr/0006-undisposed-adjustments-auto-carry.md
+++ b/docs/adr/0006-undisposed-adjustments-auto-carry.md
@@ -1,0 +1,23 @@
+# Undisposed adjustments auto-carry at close (amends ADR 0003, ADR 0004)
+
+ADR 0003 and ADR 0004 made an unresolved **Credit** *block* the year-close until
+the administrator actively recorded a refund or a carry-forward. Extending the
+model to the debit side (ADR 0005) exposed an asymmetry: a deferred **Usage
+Charge** auto-carries, but a Credit blocked. We made them symmetric.
+
+At close, **any *undisposed* adjustment—a Credit or a deferred Usage Charge—auto-carries into next year by default. Neither blocks.** Carry-forward is the
+default; refund (for credits) and off-cycle billing (for charges) are the active
+alternatives. The close-gate blocks only on **present-tense money**: a household
+that is Outstanding (underpaid, now including any billed-unpaid charges). Nothing
+*undisposed* holds the year open.
+
+One exception preserves the member protection from ADR 0003: an active,
+unresolved **`not_received`** is a live dispute, not an undisposed adjustment, so
+it still re-blocks the gate rather than silently carrying.
+
+## Amends
+
+- **ADR 0003** and **ADR 0004**: the "unresolved credit blocks the close" rule is
+  replaced by "undisposed adjustments auto-carry." Everything else in those ADRs
+  stands—recording clears (not confirmation), confirmation is advisory, refund
+  and carry-forward are the two credit exits, and there is never a write-off.

--- a/docs/adr/0007-closed-years-are-corrected-forward.md
+++ b/docs/adr/0007-closed-years-are-corrected-forward.md
@@ -1,0 +1,30 @@
+# Closed years are corrected forward, not reopened
+
+Once a billing year is Closed it is read-only (`_guardReadOnly`,
+`src/lib/BillingYearService.js`), and the new adjustment mutations (refund, usage
+charge, service credit, off-cycle bill) are guarded the same way. The natural
+question—"must I reopen a closed year to refund last year's credit or bill a
+late charge?"—has a deliberate answer: **almost never.**
+
+Because undisposed adjustments auto-carry at close (ADR 0006), by the time a year
+is Closed every actionable balance—credits, deferred charges—has already
+moved into the next year. So refunds, off-cycle bills, service credits, and
+follow-ups all happen in the current/next open year, acting on the carried
+balances. The closed year is left settled. (If no next year exists yet, the
+carried balance is pending and materializes when the next year is created—still
+forward, still no reopen.)
+
+Reopening (Settings → Billing Controls → Reopen to Settling) is reserved for
+**correcting the closed year's own ledger**—e.g., reversing a payment
+mis-recorded in that year. That is editing settled history, so it is deliberately
+friction-ful and rare.
+
+A `not_received` on a refund issued before close is a non-blocking follow-up
+(ADR 0003): resolve it forward (a fresh credit/refund in the open year) by
+default, reopening only if the closed year's record must reflect the re-send.
+
+## Consequence
+
+- The new adjustment mutations stay `_guardReadOnly`-guarded for consistency with
+  `recordPayment`/`reversePayment`; the guard rarely bites because the work is
+  forward, in the open year.


### PR DESCRIPTION
## Summary

Adds the domain documentation produced while designing #314 (now generalized to off-cycle adjustments — credits/refunds **and** usage charges, with carry-forward):

- **`CONTEXT.md`** — ubiquitous-language glossary (Administrator, Member, Household, Credit, Refund, Carry-forward, Net Contribution, Request, Review Request, Refund Notice, Usage Charge, Service Credit, Charge Notice, …).
- **`docs/adr/0001`–`0007`** — architecture decision records, each with a "Considered options" section. ADR 0006 amends 0003/0004 (auto-carry); pointers added to both.
- **`AGENTS.md` / `.ai_context.md`** — one-line pointers so an agent following the documented reading order actually finds the glossary and ADRs.

No code changes. This is the design baseline the #314 implementation slices will build on.

Authoring-Agent: claude

## Self-Review

- **Correctness:** Documentation only — no runtime impact. Cited `file:line` references (`billing-year.js:75`, `calculations.js:27/106`, `BillingYearService.js:377`, etc.) were verified against HEAD. ADR cross-references (0006 amends 0003/0004; 0007 references 0003/0006) are consistent.
- **Regression risk:** None. No files under `src/`, `functions/`, `.github/`, `firestore.rules`, or `storage.rules` are touched.
- **Style:** Closed em-dashes per house style; ADR format per the `docs/adr` convention; `CONTEXT.md` is a glossary only (no implementation detail).
- **Test coverage:** N/A (docs). `check_spec_test_alignment` unaffected — no `specs/` change. `check_required_root_files` still satisfied (`.ai_context.md` retained).
- **Security/dependency hygiene:** No secrets, credentials, or dependency changes. Secret scan unaffected.

## Note on review path

At **353 changed lines** this meets the `external_review_threshold` (300) in `.github/review-policy.yml`, so it formally qualifies for Phase 4 external review even though it is docs-only and touches no `external_review_paths`. Flagging for a decision: run the Codex Phase-4 loop, split into two sub-300 PRs (glossary vs ADRs) for internal-only review, or human break-glass given zero runtime risk.
