### PR TITLE
fix: style Service Credit "Apply to" fieldset so it no longer clips (#336)

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -1628,6 +1628,34 @@ img, svg { display: block; max-width: 100%; }
     color: var(--color-text-secondary, #5B6475);
 }
 
+/* ── Service Credit: "Apply to" fieldset (#336) ────────────
+   The radio group is a semantic <fieldset>/<legend> for accessibility, but the
+   browser-default chrome (2px groove border, min-inline-size: min-content, and an
+   unstyled legend) collides with the dialog layout and clips. Reset those defaults
+   and restyle as a clean bordered group consistent with the dialog's other fields. */
+.service-credit-scope {
+    min-width: 0;
+    margin: 0 0 var(--space-3, 12px);
+    padding: var(--space-2, 8px) var(--space-3, 12px) var(--space-3, 12px);
+    border: 1px solid var(--color-border, #e0e0e0);
+    border-radius: 6px;
+}
+
+.service-credit-scope-legend {
+    padding: 0 var(--space-1, 4px);
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--color-text-secondary, #5B6475);
+}
+
+.service-credit-scope .checkbox-item + .checkbox-item {
+    margin-top: var(--space-2, 8px);
+}
+
+.service-credit-scope .payment-field-group {
+    margin-top: var(--space-2, 8px);
+}
+
 /* ── Link Manager Dialog ───────────────────────────────── */
 .link-manager-hint {
     font-size: 0.85rem;

--- a/tests/react/components/ServiceCreditDialog.test.jsx
+++ b/tests/react/components/ServiceCreditDialog.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import ServiceCreditDialog from '@/app/components/ServiceCreditDialog.jsx';
@@ -72,6 +72,25 @@ describe('ServiceCreditDialog', () => {
             incurredDate: '2026-03-01',
             memberId: 2
         });
+    });
+
+    it('renders the "Apply to" choice as a styled fieldset/legend so it is not clipped (#336)', () => {
+        // Regression guard for #336: the radio group is a semantic <fieldset> with a
+        // <legend>, and both carry the class hooks the dialog CSS styles
+        // (.service-credit-scope / .service-credit-scope-legend). Without those hooks
+        // the fieldset falls back to browser-default chrome (groove border,
+        // min-content min-width, overlapping legend) and clips. jsdom can't assert
+        // layout, so we pin the structure + class hooks the visual fix depends on.
+        render(<ServiceCreditDialog open bill={bill} billMembers={billMembers} onSubmit={vi.fn()} onClose={vi.fn()} />);
+        const fieldset = screen.getByRole('group', { name: 'Apply to' });
+        expect(fieldset.tagName).toBe('FIELDSET');
+        expect(fieldset).toHaveClass('service-credit-scope');
+        const legend = within(fieldset).getByText('Apply to');
+        expect(legend.tagName).toBe('LEGEND');
+        expect(legend).toHaveClass('service-credit-scope-legend');
+        // Both radio options live inside the fieldset box (not clipped out of it).
+        expect(within(fieldset).getByLabelText(/whole bill/i)).toBeInTheDocument();
+        expect(within(fieldset).getByLabelText(/specific member/i)).toBeInTheDocument();
     });
 
     it('blocks submit and shows an error for a non-positive amount', async () => {


### PR DESCRIPTION
Closes #336.

Authoring-Agent: claude

## Summary

The Issue Service Credit dialog "Apply to" radio group is a semantic `<fieldset>`/`<legend>`, but no CSS rule existed for its `.service-credit-scope` / `.service-credit-scope-legend` class hooks. The fieldset therefore fell back to browser-default chrome (a groove border, `min-inline-size: min-content`, and an unstyled legend overlapping the top border) that collided with the dialog layout and clipped the radio options.

This adds the missing rules in `src/app/shell.css`: reset the default chrome and `min-width`, and restyle the fieldset as a clean bordered group (border + radius + padding) consistent with the other dialog fields (Amount, Reason, Incurred date), with the legend seated on the border and the radio options spaced inside the box. No billing-logic change.

## Verification

Rendered the dialog markup against the real `shell.css` in a static before/after harness:

- Before (no rules): legend jammed into the top border, radios cramped against the edges, reproducing the report.
- After: clean rounded box, legend seated on the border, both radio options fully inside and padded.

`npm test` is green (React suite + 58 Cloud Function tests + secret scan).

## Self-Review

- Correctness: CSS-only plus a structural test. The new rules target only the two dialog-scoped classes; the `min-width: 0` reset is the key fix for the min-content overflow. Confirmed visually before/after.
- Regression risk: Low. The `.service-credit-scope*` selectors are unique to this dialog (grep-confirmed no prior rules), and the descendant selectors are scoped under `.service-credit-scope`, so no other component is affected.
- Style: Uses the existing design tokens (`--color-border`, `--space-*`, `--color-text-secondary`) and matches the `.payment-field-group` aesthetic; placed beside the other payment-dialog field CSS.
- Test coverage: Added a regression test pinning the `<fieldset>`/`<legend>` structure and the class hooks the fix depends on (jsdom cannot assert layout; the no-clip result is confirmed via the harness). Existing ServiceCreditDialog behavior tests unchanged and green.
- Security/dependency hygiene: No new dependencies, no logic or data-flow changes, no credentials touched.