### PR TITLE
feat: warn (don't block) when reversing a payment for a refunded household (#331)

### DIFF
--- a/specs/billing-persistence.md
+++ b/specs/billing-persistence.md
@@ -18,6 +18,7 @@ Covers data serialization, normalization, initial data construction, save queue 
 
 - `buildSavePayload` includes all top-level fields: label, status, familyMembers, bills, payments, creditAdjustments, owedAdjustments, billingEvents, and settings.
 - `creditAdjustments` (refunds + carried-forward credits, #316) is preserved verbatim and defaults to an empty array when omitted. Because `save()` writes with `setDoc` and no merge, an omitted field is erased from the document; preserving `creditAdjustments` keeps the load → save round-trip lossless.
+- The reversal-after-refund warning (#331) is display/confirmation only and persists nothing of its own: `reversePayment` is unchanged (it still appends a negative reversal entry and marks the original `reversed`, never a physical delete), and the household's `type: 'refund'` `creditAdjustments[]` record is left in place — append-only, never auto-clawed-back by a reversal. A reversed-then-refunded household therefore round-trips with both the reversal ledger entry and the intact refund adjustment.
 - `owedAdjustments` (Usage Charges, #317 — signed owed-modifiers) is preserved verbatim and defaults to an empty array when omitted, for the same reason: a full-document save would otherwise erase it.
 - QR codes are stripped from payment methods in the payload and replaced with a `hasQrCode: true` flag; the original settings object is not mutated.
 

--- a/specs/settlement-board.md
+++ b/specs/settlement-board.md
@@ -11,6 +11,7 @@ Covers the settlement board component for tracking household payment status, the
 - `tests/react/components/SettlementBoard.test.jsx`
 - `tests/react/components/UsageChargeDialog.test.jsx`
 - `tests/react/components/ServiceCreditDialog.test.jsx`
+- `tests/react/components/PaymentHistoryDialog.test.jsx`
 - `tests/react/views/BillsTab.test.jsx`
 - `tests/react/views/DashboardView.test.jsx`
 
@@ -136,3 +137,11 @@ Covers the settlement board component for tracking household payment status, the
 - Shows empty state ("Add members and bills") when no members exist.
 - Shows loading state ("Loading...") when data is loading.
 - Backward lifecycle transitions (Back to Open, Reopen to Settling) are not available on the dashboard; they remain exclusively in Settings → Billing Controls.
+
+### Payment History — reversal-after-refund warning (#331, ADR 0003)
+
+The `PaymentHistoryDialog` is opened from the household card's "Payment History" action (`onViewHistory(member.id)`), so it is scoped to the household primary; its `creditAdjustments`, `owedAdjustments`, and the reopened-adjustment set are threaded in from the dashboard.
+
+- When the household holds an **active recorded Refund** (a `creditAdjustments[]` record with `type: 'refund'` and `status !== 'cancelled'`, summed across the primary + linked members via `getHouseholdRecordedRefund`), reversing a payment opens a confirmation titled "Reverse Payment — Refund on Record" whose message names (a) the recorded refund amount and (b) the resulting household Outstanding balance — `(owed − Net Contribution) + reversed amount`, derived from the same `getHouseholdFinancials` the board shows — and states the refund is not automatically clawed back. In the uncommon case where a partial refund leaves residual credit so the reversal does not actually flip the household Outstanding (resulting balance ≤ the credit epsilon), the message says the reversal "lowers their Net Contribution but leaves the household in credit" instead of naming a misleading "$0.00 Outstanding".
+- The warning is **non-blocking**: the "Reverse" action stays available and proceeds on confirm. Reversing is the correct, automatic mechanism — gross paid drops, Net Contribution falls, the household reads Outstanding — and the refund record is left in place (append-only).
+- A household with **no** active recorded refund (none, all cancelled, or only carried-forward credits with `type: 'carry_forward'`) shows the unchanged confirmation ("Reverse the $X payment from <date>? This creates a reversal entry in the audit trail.") titled "Reverse Payment" — the existing reverse flow is untouched.

--- a/src/app/components/PaymentHistoryDialog.jsx
+++ b/src/app/components/PaymentHistoryDialog.jsx
@@ -3,7 +3,15 @@
  * Port of showPaymentHistory() from main.js:5310.
  */
 import { useState } from 'react';
-import { getMemberPayments, getPaymentTotalForMember, calculateAnnualSummary } from '../../lib/calculations.js';
+import {
+    getMemberPayments,
+    getPaymentTotalForMember,
+    calculateAnnualSummary,
+    getHouseholdRecordedRefund,
+    getHouseholdFinancials,
+    getHouseholdOpeningBalance,
+    CREDIT_EPSILON
+} from '../../lib/calculations.js';
 import { getPaymentMethodLabel, formatAnnualSummaryCurrency } from '../../lib/formatting.js';
 import ConfirmDialog from './ConfirmDialog.jsx';
 
@@ -21,9 +29,9 @@ const PAYMENT_METHODS = [
 ];
 
 /**
- * @param {{ open: boolean, memberId: number, memberName: string, familyMembers: Array, bills: Array, payments: Array, readOnly: boolean, onReverse?: function, onEditPayment?: function, onClose: function }} props
+ * @param {{ open: boolean, memberId: number, memberName: string, familyMembers: Array, bills: Array, payments: Array, creditAdjustments?: Array, owedAdjustments?: Array, reopenedAdjustmentIds?: Set<string>|null, readOnly: boolean, onReverse?: function, onEditPayment?: function, onClose: function }} props
  */
-export default function PaymentHistoryDialog({ open, memberId, memberName, familyMembers, bills, payments, readOnly, onReverse, onEditPayment, onClose }) {
+export default function PaymentHistoryDialog({ open, memberId, memberName, familyMembers, bills, payments, creditAdjustments = [], owedAdjustments = [], reopenedAdjustmentIds = null, readOnly, onReverse, onEditPayment, onClose }) {
     const [reverseTarget, setReverseTarget] = useState(null);
     const [editTarget, setEditTarget] = useState(null);
 
@@ -35,10 +43,55 @@ export default function PaymentHistoryDialog({ open, memberId, memberName, famil
     const memberTotal = summary[memberId] ? summary[memberId].total : 0;
     const balance = memberTotal - totalPaid;
 
+    // Reversal-after-refund warning (#331, ADR 0003). PaymentHistoryDialog is opened
+    // for the household primary (SettlementBoard wires onViewHistory(member.id)), so
+    // its linkedMembers give the whole household. If the household carries an active
+    // recorded Refund, reversing a payment is an informed action: it lowers Net
+    // Contribution → the household flips to Outstanding, while the refund stays on the
+    // books (never auto-clawed-back). We warn, but never block — pure display.
+    const household = familyMembers.find(m => m.id === memberId);
+    const recordedRefund = getHouseholdRecordedRefund(household, creditAdjustments);
+
+    /**
+     * Resulting household Outstanding if `target` (a positive original payment) is
+     * reversed: reversing appends a −amount entry, so Net Contribution drops by that
+     * amount and the collectable shortfall rises by it. Derived from the same
+     * household financials the settlement board shows, so the figure matches the card.
+     */
+    function resultingOutstandingAfterReversal(target) {
+        if (!household || !target) return 0;
+        const openingBalance = getHouseholdOpeningBalance(household, owedAdjustments);
+        const { owed, netContribution } = getHouseholdFinancials(
+            household, summary, payments, creditAdjustments, reopenedAdjustmentIds, owedAdjustments, openingBalance
+        );
+        return Math.max(0, (owed - netContribution) + Math.abs(target.amount));
+    }
+
     function handleReverse() {
         if (!reverseTarget || !onReverse) return;
         onReverse(reverseTarget.id);
         setReverseTarget(null);
+    }
+
+    /** Confirm message for the reverse action — warns when the household has a recorded refund. */
+    function reverseConfirmMessage() {
+        if (!reverseTarget) return '';
+        const amountLabel = formatAnnualSummaryCurrency(reverseTarget.amount);
+        const dateLabel = new Date(reverseTarget.receivedAt).toLocaleDateString();
+        if (recordedRefund.has) {
+            const refundLabel = formatAnnualSummaryCurrency(recordedRefund.total);
+            const resulting = resultingOutstandingAfterReversal(reverseTarget);
+            // Usually the reversal flips the household Outstanding; with a partial refund
+            // the household can keep residual credit, so don't claim a false "$0.00 Outstanding".
+            const impact = resulting > CREDIT_EPSILON
+                ? 'will make them Outstanding by ' + formatAnnualSummaryCurrency(resulting)
+                : 'lowers their Net Contribution but leaves the household in credit';
+            return 'This household received a ' + refundLabel + ' refund. Reversing the ' + amountLabel
+                + ' payment from ' + dateLabel + ' ' + impact
+                + ' — the refund is not automatically clawed back. This creates a reversal entry in the audit trail. Reverse anyway?';
+        }
+        return 'Reverse the ' + amountLabel + ' payment from ' + dateLabel
+            + '? This creates a reversal entry in the audit trail.';
     }
 
     return (
@@ -115,10 +168,8 @@ export default function PaymentHistoryDialog({ open, memberId, memberName, famil
 
                 <ConfirmDialog
                     open={reverseTarget !== null}
-                    title="Reverse Payment"
-                    message={reverseTarget
-                        ? 'Reverse the ' + formatAnnualSummaryCurrency(reverseTarget.amount) + ' payment from ' + new Date(reverseTarget.receivedAt).toLocaleDateString() + '? This creates a reversal entry in the audit trail.'
-                        : ''}
+                    title={recordedRefund.has ? 'Reverse Payment — Refund on Record' : 'Reverse Payment'}
+                    message={reverseConfirmMessage()}
                     confirmLabel="Reverse"
                     destructive
                     onConfirm={handleReverse}

--- a/src/app/views/Dashboard/DashboardView.jsx
+++ b/src/app/views/Dashboard/DashboardView.jsx
@@ -276,6 +276,9 @@ export default function DashboardView() {
                         familyMembers={familyMembers}
                         bills={bills}
                         payments={payments}
+                        creditAdjustments={creditAdjustments}
+                        owedAdjustments={owedAdjustments}
+                        reopenedAdjustmentIds={reopenedAdjustments}
                         readOnly={isYearReadOnly(activeYear)}
                         onReverse={paymentId => {
                             service.reversePayment(paymentId);

--- a/src/lib/calculations.js
+++ b/src/lib/calculations.js
@@ -143,6 +143,12 @@ function isActiveRefundFor(a, memberId) {
  * flips to Outstanding, while the refund stays on the books (append-only, never
  * auto-clawed-back). This is pure display — it has no effect on owed, credit, the
  * settlement gate, or any mutation.
+ *
+ * `total` is summed through addFinitePositiveAmount (as getServiceCreditTotalForMember /
+ * getBilledUsageChargeTotalForMember do), so a malformed persisted amount (a string,
+ * NaN, negative, or missing) is dropped rather than leaking a `NaN`/string into the
+ * warning copy. `has` keys off the existence of an active refund record, independent of
+ * amount validity, so the warning still fires for a refund whose amount is unparseable.
  * @param {{ id: *, linkedMembers?: Array }} member  the household's primary member
  * @param {Array} creditAdjustments
  * @returns {{ has: boolean, total: number }}
@@ -151,7 +157,7 @@ export function getHouseholdRecordedRefund(member, creditAdjustments) {
     if (!member) return { has: false, total: 0 };
     const ids = [member.id, ...((member.linkedMembers) || [])];
     const refunds = (creditAdjustments || []).filter(a => ids.some(id => isActiveRefundFor(a, id)));
-    const total = refunds.reduce((sum, a) => sum + (a.amount || 0), 0);
+    const total = refunds.reduce((sum, a) => addFinitePositiveAmount(sum, a.amount), 0);
     return { has: refunds.length > 0, total };
 }
 

--- a/src/lib/calculations.js
+++ b/src/lib/calculations.js
@@ -118,6 +118,44 @@ export function getCreditAdjustmentTotalForMember(creditAdjustments, memberId, r
 }
 
 /**
+ * Predicate: an active recorded Refund for a specific member (#318, ADR 0003).
+ * A Refund is a `type: 'refund'` creditAdjustment; "active" is `status !== 'cancelled'`,
+ * the same active test getCreditAdjustmentTotalForMember applies (a cancelled refund no
+ * longer counts). Carried-forward credits (`type: 'carry_forward'`, #316) share the
+ * array but are a different type and excluded — only a true refund is relevant here.
+ * @param {Object} a  a creditAdjustments[] record
+ * @param {*} memberId
+ * @returns {boolean}
+ */
+function isActiveRefundFor(a, memberId) {
+    return !!a && a.memberId === memberId && a.type === 'refund' && a.status !== 'cancelled';
+}
+
+/**
+ * Household-grain (ADR 0001) recorded-Refund summary: whether the household holds an
+ * active Refund and the running total of those refunds, summed across a primary member
+ * and their linked members. Refunds are always issued to the primary
+ * (BillingYearService.issueRefund), but linked ids are checked too so the household
+ * grain holds regardless of where a refund is recorded. Mirrors getHouseholdDeferredCharges.
+ *
+ * Drives the non-blocking warning shown when an admin reverses a payment for a refunded
+ * household (#331): reversing lowers gross paid → Net Contribution drops → the household
+ * flips to Outstanding, while the refund stays on the books (append-only, never
+ * auto-clawed-back). This is pure display — it has no effect on owed, credit, the
+ * settlement gate, or any mutation.
+ * @param {{ id: *, linkedMembers?: Array }} member  the household's primary member
+ * @param {Array} creditAdjustments
+ * @returns {{ has: boolean, total: number }}
+ */
+export function getHouseholdRecordedRefund(member, creditAdjustments) {
+    if (!member) return { has: false, total: 0 };
+    const ids = [member.id, ...((member.linkedMembers) || [])];
+    const refunds = (creditAdjustments || []).filter(a => ids.some(id => isActiveRefundFor(a, id)));
+    const total = refunds.reduce((sum, a) => sum + (a.amount || 0), 0);
+    return { has: refunds.length > 0, total };
+}
+
+/**
  * Predicate: a deferred Usage Charge for a specific member (#317).
  * A Usage Charge is a `+owed` per-member adjustment (kind `usage_charge`).
  * "deferred" means recorded and visible but NOT yet billed, so only deferred

--- a/tests/react/components/PaymentHistoryDialog.test.jsx
+++ b/tests/react/components/PaymentHistoryDialog.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 vi.mock('@/lib/firebase.js', () => ({ storage: {} }));
 vi.mock('firebase/storage', () => ({
@@ -65,5 +66,110 @@ describe('PaymentHistoryDialog', () => {
     it('renders nothing when not open', () => {
         const { container } = render(<PaymentHistoryDialog {...baseProps} open={false} />);
         expect(container.innerHTML).toBe('');
+    });
+});
+
+describe('PaymentHistoryDialog — reversal-after-refund warning (#331)', () => {
+    // owed $100 (annual bill), gross paid $150 ($120 + $30), $40 refund recorded →
+    // Net Contribution $110 (small credit). Reversing the $30 payment drops Net to $80
+    // → Outstanding by $20. Three distinct figures: refund $40, reversed $30, owed-back $20.
+    const members = [{ id: 1, name: 'Alice', email: '', phone: '', avatar: '', linkedMembers: [], paymentReceived: 0 }];
+    const bills = [{ id: 101, name: 'Subscription', amount: 100, billingFrequency: 'annual', members: [1] }];
+    const payments = [
+        { id: 'pay-a', memberId: 1, amount: 120, receivedAt: '2026-01-15T00:00:00Z', method: 'venmo', note: '' },
+        { id: 'pay-b', memberId: 1, amount: 30, receivedAt: '2026-02-15T00:00:00Z', method: 'cash', note: '' }
+    ];
+    const refundAdjustments = [{ id: 'r1', memberId: 1, type: 'refund', amount: 40, status: 'recorded' }];
+
+    function renderDialog(overrides = {}) {
+        const onReverse = vi.fn();
+        const props = {
+            open: true, memberId: 1, memberName: 'Alice',
+            familyMembers: members, bills, payments,
+            readOnly: false, onReverse, onClose: vi.fn(),
+            ...overrides
+        };
+        render(<PaymentHistoryDialog {...props} />);
+        return { onReverse };
+    }
+
+    // getMemberPayments sorts by receivedAt desc → the $30 Feb payment is the first reverse button.
+    async function openReverseConfirmForLatestPayment(user) {
+        await user.click(screen.getAllByTitle('Reverse this payment')[0]);
+    }
+
+    it('warns naming the refund amount and resulting Outstanding, and still lets the admin proceed', async () => {
+        const user = userEvent.setup();
+        const { onReverse } = renderDialog({ creditAdjustments: refundAdjustments });
+
+        await openReverseConfirmForLatestPayment(user);
+
+        const dialog = screen.getByRole('dialog', { name: 'Reverse Payment — Refund on Record' });
+        const message = dialog.querySelector('.confirmation-message').textContent;
+        expect(message).toContain('$40.00 refund');           // recorded refund amount
+        expect(message).toContain('Reversing the $30.00 payment');
+        expect(message).toContain('Outstanding by $20.00');   // resulting balance
+        expect(message).toContain('not automatically clawed back');
+
+        // Non-blocking: the Reverse button is present and proceeds.
+        await user.click(screen.getByRole('button', { name: 'Reverse' }));
+        expect(onReverse).toHaveBeenCalledWith('pay-b');
+    });
+
+    it('shows no refund warning for a household with no recorded refund (existing flow unchanged)', async () => {
+        const user = userEvent.setup();
+        const { onReverse } = renderDialog({ creditAdjustments: [] });
+
+        await openReverseConfirmForLatestPayment(user);
+
+        const dialog = screen.getByRole('dialog', { name: 'Reverse Payment' });
+        const message = dialog.querySelector('.confirmation-message').textContent;
+        expect(message).toBe('Reverse the $30.00 payment from ' + new Date('2026-02-15T00:00:00Z').toLocaleDateString() + '? This creates a reversal entry in the audit trail.');
+        expect(message).not.toContain('refund');
+        expect(message).not.toContain('clawed back');
+
+        await user.click(screen.getByRole('button', { name: 'Reverse' }));
+        expect(onReverse).toHaveBeenCalledWith('pay-b');
+    });
+
+    it('does not warn when the only credit adjustment is a carried-forward credit, not a refund', async () => {
+        const user = userEvent.setup();
+        renderDialog({ creditAdjustments: [{ id: 'cf1', memberId: 1, type: 'carry_forward', amount: 40, status: 'recorded' }] });
+
+        await openReverseConfirmForLatestPayment(user);
+
+        expect(screen.getByRole('dialog', { name: 'Reverse Payment' })).toBeInTheDocument();
+        expect(screen.getByText(/This creates a reversal entry in the audit trail\./).textContent).not.toContain('refund');
+    });
+
+    it('does not warn when the household refund has been cancelled', async () => {
+        const user = userEvent.setup();
+        renderDialog({ creditAdjustments: [{ id: 'r1', memberId: 1, type: 'refund', amount: 40, status: 'cancelled' }] });
+
+        await openReverseConfirmForLatestPayment(user);
+
+        expect(screen.getByRole('dialog', { name: 'Reverse Payment' })).toBeInTheDocument();
+    });
+
+    it('avoids a false "$0.00 Outstanding" when a partial refund leaves the household in credit', async () => {
+        const user = userEvent.setup();
+        // owed $100, gross paid $230 ($200 + $30), $80 refund → Net $150 (credit $50).
+        // Reversing the $30 payment drops Net to $120 — still $20 of credit, not Outstanding.
+        renderDialog({
+            payments: [
+                { id: 'pay-a', memberId: 1, amount: 200, receivedAt: '2026-01-15T00:00:00Z', method: 'venmo', note: '' },
+                { id: 'pay-b', memberId: 1, amount: 30, receivedAt: '2026-02-15T00:00:00Z', method: 'cash', note: '' }
+            ],
+            creditAdjustments: [{ id: 'r1', memberId: 1, type: 'refund', amount: 80, status: 'recorded' }]
+        });
+
+        await openReverseConfirmForLatestPayment(user);
+
+        const dialog = screen.getByRole('dialog', { name: 'Reverse Payment — Refund on Record' });
+        const message = dialog.querySelector('.confirmation-message').textContent;
+        expect(message).toContain('$80.00 refund');
+        expect(message).toContain('leaves the household in credit');
+        expect(message).not.toContain('Outstanding by');
+        expect(message).toContain('not automatically clawed back');
     });
 });

--- a/tests/react/lib/calculations.test.js
+++ b/tests/react/lib/calculations.test.js
@@ -292,6 +292,18 @@ describe('getHouseholdRecordedRefund (#331)', () => {
         expect(getHouseholdRecordedRefund(undefined, [{ id: 'c1', memberId: 1, type: 'refund', amount: 5, status: 'recorded' }]))
             .toEqual({ has: false, total: 0 });
     });
+
+    it('keeps total finite when a refund amount is malformed (no NaN/string leakage)', () => {
+        const adjustments = [
+            { id: 'c1', memberId: 1, type: 'refund', amount: 50, status: 'recorded' },
+            { id: 'c2', memberId: 1, type: 'refund', amount: 'not-a-number', status: 'recorded' },
+            { id: 'c3', memberId: 1, type: 'refund', status: 'recorded' } // missing amount
+        ];
+        const { has, total } = getHouseholdRecordedRefund(members[0], adjustments);
+        expect(has).toBe(true); // the active refund records still trigger the warning
+        expect(Number.isFinite(total)).toBe(true);
+        expect(total).toBeCloseTo(50, 5); // only the valid amount contributes
+    });
 });
 
 describe('getHouseholdFinancials', () => {

--- a/tests/react/lib/calculations.test.js
+++ b/tests/react/lib/calculations.test.js
@@ -9,6 +9,7 @@ import {
     getParentMember,
     calculateSettlementMetrics,
     getCreditAdjustmentTotalForMember,
+    getHouseholdRecordedRefund,
     getHouseholdFinancials,
     getDeferredUsageChargeTotalForMember,
     getHouseholdDeferredCharges,
@@ -235,6 +236,61 @@ describe('getCreditAdjustmentTotalForMember', () => {
     it('counts every active adjustment when the reopened set is null or empty', () => {
         expect(getCreditAdjustmentTotalForMember(adjustments, 1, null)).toBe(70);
         expect(getCreditAdjustmentTotalForMember(adjustments, 1, new Set())).toBe(70);
+    });
+});
+
+describe('getHouseholdRecordedRefund (#331)', () => {
+    const members = [
+        { id: 1, name: 'Alice', linkedMembers: [3] },
+        { id: 2, name: 'Bob', linkedMembers: [] },
+        { id: 3, name: 'Carol', linkedMembers: [] }
+    ];
+
+    it('detects an active refund issued to the primary and reports the total', () => {
+        const adjustments = [
+            { id: 'c1', memberId: 1, type: 'refund', amount: 50, status: 'recorded' }
+        ];
+        const { has, total } = getHouseholdRecordedRefund(members[0], adjustments);
+        expect(has).toBe(true);
+        expect(total).toBeCloseTo(50, 5);
+    });
+
+    it('sums refunds across the whole household (primary + linked, ADR 0001 grain)', () => {
+        const adjustments = [
+            { id: 'c1', memberId: 1, type: 'refund', amount: 50, status: 'recorded' },
+            { id: 'c2', memberId: 3, type: 'refund', amount: 12.5, status: 'recorded' } // linked member
+        ];
+        const { has, total } = getHouseholdRecordedRefund(members[0], adjustments);
+        expect(has).toBe(true);
+        expect(total).toBeCloseTo(62.5, 5);
+    });
+
+    it('excludes cancelled refunds', () => {
+        const adjustments = [
+            { id: 'c1', memberId: 1, type: 'refund', amount: 999, status: 'cancelled' }
+        ];
+        expect(getHouseholdRecordedRefund(members[0], adjustments)).toEqual({ has: false, total: 0 });
+    });
+
+    it('excludes carried-forward credits — only true refunds count (#316)', () => {
+        const adjustments = [
+            { id: 'c1', memberId: 1, type: 'carry_forward', amount: 40, status: 'recorded' }
+        ];
+        expect(getHouseholdRecordedRefund(members[0], adjustments)).toEqual({ has: false, total: 0 });
+    });
+
+    it('does not count another household refund', () => {
+        const adjustments = [
+            { id: 'c1', memberId: 2, type: 'refund', amount: 30, status: 'recorded' }
+        ];
+        expect(getHouseholdRecordedRefund(members[0], adjustments)).toEqual({ has: false, total: 0 });
+    });
+
+    it('is safe for an empty/missing array or missing member', () => {
+        expect(getHouseholdRecordedRefund(members[0], [])).toEqual({ has: false, total: 0 });
+        expect(getHouseholdRecordedRefund(members[0], undefined)).toEqual({ has: false, total: 0 });
+        expect(getHouseholdRecordedRefund(undefined, [{ id: 'c1', memberId: 1, type: 'refund', amount: 5, status: 'recorded' }]))
+            .toEqual({ has: false, total: 0 });
     });
 });
 


### PR DESCRIPTION
## Summary

Closes #331.

Adds a **non-blocking** confirmation when an admin reverses a payment for a household that holds an **active recorded refund** (`creditAdjustments[]` record with `type: 'refund'` and `status !== 'cancelled'`). The reverse `ConfirmDialog` now names the recorded refund amount and the resulting Outstanding balance and reminds that the refund is **not** automatically clawed back — the admin can still proceed.

The underlying behavior was already correct and automatic (reversing lowers gross paid → Net Contribution drops → the household reads Outstanding, and the refund stays append-only). This PR adds only the **administrator warning** so the flip is an informed action rather than a silent one.

> Example: *"This household received a $40.00 refund. Reversing the $30.00 payment from 2/15/2026 will make them Outstanding by $20.00 — the refund is not automatically clawed back. This creates a reversal entry in the audit trail. Reverse anyway?"*

Authoring-Agent: claude

## What changed

- **`src/lib/calculations.js`** — new pure helper `getHouseholdRecordedRefund(member, creditAdjustments) → { has, total }` (household grain, ADR 0001), mirroring the existing `getHouseholdDeferredCharges` idiom. **Additive only** — it does not touch `calculateAnnualSummary` / `getPaymentTotalForMember` / `calculateSettlementMetrics` or any settlement math.
- **`src/app/components/PaymentHistoryDialog.jsx`** — surfaces the warning in the existing reverse flow. The resulting Outstanding is `(owed − Net Contribution) + reversed amount`, derived from the **same `getHouseholdFinancials` the settlement board uses**, so the figure matches the card. Guards the rare partial-refund-leaves-credit case so it never claims a false "$0.00 Outstanding".
- **`src/app/views/Dashboard/DashboardView.jsx`** — threads `creditAdjustments` / `owedAdjustments` / the reopened-adjustment set into the dialog. **`reversePayment` mutation is unchanged.**
- **Specs** — `settlement-board.md` (new #331 subsection + `PaymentHistoryDialog.test.jsx` in Test Coverage) and `billing-persistence.md` (reaffirms display-only / append-only / never auto-clawed-back). CI `check_spec_test_alignment` is green.

## Acceptance criteria

- [x] Reversing a payment for a household with an active recorded refund shows a warning naming the recorded refund amount and the resulting Outstanding balance, and lets the admin proceed (non-blocking).
- [x] No warning shows for a household with no recorded refund (existing reverse flow unchanged).
- [x] The `reversePayment` mutation is unchanged — display/confirmation only; `payments[]` stays append-only and the refund is never auto-clawed-back.
- [x] Tests cover the warning path and the no-warning path; specs updated with CI `check_spec_test_alignment` green.

## Self-Review

- **Correctness.** The warning fires only for an active (`status !== 'cancelled'`) `type: 'refund'` adjustment in the household (primary + linked); carried-forward credits (`type: 'carry_forward'`) and cancelled refunds are excluded (unit-tested). Resulting Outstanding reuses `getHouseholdFinancials` with the same args the board passes (`creditAdjustments`, reopened set, `owedAdjustments`, derived `openingBalance`), so it matches the card; `(owed − netContribution) + reversedAmount` is the exact post-reversal shortfall since a reversal lowers Net Contribution by the payment amount. The partial-refund edge (residual credit) is handled so no misleading "$0.00 Outstanding" is shown.
- **Regression risk.** Low and display-only. New dialog props default (`creditAdjustments = []`, `owedAdjustments = []`, `reopenedAdjustmentIds = null`), so the no-refund/no-prop path renders the **unchanged** message and the 6 prior dialog tests still pass. No mutation, settlement-math, security-rule, or Cloud Function change.
- **High-risk-zone note.** `src/lib/calculations.js` is listed as a high-risk file, but the change is purely additive (a new pure helper + a private predicate). None of the named high-risk functions (`calculateAnnualSummary`, `getPaymentTotalForMember`, `calculateSettlementMetrics`) are modified, and `getHouseholdFinancials` / `reversePayment` are called, not changed.
- **Style.** Mirrors existing household-grain helpers (`getHouseholdDeferredCharges`) and the dialog's existing message/`ConfirmDialog` pattern. JSDoc added with ADR/issue references consistent with the file.
- **Test coverage.** `calculations.test.js`: 6 cases for `getHouseholdRecordedRefund` (primary, household sum, cancelled, carry-forward exclusion, other-household, empty/missing). `PaymentHistoryDialog.test.jsx`: warning path (names $40 refund / $30 reversed / $20 Outstanding, proceeds via `onReverse`), no-warning path (exact unchanged message), carry-forward exclusion, cancelled exclusion, partial-refund-in-credit edge. Full suite green (1020 React + 334 legacy + secret scan).
- **Security / dependency hygiene.** No new dependencies, no credential or rules changes, secret scan passes. Admin-only surface (the reverse action is hidden when `readOnly`); no member-facing/share/CF surface touched.

## Review routing

This PR touches `src/lib/**`, which is in `external_review_paths`, so **Phase 4 external review is mandatory** even though the diff (~270 lines) is under the `external_review_threshold` of 300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
