### PR TITLE
feat: state-driven settled/owed layout on the share page

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3323,6 +3323,15 @@ img, svg { display: block; max-width: 100%; }
     border-left: 3px solid var(--color-success, #3FA37C);
 }
 
+/* Owed lead: make the amount due the prominent figure in the outstanding
+   callout (#355) so it reads as the headline, not a footnote. */
+.share-amount-due {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-danger, #C65A5A);
+    margin-top: var(--space-1, 4px);
+}
+
 /* Payment Methods */
 .share-pm-grid {
     display: grid;
@@ -3342,6 +3351,42 @@ img, svg { display: block; max-width: 100%; }
 .share-pm-card--preferred {
     border-color: var(--color-primary, #4A6FA5);
     margin-bottom: var(--space-3, 12px);
+}
+
+/* Owed-amount echo on the preferred method (#355): repeats the figure right
+   where the member acts on it. */
+.share-pm-amount-due {
+    font-weight: 600;
+    color: var(--color-danger, #C65A5A);
+    margin: 0 0 var(--space-2, 8px);
+}
+
+/* Collapsed payment-methods summary shown when settled (#354); the member can
+   expand the full methods on demand. */
+.share-pm-collapsed {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3, 12px);
+    flex-wrap: wrap;
+}
+
+.share-pm-collapsed-note {
+    color: var(--color-text-secondary, #5B6475);
+    font-size: 0.9rem;
+}
+
+.share-pm-expand {
+    background: transparent;
+    border: 1px solid var(--color-border, #e0e0e0);
+    border-radius: var(--radius-sm, 6px);
+    padding: 0.3rem 0.7rem;
+    font-size: 0.82rem;
+    color: var(--color-primary, #4A6FA5);
+    cursor: pointer;
+}
+
+.share-pm-expand:hover {
+    border-color: var(--color-primary, #4A6FA5);
 }
 
 .share-pm-preferred-badge {

--- a/src/app/views/ShareView.jsx
+++ b/src/app/views/ShareView.jsx
@@ -37,6 +37,22 @@ function formatSplitMath(b) {
         + ' = ' + formatCurrency(b.monthlyShare) + '/mo · ×12 = ' + formatCurrency(b.annualShare) + '/yr';
 }
 
+/**
+ * Derive the member's payment state from the share `paymentSummary` (#354/#355).
+ * Shared by PaymentSummarySection and PaymentMethodsSection so the settled/owed
+ * layout decisions stay in lockstep. Mirrors the original inline logic:
+ * owed when a positive balance remains; settled when nothing remains and
+ * something has been paid (an overpaid/zero balance with payments still reads
+ * as settled).
+ */
+function derivePaymentState(ps) {
+    const balanceRemaining = (ps && ps.balanceRemaining) || 0;
+    const totalPaid = (ps && ps.totalPaid) || 0;
+    const isOwed = balanceRemaining > 0;
+    const isSettled = !isOwed && totalPaid > 0;
+    return { isOwed, isSettled, balanceRemaining };
+}
+
 export default function ShareView() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
@@ -228,7 +244,7 @@ export default function ShareView() {
             <ShareHeader data={data} />
             {data.summary && <HouseholdBillsSection data={data} canDispute={shareCtx.canDispute} shareCtx={shareCtx} />}
             {data.paymentSummary && <PaymentSummarySection ps={data.paymentSummary} year={data.year} />}
-            {data.paymentMethods && data.paymentMethods.length > 0 && <PaymentMethodsSection methods={data.paymentMethods} ownerId={shareCtx.ownerId} canDispute={shareCtx.canDispute} />}
+            {data.paymentMethods && data.paymentMethods.length > 0 && <PaymentMethodsSection methods={data.paymentMethods} ownerId={shareCtx.ownerId} canDispute={shareCtx.canDispute} paymentSummary={data.paymentSummary} />}
             {data.refundNotices && data.refundNotices.length > 0 && <RefundNoticesSection notices={data.refundNotices} shareCtx={shareCtx} />}
             {data.pendingCharges && data.pendingCharges.charges && data.pendingCharges.charges.length > 0 && (
                 <PendingChargesSection pendingCharges={data.pendingCharges} year={data.year} />
@@ -414,41 +430,55 @@ function BillsTable({ bills, canDispute, onRequestReview }) {
 
 function PaymentSummarySection({ ps, year }) {
     const pctPaid = ps.combinedAnnualTotal > 0 ? Math.min(100, Math.round((ps.totalPaid / ps.combinedAnnualTotal) * 100)) : 0;
-    const isOwed = ps.balanceRemaining > 0;
-    const isSettled = !isOwed && ps.totalPaid > 0;
+    const { isOwed, isSettled } = derivePaymentState(ps);
     const balClass = isOwed ? 'owed' : (isSettled ? 'settled-zero' : '');
     const balLabel = isSettled ? 'Paid' : formatCurrency(ps.balanceRemaining);
 
     return (
         <div className="share-section">
             <h2>Payment Summary</h2>
-            <div className="share-stat-grid">
-                <div className="share-stat-card"><div className="share-stat-label">Annual Total</div><div className="share-stat-value">{formatCurrency(ps.combinedAnnualTotal)}</div></div>
-                <div className="share-stat-card"><div className="share-stat-label">Monthly</div><div className="share-stat-value">{formatCurrency(ps.combinedMonthlyTotal)}</div></div>
-                <div className="share-stat-card"><div className="share-stat-label">Paid to Date</div><div className="share-stat-value paid">{formatCurrency(ps.totalPaid)}</div></div>
-                <div className="share-stat-card"><div className="share-stat-label">Balance Remaining</div><div className={'share-stat-value ' + balClass}>{balLabel}</div></div>
-            </div>
-            <div className="share-progress">
-                <div className="share-progress-bar" style={{ width: pctPaid + '%' }} />
-            </div>
-            <div className="share-progress-label">{pctPaid}% paid</div>
 
-            {ps.balanceRemaining > 0 && (
-                <div className="share-callout outstanding">
-                    <strong>You still have an outstanding balance for {year}.</strong>
-                    <p>Amount Remaining: {formatCurrency(ps.balanceRemaining)}</p>
-                </div>
-            )}
-            {ps.balanceRemaining <= 0 && ps.totalPaid > 0 && (
+            {/* State-driven lead (#354/#355): when settled, lead with the
+                confirmation and demote the transactional detail; when owed, lead
+                with the amount due so there's no ambiguity about what to send. */}
+            {isSettled && (
                 <div className="share-callout settled">
                     <strong>You're all settled for {year}. Thank you!</strong>
                 </div>
+            )}
+            {isOwed && (
+                <div className="share-callout outstanding">
+                    <strong>You still have an outstanding balance for {year}.</strong>
+                    <p className="share-amount-due">Amount Remaining: {formatCurrency(ps.balanceRemaining)}</p>
+                </div>
+            )}
+
+            <div className="share-stat-grid">
+                <div className="share-stat-card"><div className="share-stat-label">Annual Total</div><div className="share-stat-value">{formatCurrency(ps.combinedAnnualTotal)}</div></div>
+                <div className="share-stat-card"><div className="share-stat-label">Monthly</div><div className="share-stat-value">{formatCurrency(ps.combinedMonthlyTotal)}</div></div>
+                {/* Paid-to-date and Balance carry no new information once settled (paid == total,
+                    balance == 0), so collapse the grid to the two figures that still do (#354). */}
+                {!isSettled && <div className="share-stat-card"><div className="share-stat-label">Paid to Date</div><div className="share-stat-value paid">{formatCurrency(ps.totalPaid)}</div></div>}
+                {!isSettled && <div className="share-stat-card"><div className="share-stat-label">Balance Remaining</div><div className={'share-stat-value ' + balClass}>{balLabel}</div></div>}
+            </div>
+
+            {/* The bar is always 100% when settled, so hide it (#354). */}
+            {!isSettled && (
+                <>
+                    <div className="share-progress">
+                        <div className="share-progress-bar" style={{ width: pctPaid + '%' }} />
+                    </div>
+                    <div className="share-progress-label">{pctPaid}% paid</div>
+                </>
             )}
         </div>
     );
 }
 
-function PaymentMethodsSection({ methods, ownerId, canDispute }) {
+function PaymentMethodsSection({ methods, ownerId, canDispute, paymentSummary }) {
+    const { isOwed, isSettled, balanceRemaining } = derivePaymentState(paymentSummary);
+    // Collapse the methods once settled (#354); the member can still expand them on demand.
+    const [expanded, setExpanded] = useState(!isSettled);
     const [qrModal, setQrModal] = useState(null);
     const [loadingQr, setLoadingQr] = useState(null);
 
@@ -491,6 +521,9 @@ function PaymentMethodsSection({ methods, ownerId, canDispute }) {
                     <strong>{pm.label}</strong>
                     {pm.preferred && <span className="share-pm-preferred-badge">&#9733; Preferred</span>}
                 </div>
+                {pm.preferred && isOwed && (
+                    <p className="share-pm-amount-due">Send {formatCurrency(balanceRemaining)} via {pm.label}</p>
+                )}
                 <div className="share-pm-body">
                     {pm.type === 'zelle' && [pm.email, pm.phone].filter(Boolean).map(c => (
                         <div key={c} className="share-pm-detail">
@@ -556,21 +589,36 @@ function PaymentMethodsSection({ methods, ownerId, canDispute }) {
     return (
         <div className="share-section">
             <h2>Payment Methods</h2>
-            <p className="share-trust-note share-trust-note--secure">
-                <svg className="share-trust-lock" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-                </svg>
-                <span>
-                    Pay directly through the apps below—Friends &amp; Family Billing doesn't process payments.
-                    {canDispute && ' That’s also why "Question This" exists: flag anything that looks off and the account owner is notified.'}
-                </span>
-            </p>
-            {preferredMethod && renderCard(preferredMethod, 'share-pm-card share-pm-card--preferred')}
-            {otherMethods.length > 0 && (
-                <div className="share-pm-grid">
-                    {otherMethods.map(pm => renderCard(pm, 'share-pm-card'))}
+            {isSettled && !expanded ? (
+                /* Settled: collapse to a one-line "Paid via {preferred}" summary with an
+                   expand affordance, so the methods don't dominate an already-paid view (#354). */
+                <div className="share-pm-collapsed">
+                    <span className="share-pm-collapsed-note">
+                        {preferredMethod ? 'Paid via ' + preferredMethod.label + '.' : 'This balance is settled.'}
+                    </span>
+                    <button type="button" className="share-pm-expand" onClick={() => setExpanded(true)}>
+                        Show payment methods
+                    </button>
                 </div>
+            ) : (
+                <>
+                    <p className="share-trust-note share-trust-note--secure">
+                        <svg className="share-trust-lock" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                        </svg>
+                        <span>
+                            Pay directly through the apps below—Friends &amp; Family Billing doesn't process payments.
+                            {canDispute && ' That’s also why "Question This" exists: flag anything that looks off and the account owner is notified.'}
+                        </span>
+                    </p>
+                    {preferredMethod && renderCard(preferredMethod, 'share-pm-card share-pm-card--preferred')}
+                    {otherMethods.length > 0 && (
+                        <div className="share-pm-grid">
+                            {otherMethods.map(pm => renderCard(pm, 'share-pm-card'))}
+                        </div>
+                    )}
+                </>
             )}
 
             {qrModal && (

--- a/src/app/views/ShareView.jsx
+++ b/src/app/views/ShareView.jsx
@@ -264,7 +264,7 @@ function ShareHeader({ data }) {
     const lastName = deriveLastName(data.memberName);
     return (
         <header className="share-header">
-            <h1>{lastName} Household's Annual Billing Summary</h1>
+            <h1>{lastName} Household&apos;s Annual Billing Summary</h1>
             <p className="share-subtitle">Your shared billing summary for {data.year}.</p>
         </header>
     );
@@ -443,7 +443,7 @@ function PaymentSummarySection({ ps, year }) {
                 with the amount due so there's no ambiguity about what to send. */}
             {isSettled && (
                 <div className="share-callout settled">
-                    <strong>You're all settled for {year}. Thank you!</strong>
+                    <strong>You&apos;re all settled for {year}. Thank you!</strong>
                 </div>
             )}
             {isOwed && (
@@ -608,7 +608,7 @@ function PaymentMethodsSection({ methods, ownerId, canDispute, paymentSummary })
                             <path d="M7 11V7a5 5 0 0 1 10 0v4" />
                         </svg>
                         <span>
-                            Pay directly through the apps below—Friends &amp; Family Billing doesn't process payments.
+                            Pay directly through the apps below—Friends &amp; Family Billing doesn&apos;t process payments.
                             {canDispute && ' That’s also why "Question This" exists: flag anything that looks off and the account owner is notified.'}
                         </span>
                     </p>

--- a/tests/react/views/ShareView.test.jsx
+++ b/tests/react/views/ShareView.test.jsx
@@ -705,6 +705,98 @@ describe('ShareView', () => {
     });
 
     // -----------------------------------------------------------------------
+    // 10b. State-driven settled / owed layout (#354/#355)
+    // -----------------------------------------------------------------------
+    describe('state-driven settled / owed layout', () => {
+        const settledData = {
+            ...sampleShareData,
+            paymentSummary: { combinedAnnualTotal: 100, combinedMonthlyTotal: 8.33, totalPaid: 100, balanceRemaining: 0 },
+            paymentMethods: [{ id: 'pm1', type: 'venmo', label: 'Venmo', handle: '@john', preferred: true }]
+        };
+        const owedPreferred = {
+            ...sampleShareData, // balanceRemaining 85.96 (owed)
+            paymentMethods: [{ id: 'pm1', type: 'venmo', label: 'Venmo', handle: '@john', preferred: true }]
+        };
+
+        it('leads with the settled callout and drops the transactional cards/progress (#354)', async () => {
+            setToken('abc123');
+            mockPublicSharesHit(settledData);
+
+            render(<ShareView />);
+
+            const heading = await screen.findByText('Payment Summary');
+            const section = heading.closest('.share-section');
+
+            expect(within(section).getByText(/all settled for 2024/)).toBeInTheDocument();
+            expect(within(section).queryByText('Paid to Date')).not.toBeInTheDocument();
+            expect(within(section).queryByText('Balance Remaining')).not.toBeInTheDocument();
+            expect(within(section).queryByText(/% paid/)).not.toBeInTheDocument();
+            expect(within(section).getByText('Annual Total')).toBeInTheDocument();
+            expect(within(section).getByText('Monthly')).toBeInTheDocument();
+
+            // Settled callout renders before the stat grid.
+            const callout = within(section).getByText(/all settled/).closest('.share-callout');
+            const grid = section.querySelector('.share-stat-grid');
+            expect(callout.compareDocumentPosition(grid) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        });
+
+        it('collapses payment methods when settled and expands on demand (#354)', async () => {
+            const user = userEvent.setup();
+            setToken('abc123');
+            mockPublicSharesHit(settledData);
+
+            render(<ShareView />);
+
+            const heading = await screen.findByText('Payment Methods');
+            const section = heading.closest('.share-section');
+
+            expect(within(section).getByText('Paid via Venmo.')).toBeInTheDocument();
+            expect(within(section).queryByText('@john')).not.toBeInTheDocument();
+
+            await user.click(within(section).getByRole('button', { name: 'Show payment methods' }));
+
+            expect(within(section).getByText('@john')).toBeInTheDocument();
+            expect(within(section).queryByRole('button', { name: 'Show payment methods' })).not.toBeInTheDocument();
+        });
+
+        it('does not echo an amount on the preferred method when settled (#355)', async () => {
+            const user = userEvent.setup();
+            setToken('abc123');
+            mockPublicSharesHit(settledData);
+
+            render(<ShareView />);
+
+            await screen.findByText('Payment Methods');
+            await user.click(screen.getByRole('button', { name: 'Show payment methods' }));
+            expect(screen.queryByText(/Send \$/)).not.toBeInTheDocument();
+        });
+
+        it('echoes the balance on the preferred method when owed (#355)', async () => {
+            setToken('abc123');
+            mockPublicSharesHit(owedPreferred);
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Send \$85\.96 via Venmo/)).toBeInTheDocument();
+            });
+            expect(screen.queryByRole('button', { name: 'Show payment methods' })).not.toBeInTheDocument();
+        });
+
+        it('surfaces the amount due prominently in the owed lead (#355)', async () => {
+            setToken('abc123');
+            mockPublicSharesHit(); // sampleShareData: owed 85.96
+
+            render(<ShareView />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Amount Remaining: \$85.96/)).toBeInTheDocument();
+            });
+            expect(screen.getByText(/Amount Remaining: \$85.96/)).toHaveClass('share-amount-due');
+        });
+    });
+
+    // -----------------------------------------------------------------------
     // 11. Evidence viewing
     // -----------------------------------------------------------------------
     describe('Evidence viewing', () => {


### PR DESCRIPTION
## Summary

Makes the public share page state-aware — items 4 and 5 of epic #350. View-layer + CSS only.

Closes #354
Closes #355

- **#354 — settled view.** When the household is settled, the Payment Summary now **leads** with the "all settled" confirmation (previously the last child), **collapses** the four stat cards to the two that still carry information (Annual Total + Monthly — Paid-to-date and Balance are redundant once paid), and **hides** the always-100% progress bar. Payment Methods collapse to a one-line **"Paid via {preferred}"** summary with a **"Show payment methods"** expand control.
- **#355 — owed echo.** When owed, the summary leads with the amount due (prominent in the outstanding callout) and the figure is **echoed on the preferred method** ("Send $X via {label}") so there's no ambiguity about what to send.
- Refactor: the settled/owed derivation is factored into `derivePaymentState(ps)` so `PaymentSummarySection` and `PaymentMethodsSection` (sibling components) stay in lockstep.

Authoring-Agent: claude

## Self-Review

- **Correctness:** `derivePaymentState` reproduces the original inline logic exactly (owed = positive balance; settled = no balance remaining with payments made; the neither/zero state is preserved — all four cards + progress, no callout). The owed/settled callouts and existing copy ("Amount Remaining: $X", "all settled for {year}") are unchanged in text, so existing assertions hold. `paymentSummary` is threaded to `PaymentMethodsSection`; absent (methods-only link) it degrades to the expanded, no-echo default.
- **Regression risk:** Low. No changes to `calculations.js`, `share.js`, or the payload — purely how existing `paymentSummary` fields are presented. The collapse uses local `useState(!isSettled)`.
- **Style:** Reuses existing tokens/classes; new `share-amount-due`, `share-pm-amount-due`, `share-pm-collapsed`, `share-pm-expand` follow the `share-*` convention. Expand control has `type="button"`.
- **Test coverage:** Adds 5 ShareView tests (settled lead + dropped cards/progress + DOM order; methods collapse→expand; no echo when settled; echo when owed; prominent amount-due class). 68 ShareView tests pass; full `npm test` green.
- **Security/deps:** No new deps, no scope/data-model changes, no change to the unauthenticated payload.

## Depends on / follow-ups

Builds on #358 (merged). Payment history (#356 backend → #357 frontend) ships next.