### PR TITLE
fix: reversal-after-refund warning says "increase" when already Outstanding (#333)

### DIFF
--- a/src/app/components/PaymentHistoryDialog.jsx
+++ b/src/app/components/PaymentHistoryDialog.jsx
@@ -53,18 +53,18 @@ export default function PaymentHistoryDialog({ open, memberId, memberName, famil
     const recordedRefund = getHouseholdRecordedRefund(household, creditAdjustments);
 
     /**
-     * Resulting household Outstanding if `target` (a positive original payment) is
-     * reversed: reversing appends a −amount entry, so Net Contribution drops by that
-     * amount and the collectable shortfall rises by it. Derived from the same
-     * household financials the settlement board shows, so the figure matches the card.
+     * Household owed and Net Contribution exactly as the settlement board computes
+     * them, BEFORE any reversal. Reversing a payment appends a −amount entry, which
+     * drops Net Contribution by that amount, so the resulting Outstanding works out to
+     * `Math.max(0, (owed − netContribution) + |amount|)`. Derived from the same
+     * financials the board shows, so the warning figures match the card.
      */
-    function resultingOutstandingAfterReversal(target) {
-        if (!household || !target) return 0;
+    function householdOwedAndContribution() {
+        if (!household) return { owed: 0, netContribution: 0 };
         const openingBalance = getHouseholdOpeningBalance(household, owedAdjustments);
-        const { owed, netContribution } = getHouseholdFinancials(
+        return getHouseholdFinancials(
             household, summary, payments, creditAdjustments, reopenedAdjustmentIds, owedAdjustments, openingBalance
         );
-        return Math.max(0, (owed - netContribution) + Math.abs(target.amount));
     }
 
     function handleReverse() {
@@ -80,12 +80,24 @@ export default function PaymentHistoryDialog({ open, memberId, memberName, famil
         const dateLabel = new Date(reverseTarget.receivedAt).toLocaleDateString();
         if (recordedRefund.has) {
             const refundLabel = formatAnnualSummaryCurrency(recordedRefund.total);
-            const resulting = resultingOutstandingAfterReversal(reverseTarget);
-            // Usually the reversal flips the household Outstanding; with a partial refund
-            // the household can keep residual credit, so don't claim a false "$0.00 Outstanding".
-            const impact = resulting > CREDIT_EPSILON
-                ? 'will make them Outstanding by ' + formatAnnualSummaryCurrency(resulting)
-                : 'lowers their Net Contribution but leaves the household in credit';
+            // The resulting Outstanding and the household's state BEFORE the reversal,
+            // from the same financials the settlement board shows.
+            const { owed, netContribution } = householdOwedAndContribution();
+            const beforeOutstanding = owed - netContribution;
+            const resulting = Math.max(0, beforeOutstanding + Math.abs(reverseTarget.amount));
+            const resultingLabel = formatAnnualSummaryCurrency(resulting);
+            // Three cases (#331, #333):
+            //  • still in credit after the reversal (partial refund) — don't claim a false "$0.00 Outstanding"
+            //  • already Outstanding before the reversal — the reversal *increases* the balance to the new total
+            //  • settled or in credit before — the reversal *makes* them Outstanding
+            let impact;
+            if (resulting <= CREDIT_EPSILON) {
+                impact = 'lowers their Net Contribution but leaves the household in credit';
+            } else if (beforeOutstanding > CREDIT_EPSILON) {
+                impact = 'will increase their Outstanding balance to ' + resultingLabel;
+            } else {
+                impact = 'will make them Outstanding by ' + resultingLabel;
+            }
             return 'This household received a ' + refundLabel + ' refund. Reversing the ' + amountLabel
                 + ' payment from ' + dateLabel + ' ' + impact
                 + ' — the refund is not automatically clawed back. This creates a reversal entry in the audit trail. Reverse anyway?';

--- a/tests/react/components/PaymentHistoryDialog.test.jsx
+++ b/tests/react/components/PaymentHistoryDialog.test.jsx
@@ -172,4 +172,30 @@ describe('PaymentHistoryDialog — reversal-after-refund warning (#331)', () => 
         expect(message).not.toContain('Outstanding by');
         expect(message).toContain('not automatically clawed back');
     });
+
+    it('says the reversal increases the balance when the household is already Outstanding (#333)', async () => {
+        const user = userEvent.setup();
+        // owed $100, gross paid $80 ($50 + $30), $20 refund → Net Contribution $60, so the
+        // household is ALREADY Outstanding by $40 before any reversal (e.g. a bill or billed
+        // Usage Charge was added after the refund). Reversing the $30 payment raises that to
+        // $70 — it does not flip a settled household, so the copy must say *increase ... to*,
+        // not *make them Outstanding by*.
+        renderDialog({
+            payments: [
+                { id: 'pay-a', memberId: 1, amount: 50, receivedAt: '2026-01-15T00:00:00Z', method: 'venmo', note: '' },
+                { id: 'pay-b', memberId: 1, amount: 30, receivedAt: '2026-02-15T00:00:00Z', method: 'cash', note: '' }
+            ],
+            creditAdjustments: [{ id: 'r1', memberId: 1, type: 'refund', amount: 20, status: 'recorded' }]
+        });
+
+        await openReverseConfirmForLatestPayment(user);
+
+        const dialog = screen.getByRole('dialog', { name: 'Reverse Payment — Refund on Record' });
+        const message = dialog.querySelector('.confirmation-message').textContent;
+        expect(message).toContain('$20.00 refund');
+        expect(message).toContain('Reversing the $30.00 payment');
+        expect(message).toContain('will increase their Outstanding balance to $70.00');
+        expect(message).not.toContain('will make them Outstanding by'); // not a settled → Outstanding flip
+        expect(message).toContain('not automatically clawed back');
+    });
 });


### PR DESCRIPTION
Closes #333.

Authoring-Agent: claude

## Summary

Post-review follow-up to #331 (reversal-after-refund warning). The warning read "will make them Outstanding by \$Y" even when the household was ALREADY Outstanding before the reversal (e.g. a bill or a billed Usage Charge was added after the refund). In that state the reversal increases an existing Outstanding balance rather than flipping a settled household, so "make them Outstanding" is imprecise. \$Y (the resulting balance) was always correct.

`src/app/components/PaymentHistoryDialog.jsx`:
- Compute the pre-reversal owed / Net Contribution once (new `householdOwedAndContribution()` helper, replacing the single-use `resultingOutstandingAfterReversal`).
- Pick the phrasing by state: still in credit after the reversal (partial refund) -> "leaves the household in credit"; already Outstanding before -> "will increase their Outstanding balance to \$Y"; settled / credit before -> "will make them Outstanding by \$Y".

Member-facing copy only; no settlement math change (\$Y is unchanged in all cases).

## Verification

`npm test` green (React suite incl. PaymentHistoryDialog 12/12, 58 Cloud Function tests, secret scan).

## Self-Review

- Correctness: the pre-reversal balance is `owed - netContribution` from the same `getHouseholdFinancials` the settlement board uses; alreadyOutstanding is that value > CREDIT_EPSILON. The resulting figure is unchanged (`Math.max(0, before + |amount|)`). Traced against the three test scenarios.
- Regression risk: Low. The two pre-existing branches (flip -> "make them Outstanding by", partial-refund residual -> "leaves the household in credit") keep identical wording and assertions; only the already-Outstanding branch is new.
- Style: Reuses CREDIT_EPSILON and formatAnnualSummaryCurrency; one shared financials helper instead of two computations.
- Test coverage: Added the already-Outstanding case (owed 100, net 60 -> increase to 70 on a 30 reversal); existing flip and credit-residual tests unchanged and green.
- Security/dependency hygiene: No new dependencies, no data-flow or persistence changes.