### PR TITLE
feat: issue a refund — recording clears the household credit (#318)

### DIFF
--- a/specs/billing-calculations.md
+++ b/specs/billing-calculations.md
@@ -112,6 +112,11 @@ Off-cycle credits (#316, ADR 0001, ADR 0005) are read-only display calculations 
 - `reversePayment` creates a negative reversal entry, marks the original as reversed, emits `PAYMENT_REVERSED` event, rejects unknown or already-reversed payments, and prevents reversing a reversal entry.
 - `updatePayment` edits a payment's method and/or note in place, emits `PAYMENT_UPDATED` event with before/after values for audit trail, returns original unchanged when no fields differ, and rejects edits on reversed or reversal entries.
 
+#### Credit Dispositions
+
+- `issueRefund` records a Refund (#318) for a household that carries a Credit by appending to `creditAdjustments[]` (append-only; `type: 'refund'`, `status: 'recorded'`, the household primary's `memberId`). Recording it clears the credit immediately (Model B, ADR 0003 — no member confirmation), since the refund subtracts from Net Contribution and lives outside the payments ledger; `payments[]` and the payment math are untouched. It emits a `REFUND_ISSUED` billing event and triggers save.
+- The refund must target the household primary (rejects a linked member, ADR 0001), requires a non-empty reason, rejects non-positive amounts, rejects a household with no credit, and **caps the amount at the household's current credit** (the credit is computed from `getHouseholdFinancials`). Throws on a read-only year.
+
 #### Settings
 
 - `updateSettings` merges new settings into existing ones, preserving unmodified keys, and throws on read-only years.

--- a/specs/settlement-board.md
+++ b/specs/settlement-board.md
@@ -39,6 +39,7 @@ Covers the settlement board component for tracking household payment status, the
 - Expanded detail shows primary actions (Record Payment, Payment History, Text Invoice) as direct buttons.
 - Secondary actions (Email Invoice, Generate Share Link, Manage Share Links) are in a three-dot overflow menu.
 - Shows "Record Payment" button for outstanding members; hides it when `readOnly` is true or when the member is fully settled.
+- Shows an "Issue Refund" button (#318) in the expanded card for a household carrying a credit (beyond the epsilon); hides it when `readOnly`. It opens a refund dialog with the amount defaulted to the household credit and capped at it, a method selector, and a required reason; on submit it calls `onIssueRefund` with `{ memberId, amount, method, reason }` (and validates a non-empty reason and a valid amount within the credit).
 - Opens a payment dialog with amount input, method selector, and "Save Payment" button on "Record Payment" click.
 - Validates payment amount before submission (shows "Enter a valid amount." for invalid input).
 - Calls `onRecordPayment` with memberId, amount, method, and note when submitted.

--- a/src/app/components/SettlementBoard.jsx
+++ b/src/app/components/SettlementBoard.jsx
@@ -38,7 +38,7 @@ const PAYMENT_METHODS = [
 /**
  * @param {{ familyMembers: Array, bills: Array, payments: Array, readOnly: boolean, onRecordPayment?: function, onTextInvoice?: function, onEmailInvoice?: function, onGenerateShareLink?: function, onViewHistory?: function }} props
  */
-export default function SettlementBoard({ familyMembers, bills, payments, creditAdjustments = [], readOnly, onRecordPayment, onTextInvoice, onEmailInvoice, onGenerateShareLink, onManageShareLinks, onViewHistory }) {
+export default function SettlementBoard({ familyMembers, bills, payments, creditAdjustments = [], readOnly, onRecordPayment, onIssueRefund, onTextInvoice, onEmailInvoice, onGenerateShareLink, onManageShareLinks, onViewHistory }) {
     const [filter, setFilter] = useState('all');
 
     if (familyMembers.length === 0) return null;
@@ -136,6 +136,7 @@ export default function SettlementBoard({ familyMembers, bills, payments, credit
                             onGenerateShareLink={onGenerateShareLink}
                             onManageShareLinks={onManageShareLinks}
                             onViewHistory={onViewHistory}
+                            onIssueRefund={onIssueRefund}
                         />
                     ))
                 )}
@@ -192,7 +193,7 @@ function hasSameBillSet(dataA, dataB) {
     return idsA.every((id, i) => id === idsB[i]);
 }
 
-function HouseholdCard({ row, payments, readOnly, onRecordPayment, onTextInvoice, onEmailInvoice, onGenerateShareLink, onManageShareLinks, onViewHistory }) {
+function HouseholdCard({ row, payments, readOnly, onRecordPayment, onIssueRefund, onTextInvoice, onEmailInvoice, onGenerateShareLink, onManageShareLinks, onViewHistory }) {
     const [expanded, setExpanded] = useState(false);
     const [linkedExpanded, setLinkedExpanded] = useState({});
     const [paymentOpen, setPaymentOpen] = useState(false);
@@ -201,6 +202,11 @@ function HouseholdCard({ row, payments, readOnly, onRecordPayment, onTextInvoice
     const [paymentNote, setPaymentNote] = useState('');
     const [paymentError, setPaymentError] = useState('');
     const [distribute, setDistribute] = useState(true);
+    const [refundOpen, setRefundOpen] = useState(false);
+    const [refundAmount, setRefundAmount] = useState('');
+    const [refundMethod, setRefundMethod] = useState('venmo');
+    const [refundReason, setRefundReason] = useState('');
+    const [refundError, setRefundError] = useState('');
 
     function toggleLinkedBreakdown(memberId) {
         setLinkedExpanded(prev => ({ ...prev, [memberId]: !prev[memberId] }));
@@ -211,6 +217,49 @@ function HouseholdCard({ row, payments, readOnly, onRecordPayment, onTextInvoice
     // balance is the net shortfall (owed − Net Contribution); a sub-cent residue
     // reads as settled, matching the status badge and the credit epsilon.
     const showPaymentAction = !readOnly && balance > CREDIT_EPSILON;
+    // A household with a Credit can be refunded (#318); the refund is issued to the primary member.
+    const showRefundAction = !readOnly && credit > CREDIT_EPSILON;
+
+    function openRefund() {
+        setRefundAmount(credit.toFixed(2));
+        setRefundMethod('venmo');
+        setRefundReason('');
+        setRefundError('');
+        setRefundOpen(true);
+    }
+
+    function cancelRefund() {
+        setRefundOpen(false);
+        setRefundAmount('');
+        setRefundReason('');
+        setRefundError('');
+    }
+
+    function handleIssueRefund(e) {
+        e.preventDefault();
+        setRefundError('');
+        const amt = Math.round((parseFloat(refundAmount) || 0) * 100) / 100;
+        if (!amt || amt <= 0) {
+            setRefundError('Enter a valid amount.');
+            return;
+        }
+        if (amt > credit + CREDIT_EPSILON) {
+            setRefundError('Refund cannot exceed the credit of ' + formatAnnualSummaryCurrency(credit) + '.');
+            return;
+        }
+        if (!refundReason.trim()) {
+            setRefundError('A reason is required.');
+            return;
+        }
+        try {
+            if (onIssueRefund) {
+                onIssueRefund({ memberId: member.id, amount: amt, method: refundMethod, reason: refundReason.trim() });
+            }
+            cancelRefund();
+        } catch (err) {
+            setRefundError(err.message);
+        }
+    }
 
     function handleRecordPayment(e) {
         e.preventDefault();
@@ -404,6 +453,14 @@ function HouseholdCard({ row, payments, readOnly, onRecordPayment, onTextInvoice
                                 Record Payment
                             </button>
                         )}
+                        {showRefundAction && (
+                            <button
+                                className="btn btn-primary btn-sm"
+                                onClick={openRefund}
+                            >
+                                Issue Refund
+                            </button>
+                        )}
                         <button
                             className="btn btn-tertiary btn-sm"
                             onClick={() => onViewHistory && onViewHistory(member.id)}
@@ -503,6 +560,68 @@ function HouseholdCard({ row, payments, readOnly, onRecordPayment, onTextInvoice
                             <div className="dialog-buttons">
                                 <button type="button" className="btn btn-sm btn-header-secondary" onClick={cancelPayment}>Cancel</button>
                                 <button type="submit" className="btn btn-sm btn-primary">Save Payment</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
+
+            {refundOpen && (
+                <div className="dialog-overlay" onClick={cancelRefund}>
+                    <div className="dialog" onClick={e => e.stopPropagation()}>
+                        <div className="dialog-title">Issue Refund</div>
+                        <form onSubmit={handleIssueRefund}>
+                            <p className="payment-dialog-for">
+                                For: <strong>{member.name}</strong>
+                                <span className="payment-dialog-balance">
+                                    {' '}(Credit: {formatAnnualSummaryCurrency(credit)})
+                                </span>
+                            </p>
+                            <div className="payment-dialog-fields">
+                                <div className="payment-field-group">
+                                    <label htmlFor={'refund-amount-' + member.id}>Refund amount ($)</label>
+                                    <input
+                                        id={'refund-amount-' + member.id}
+                                        className="composer-input"
+                                        type="number"
+                                        step="0.01"
+                                        min="0.01"
+                                        max={credit.toFixed(2)}
+                                        placeholder="0.00"
+                                        value={refundAmount}
+                                        onChange={e => setRefundAmount(e.target.value)}
+                                        autoFocus
+                                    />
+                                </div>
+                                <div className="payment-field-group">
+                                    <label htmlFor={'refund-method-' + member.id}>Method</label>
+                                    <select
+                                        id={'refund-method-' + member.id}
+                                        className="composer-input"
+                                        value={refundMethod}
+                                        onChange={e => setRefundMethod(e.target.value)}
+                                    >
+                                        {PAYMENT_METHODS.map(m => (
+                                            <option key={m.value} value={m.value}>{m.label}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div className="payment-field-group">
+                                    <label htmlFor={'refund-reason-' + member.id}>Reason</label>
+                                    <input
+                                        id={'refund-reason-' + member.id}
+                                        className="composer-input"
+                                        type="text"
+                                        placeholder="e.g., Returned Q1 overpayment"
+                                        value={refundReason}
+                                        onChange={e => setRefundReason(e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                            {refundError && <p className="composer-error">{refundError}</p>}
+                            <div className="dialog-buttons">
+                                <button type="button" className="btn btn-sm btn-header-secondary" onClick={cancelRefund}>Cancel</button>
+                                <button type="submit" className="btn btn-sm btn-primary">Save Refund</button>
                             </div>
                         </form>
                     </div>

--- a/src/app/views/Dashboard/DashboardView.jsx
+++ b/src/app/views/Dashboard/DashboardView.jsx
@@ -182,6 +182,14 @@ export default function DashboardView() {
                 creditAdjustments={creditAdjustments}
                 readOnly={isYearReadOnly(activeYear)}
                 onRecordPayment={data => service.recordPayment(data)}
+                onIssueRefund={data => {
+                    try {
+                        service.issueRefund(data);
+                        showToast('Refund recorded');
+                    } catch (err) {
+                        showToast('Error: ' + err.message);
+                    }
+                }}
                 onEmailInvoice={(memberId, isSettled) => {
                     if (isSettled) {
                         showToast('No balance due\u2014nothing to invoice.');

--- a/src/app/views/Dashboard/DashboardView.jsx
+++ b/src/app/views/Dashboard/DashboardView.jsx
@@ -183,12 +183,11 @@ export default function DashboardView() {
                 readOnly={isYearReadOnly(activeYear)}
                 onRecordPayment={data => service.recordPayment(data)}
                 onIssueRefund={data => {
-                    try {
-                        service.issueRefund(data);
-                        showToast('Refund recorded');
-                    } catch (err) {
-                        showToast('Error: ' + err.message);
-                    }
+                    // Let errors propagate so the board's dialog shows the inline
+                    // error and stays open (mirrors onRecordPayment). The success
+                    // toast runs only when issueRefund did not throw.
+                    service.issueRefund(data);
+                    showToast('Refund recorded');
                 }}
                 onEmailInvoice={(memberId, isSettled) => {
                     if (isSettled) {

--- a/src/lib/BillingYearService.js
+++ b/src/lib/BillingYearService.js
@@ -14,8 +14,8 @@ import { db } from './firebase.js';
 import { normalizeYearData, buildSavePayload, buildInitialYearData } from './persistence.js';
 import { plainTextToDoc } from './template-doc.js';
 import { buildNewYearData, isYearLabelDuplicate } from './billing-year.js';
-import { generateEventId, generateUniqueId, generateUniqueBillId, generateUniquePaymentId, isYearReadOnly, isValidE164 } from './validation.js';
-import { isLinkedToAnyone, calculateAnnualSummary } from './calculations.js';
+import { generateEventId, generateUniqueId, generateUniqueBillId, generateUniquePaymentId, generateCreditAdjustmentId, isYearReadOnly, isValidE164 } from './validation.js';
+import { isLinkedToAnyone, calculateAnnualSummary, getHouseholdFinancials, CREDIT_EPSILON } from './calculations.js';
 import { SaveQueue } from './SaveQueue.js';
 
 /** Default settings matching the legacy app (main.js line 77). */
@@ -923,6 +923,76 @@ export class BillingYearService {
         this._setState({ payments: updatedPayments, billingEvents: events });
         this.save();
         return updated;
+    }
+
+    // ── Credit dispositions (#318) ──
+
+    /**
+     * Issue a Refund for a household that carries a Credit. Recording the refund
+     * (Model B, ADR 0003) clears the credit immediately — no member confirmation
+     * required — by appending to creditAdjustments[] (append-only; void via status,
+     * never deleted). The refund lives OUTSIDE the payments ledger and reduces the
+     * household's Net Contribution so it reads Settled. The amount is capped at the
+     * household's current credit. HIGH-RISK: settlement/ledger boundary.
+     * @param {{ memberId: number, amount: number, method?: string, reason: string }} data
+     * @returns {Object} the recorded creditAdjustment
+     */
+    issueRefund(data) {
+        this._guardReadOnly();
+        const { familyMembers, bills, payments, creditAdjustments } = this._state;
+        const member = familyMembers.find(m => m.id === data.memberId);
+        if (!member) throw new Error('Member not found.');
+        // A Refund is a household disposition (ADR 0001) — issued to the primary member.
+        if (isLinkedToAnyone(familyMembers, member.id)) {
+            throw new Error('Refunds are issued to the household primary member.');
+        }
+
+        const amount = Math.round((parseFloat(data.amount) || 0) * 100) / 100;
+        if (amount <= 0) throw new Error('Refund amount must be greater than zero.');
+
+        const reason = (data.reason || '').trim();
+        if (!reason) throw new Error('A reason is required.');
+
+        // Cap at the household's current credit (Net Contribution − owed).
+        const summary = calculateAnnualSummary(familyMembers, bills);
+        const { credit } = getHouseholdFinancials(member, summary, payments, creditAdjustments);
+        if (credit <= CREDIT_EPSILON) throw new Error('This household has no credit to refund.');
+        if (amount > credit + CREDIT_EPSILON) {
+            throw new Error('Refund cannot exceed the household credit of ' + credit.toFixed(2) + '.');
+        }
+
+        const entry = {
+            id: generateCreditAdjustmentId(),
+            memberId: member.id,
+            type: 'refund',
+            amount,
+            method: data.method || 'other',
+            reason,
+            status: 'recorded',
+            createdAt: new Date().toISOString()
+        };
+        const event = {
+            id: generateEventId(),
+            timestamp: new Date().toISOString(),
+            actor: { type: 'admin', userId: this._user ? this._user.uid : null },
+            eventType: 'REFUND_ISSUED',
+            payload: {
+                adjustmentId: entry.id,
+                memberId: member.id,
+                memberName: member.name,
+                amount,
+                method: entry.method
+            },
+            note: '',
+            source: 'ui'
+        };
+
+        this._setState({
+            creditAdjustments: [...(creditAdjustments || []), entry],
+            billingEvents: [...(this._state.billingEvents || []), event]
+        });
+        this.save();
+        return entry;
     }
 
     // ── Settings ──

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -52,6 +52,13 @@ export function generateUniquePaymentId() {
 /**
  * @returns {string}
  */
+export function generateCreditAdjustmentId() {
+    return 'cadj_' + Date.now() + '_' + Math.floor(Math.random() * 100000);
+}
+
+/**
+ * @returns {string}
+ */
 export function generateRawToken() {
     const bytes = new Uint8Array(32);
     crypto.getRandomValues(bytes);

--- a/tests/react/components/SettlementBoard.test.jsx
+++ b/tests/react/components/SettlementBoard.test.jsx
@@ -458,3 +458,59 @@ describe('SettlementBoard — household credit', () => {
         expect(screen.getAllByText('Record Payment').length).toBeGreaterThanOrEqual(1);
     });
 });
+
+// ──────────────── Issue Refund action (#318) ────────────────
+//
+// Bob (independent) owes $480/yr; paying $548.98 leaves a $68.98 household credit.
+
+describe('SettlementBoard — Issue Refund', () => {
+    const overpaid = [{ memberId: 2, amount: 548.98, method: 'cash' }];
+
+    it('shows Issue Refund in the expanded card for a household with a credit', () => {
+        render(<SettlementBoard familyMembers={members} bills={bills} payments={overpaid} readOnly={false} onIssueRefund={() => {}} />);
+        expandCard('Bob');
+        expect(screen.getAllByText('Issue Refund').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not show Issue Refund for a household with no credit', () => {
+        render(<SettlementBoard familyMembers={members} bills={bills} payments={[]} readOnly={false} onIssueRefund={() => {}} />);
+        expandCard('Bob');
+        expect(screen.queryByText('Issue Refund')).toBeNull();
+    });
+
+    it('hides Issue Refund when readOnly', () => {
+        render(<SettlementBoard familyMembers={members} bills={bills} payments={overpaid} readOnly={true} onIssueRefund={() => {}} />);
+        expandCard('Bob');
+        expect(screen.queryByText('Issue Refund')).toBeNull();
+    });
+
+    it('opens a refund dialog defaulting the amount to the household credit', () => {
+        render(<SettlementBoard familyMembers={members} bills={bills} payments={overpaid} readOnly={false} onIssueRefund={() => {}} />);
+        expandCard('Bob');
+        fireEvent.click(screen.getByText('Issue Refund'));
+        expect(screen.getByText('Save Refund')).toBeInTheDocument();
+        expect(screen.getByLabelText(/Refund amount/).value).toBe('68.98');
+    });
+
+    it('calls onIssueRefund with memberId, amount, method, and reason', () => {
+        const onIssueRefund = vi.fn();
+        render(<SettlementBoard familyMembers={members} bills={bills} payments={overpaid} readOnly={false} onIssueRefund={onIssueRefund} />);
+        expandCard('Bob');
+        fireEvent.click(screen.getByText('Issue Refund'));
+        fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'Overpaid Q1' } });
+        fireEvent.click(screen.getByText('Save Refund'));
+        expect(onIssueRefund).toHaveBeenCalledWith(expect.objectContaining({
+            memberId: 2, amount: 68.98, reason: 'Overpaid Q1'
+        }));
+    });
+
+    it('requires a reason before submitting', () => {
+        const onIssueRefund = vi.fn();
+        render(<SettlementBoard familyMembers={members} bills={bills} payments={overpaid} readOnly={false} onIssueRefund={onIssueRefund} />);
+        expandCard('Bob');
+        fireEvent.click(screen.getByText('Issue Refund'));
+        fireEvent.click(screen.getByText('Save Refund'));
+        expect(onIssueRefund).not.toHaveBeenCalled();
+        expect(screen.getByText(/reason is required/i)).toBeInTheDocument();
+    });
+});

--- a/tests/react/components/SettlementBoard.test.jsx
+++ b/tests/react/components/SettlementBoard.test.jsx
@@ -500,7 +500,7 @@ describe('SettlementBoard — Issue Refund', () => {
         fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'Overpaid Q1' } });
         fireEvent.click(screen.getByText('Save Refund'));
         expect(onIssueRefund).toHaveBeenCalledWith(expect.objectContaining({
-            memberId: 2, amount: 68.98, reason: 'Overpaid Q1'
+            memberId: 2, amount: 68.98, method: 'venmo', reason: 'Overpaid Q1'
         }));
     });
 
@@ -512,5 +512,19 @@ describe('SettlementBoard — Issue Refund', () => {
         fireEvent.click(screen.getByText('Save Refund'));
         expect(onIssueRefund).not.toHaveBeenCalled();
         expect(screen.getByText(/reason is required/i)).toBeInTheDocument();
+    });
+
+    it('surfaces a refund failure as an inline error and keeps the dialog open', () => {
+        // A throwing callback (e.g. the service rejecting an over-cap amount) must
+        // not close the dialog — the error shows inline and input is preserved.
+        const onIssueRefund = vi.fn(() => { throw new Error('Refund cannot exceed the credit.'); });
+        render(<SettlementBoard familyMembers={members} bills={bills} payments={overpaid} readOnly={false} onIssueRefund={onIssueRefund} />);
+        expandCard('Bob');
+        fireEvent.click(screen.getByText('Issue Refund'));
+        fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'Overpaid' } });
+        fireEvent.click(screen.getByText('Save Refund'));
+        expect(onIssueRefund).toHaveBeenCalled();
+        expect(screen.getByText(/cannot exceed/i)).toBeInTheDocument(); // inline error
+        expect(screen.getByText('Save Refund')).toBeInTheDocument();    // dialog still open
     });
 });

--- a/tests/react/lib/BillingYearService.mutations.test.js
+++ b/tests/react/lib/BillingYearService.mutations.test.js
@@ -34,6 +34,7 @@ vi.mock('firebase/firestore', () => ({
 }));
 
 import { BillingYearService } from '@/lib/BillingYearService.js';
+import { calculateAnnualSummary, getHouseholdFinancials } from '@/lib/calculations.js';
 
 function clearStore() {
     for (const key of Object.keys(mockStore)) delete mockStore[key];
@@ -547,6 +548,88 @@ describe('BillingYearService — CRUD mutations', () => {
     });
 
     // ── Settings ──
+
+    describe('issueRefund', () => {
+        // Alice (id 1, solo) owes 600 on Internet; overpay so the household carries a credit.
+        function withCredit(amount = 700) {
+            const svc = createService();
+            svc._setState({ payments: [{ id: 'pay_1', memberId: 1, amount, receivedAt: '2026-01-01', note: '', method: 'cash' }] });
+            return svc;
+        }
+
+        function householdCredit(svc, memberId) {
+            const { familyMembers, bills, payments, creditAdjustments } = svc.getState();
+            const summary = calculateAnnualSummary(familyMembers, bills);
+            return getHouseholdFinancials(familyMembers.find(m => m.id === memberId), summary, payments, creditAdjustments);
+        }
+
+        it('records a refund to creditAdjustments and triggers save', () => {
+            const svc = withCredit();
+            const entry = svc.issueRefund({ memberId: 1, amount: 100, method: 'venmo', reason: 'Overpaid' });
+            expect(entry.type).toBe('refund');
+            expect(entry.status).toBe('recorded');
+            expect(entry.amount).toBe(100);
+            expect(entry.memberId).toBe(1);
+            expect(svc.getState().creditAdjustments).toHaveLength(1);
+        });
+
+        it('clears the household credit so Net Contribution nets to owed (Model B, no confirmation)', () => {
+            const svc = withCredit(); // credit 100
+            svc.issueRefund({ memberId: 1, amount: 100, method: 'venmo', reason: 'Overpaid' });
+            const f = householdCredit(svc, 1);
+            expect(f.credit).toBe(0);
+            expect(f.netContribution).toBeCloseTo(600, 5); // == owed
+        });
+
+        it('caps the refund at the household credit (rejects an amount over it)', () => {
+            const svc = withCredit(); // credit 100
+            expect(() => svc.issueRefund({ memberId: 1, amount: 150, reason: 'x' })).toThrow(/exceed|credit/i);
+        });
+
+        it('rejects a household with no credit', () => {
+            const svc = createService(); // Alice paid 50 → underpaid, no credit
+            expect(() => svc.issueRefund({ memberId: 1, amount: 10, reason: 'x' })).toThrow(/no credit/i);
+        });
+
+        it('rejects zero or negative amounts', () => {
+            const svc = withCredit();
+            expect(() => svc.issueRefund({ memberId: 1, amount: 0, reason: 'x' })).toThrow(/greater than zero/i);
+        });
+
+        it('requires a reason', () => {
+            const svc = withCredit();
+            expect(() => svc.issueRefund({ memberId: 1, amount: 50, reason: '   ' })).toThrow(/reason/i);
+        });
+
+        it('rejects an unknown member', () => {
+            const svc = withCredit();
+            expect(() => svc.issueRefund({ memberId: 999, amount: 50, reason: 'x' })).toThrow(/not found/i);
+        });
+
+        it('must target the household primary (rejects a linked member)', () => {
+            const svc = createService(); // Carol (3) is linked to Bob (2)
+            expect(() => svc.issueRefund({ memberId: 3, amount: 10, reason: 'x' })).toThrow(/primary|household/i);
+        });
+
+        it('emits a REFUND_ISSUED billing event', () => {
+            const svc = withCredit();
+            svc.issueRefund({ memberId: 1, amount: 100, method: 'venmo', reason: 'Overpaid' });
+            expect(svc.getState().billingEvents.some(e => e.eventType === 'REFUND_ISSUED')).toBe(true);
+        });
+
+        it('is append-only — a partial refund leaves a residual credit', () => {
+            const svc = withCredit(); // credit 100
+            svc.issueRefund({ memberId: 1, amount: 60, method: 'venmo', reason: 'Partial' });
+            expect(svc.getState().creditAdjustments).toHaveLength(1);
+            expect(householdCredit(svc, 1).credit).toBeCloseTo(40, 5); // 100 − 60
+        });
+
+        it('throws on a read-only year', () => {
+            const svc = withCredit();
+            svc._setState({ activeYear: { id: '2024', status: 'closed' } });
+            expect(() => svc.issueRefund({ memberId: 1, amount: 50, reason: 'x' })).toThrow(/read-only/i);
+        });
+    });
 
     describe('updateSettings', () => {
         it('merges settings', () => {


### PR DESCRIPTION
Closes #318. Refund disposition (credit side) of the off-cycle-adjustments epic (#314), building on the merged #316.

Authoring-Agent: claude

## What this builds
Lets the administrator record a Refund for a household that carries a Credit; recording it clears the credit immediately (Model B, ADR 0003 — no member confirmation), because the refund subtracts from Net Contribution and lives outside the payments ledger.

- `BillingYearService.issueRefund({ memberId, amount, method, reason })`: appends to `creditAdjustments[]` (append-only; `type: 'refund'`, `status: 'recorded'`, household primary). Caps the amount at the household credit; requires a reason; targets the primary (ADR 0001); emits `REFUND_ISSUED`; guards read-only. `payments[]` and the payment math are untouched.
- SettlementBoard "Issue Refund" action + dialog (amount defaults to the credit and is capped, method, required reason) for households with a credit; DashboardView wires it to the service.
- Netting to Settled, the "Owed to Members" decrease, the `creditAdjustments` persistence round-trip, and legacy settlement math were already wired by #316; this slice adds the mutation + UI.

## ⚠️ High-risk zone — mandatory human review
Touches `src/lib/BillingYearService.js` (new `issueRefund` mutation) and `src/lib/calculations.js` (credit cap via `getHouseholdFinancials`). Meets the Phase 4 external-review threshold (touches `src/lib/**`, > 300 lines).

## Scope boundaries (NOT here)
- No Refund Notice / member notification / confirm / not_received — that is #319.
- No carry-forward — that is #322. This slice records a refund only.
- No usage-charge / owedAdjustments code — that is #317 (built in parallel).

## Self-Review
**Correctness.** `issueRefund` validates in order: read-only guard, member exists, primary-only (ADR 0001), positive amount, non-empty reason, household has a credit, amount within credit + epsilon. The refund record holds the financial source of truth; recording subtracts from Net Contribution via the existing `getHouseholdFinancials`, so the household reads Settled and "Owed to Members" drops. Append-only — void is a future status change, never a delete.
**Regression risk.** `payments[]`, `recordPayment` / `reversePayment`, and the existing payment math are untouched. The new optional `onIssueRefund` prop defaults to a no-op, so existing SettlementBoard / Dashboard behavior is unchanged when absent. Full suite green: 691 React + 290 legacy, secret scan clean.
**Test coverage.** +17 tests: 11 mutation (validation, cap, netting, append-only partial refund, event, read-only, primary-only) + 6 board (action visibility, dialog default/cap, callback, reason-required). Specs updated (billing-calculations, settlement-board); alignment passes.
**Security / dependency hygiene.** No new deps. No `firestore.rules` / `storage.rules` / Cloud Functions changes (the member-facing Refund Notice and its share scope are #319). Secret scan passes. The app records an out-of-band transfer; it does not move money.

## Test plan
- `npm test` → legacy (290) + React (691) + secret scan: green locally.
- repo_lint `check_*`: pass.