### PR TITLE
feat: redesign the public share page to the settled/owed mockup (#350 follow-up)

### DIFF
--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -3285,6 +3285,13 @@ img, svg { display: block; max-width: 100%; }
 .share-stat-value.owed { color: var(--color-danger, #C65A5A); }
 .share-stat-value.settled-zero { color: var(--color-text-secondary, #5B6475); }
 
+.share-stat-unit {
+    font-size: 0.8rem;
+    font-weight: 400;
+    color: var(--color-text-secondary, #5B6475);
+    margin-left: 1px;
+}
+
 .share-progress {
     height: 8px;
     background: var(--color-surface-alt, #F7F8FB);
@@ -3332,6 +3339,50 @@ img, svg { display: block; max-width: 100%; }
     margin-top: var(--space-1, 4px);
 }
 
+/* State-driven lead callout (mockup redesign): the page leads with settled/owed
+   status above the bills — a tinted banner with an icon, a headline, and a subline. */
+.share-lead {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3, 12px);
+    border-radius: var(--radius-sm, 6px);
+    padding: var(--space-3, 12px) var(--space-4, 16px);
+    margin-bottom: var(--space-4, 16px);
+}
+
+.share-lead-icon {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+}
+
+.share-lead-title { font-size: 1.05rem; font-weight: 600; }
+.share-lead-sub { font-size: 0.9rem; color: var(--color-text-secondary, #5B6475); }
+
+.share-lead--settled {
+    background: var(--color-success-light, rgba(63, 163, 124, 0.10));
+    border-left: 3px solid var(--color-success, #3FA37C);
+}
+.share-lead--settled .share-lead-icon {
+    background: var(--color-success-bg, #c6f6d5);
+    color: var(--color-success-fg, #22543d);
+}
+.share-lead--settled .share-lead-title { color: var(--color-success-fg, #22543d); }
+
+.share-lead--owed {
+    background: var(--color-danger-light, rgba(198, 90, 90, 0.10));
+    border-left: 3px solid var(--color-danger, #C65A5A);
+}
+.share-lead--owed .share-lead-icon {
+    background: var(--color-danger-bg, #fed7d7);
+    color: var(--color-danger-fg, #9b2c2c);
+}
+.share-lead--owed .share-lead-title { color: var(--color-danger-fg, #9b2c2c); }
+
 /* Payment Methods */
 .share-pm-grid {
     display: grid;
@@ -3361,18 +3412,64 @@ img, svg { display: block; max-width: 100%; }
     margin: 0 0 var(--space-2, 8px);
 }
 
-/* Collapsed payment-methods summary shown when settled (#354); the member can
-   expand the full methods on demand. */
-.share-pm-collapsed {
+/* Settled bill cards (mockup redesign): each bill is a card with a "Paid" pill and
+   the split shown as inline arithmetic. The owed/unpaid view keeps the full table. */
+.share-bill-cards {
     display: flex;
-    align-items: center;
+    flex-direction: column;
     gap: var(--space-3, 12px);
-    flex-wrap: wrap;
 }
 
-.share-pm-collapsed-note {
-    color: var(--color-text-secondary, #5B6475);
-    font-size: 0.9rem;
+.share-bill-card {
+    background: var(--color-surface, #ffffff);
+    border: 1px solid var(--color-border, #e0e0e0);
+    border-radius: var(--radius-md, 8px);
+    padding: var(--space-3, 12px) var(--space-4, 16px);
+}
+
+.share-bill-card-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2, 8px);
+}
+
+.share-bill-card-name {
+    font-size: 1rem;
+    font-weight: 600;
+    flex: 1;
+    min-width: 0;
+}
+
+.share-bill-paid-pill {
+    font-size: 0.72rem;
+    font-weight: 500;
+    padding: 3px 10px;
+    border-radius: var(--radius-pill, 9999px);
+    background: var(--color-success-bg, #c6f6d5);
+    color: var(--color-success-fg, #22543d);
+}
+
+.share-bill-card-math {
+    margin-top: var(--space-3, 12px);
+    padding-top: var(--space-3, 12px);
+    border-top: 1px solid var(--color-border-light, #f0f0f0);
+}
+
+.share-bill-math-expr {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px 10px;
+    font-variant-numeric: tabular-nums;
+}
+
+.share-math-src { font-size: 0.85rem; color: var(--color-text-secondary, #5B6475); }
+.share-math-op { font-size: 0.85rem; color: var(--color-text-faint, #999999); }
+.share-math-eq { font-size: 0.95rem; font-weight: 600; color: var(--color-text, #1F2430); }
+
+.share-bill-card .share-review-btn {
+    margin-top: var(--space-2, 8px);
+    padding-left: 0;
 }
 
 .share-pm-expand {

--- a/src/app/views/ShareView.jsx
+++ b/src/app/views/ShareView.jsx
@@ -53,6 +53,100 @@ function derivePaymentState(ps) {
     return { isOwed, isSettled, balanceRemaining };
 }
 
+/** Inline check / alert icons for the lead callout (no icon-font dependency). */
+function LeadCheckIcon() {
+    return (
+        <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M5 12l5 5L20 7" />
+        </svg>
+    );
+}
+function LeadAlertIcon() {
+    return (
+        <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 9v4" /><path d="M12 17h.01" />
+            <path d="M10.3 3.6 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.6a2 2 0 0 0-3.4 0z" />
+        </svg>
+    );
+}
+
+/**
+ * State-driven lead callout (#354/#355) — the first thing the member sees, above
+ * the bills. Settled: a green confirmation with the amount paid in full. Owed: a
+ * red amount-due banner with how much remains and how much is paid. Neither state
+ * (nothing paid, nothing owed) renders nothing.
+ */
+function ShareLeadCallout({ ps, year }) {
+    const { isOwed, isSettled } = derivePaymentState(ps);
+    if (isSettled) {
+        return (
+            <div className="share-lead share-lead--settled">
+                <span className="share-lead-icon"><LeadCheckIcon /></span>
+                <div className="share-lead-text">
+                    <div className="share-lead-title">You&apos;re all settled for {year}</div>
+                    <div className="share-lead-sub">{formatCurrency(ps.totalPaid)} paid in full — nothing due</div>
+                </div>
+            </div>
+        );
+    }
+    if (isOwed) {
+        return (
+            <div className="share-lead share-lead--owed">
+                <span className="share-lead-icon"><LeadAlertIcon /></span>
+                <div className="share-lead-text">
+                    <div className="share-lead-title">{formatCurrency(ps.balanceRemaining)} due for {year}</div>
+                    <div className="share-lead-sub">{formatCurrency(ps.totalPaid)} of {formatCurrency(ps.combinedAnnualTotal)} paid</div>
+                </div>
+            </div>
+        );
+    }
+    return null;
+}
+
+/**
+ * The per-bill split as styled inline arithmetic (#351): the source figure and
+ * operators muted, the member's resulting /mo and /yr shares emphasized. Used in
+ * the settled bill cards; the owed table renders the same figures via formatSplitMath.
+ */
+function BillMath({ b }) {
+    const memberWord = b.splitCount === 1 ? 'member' : 'members';
+    return (
+        <span className="share-bill-math-expr">
+            <span className="share-math-src">{formatCurrency(b.monthlyAmount)}/mo</span>
+            <span className="share-math-op">÷ {b.splitCount} {memberWord}</span>
+            <span className="share-math-eq">= {formatCurrency(b.monthlyShare)}/mo</span>
+            <span className="share-math-op">× 12</span>
+            <span className="share-math-eq">= {formatCurrency(b.annualShare)}/yr</span>
+        </span>
+    );
+}
+
+/**
+ * Settled bill cards (mockup redesign) — each bill as a card with a "Paid" pill and
+ * the inline split math, replacing the dense table when the household is settled.
+ * The owed/unpaid view keeps the full itemized table (BillsTable).
+ */
+function BillsCards({ bills, canDispute, onRequestReview }) {
+    if (!bills || bills.length === 0) return <p className="share-hint">No bills assigned.</p>;
+    return (
+        <div className="share-bill-cards">
+            {bills.map((b, i) => (
+                <div key={b.billId || i} className="share-bill-card">
+                    <div className="share-bill-card-head">
+                        <CompanyLogo logo={b.logo} website={b.website} name={b.name || 'Bill'} size={28} />
+                        <strong className="share-bill-card-name">{b.name || 'Unnamed Bill'}</strong>
+                        <span className="share-bill-paid-pill">Paid</span>
+                    </div>
+                    <div className="share-bill-card-math"><BillMath b={b} /></div>
+                    {canDispute && (
+                        <button type="button" className="share-review-btn" onClick={() => onRequestReview(b)}>Question this charge</button>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+}
+
 export default function ShareView() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
@@ -239,11 +333,14 @@ export default function ShareView() {
 
     if (!data) return null;
 
+    const { isSettled } = derivePaymentState(data.paymentSummary);
+
     return (
         <div className="share-page">
             <ShareHeader data={data} />
-            {data.summary && <HouseholdBillsSection data={data} canDispute={shareCtx.canDispute} shareCtx={shareCtx} />}
-            {data.paymentSummary && <PaymentSummarySection ps={data.paymentSummary} year={data.year} />}
+            {data.paymentSummary && <ShareLeadCallout ps={data.paymentSummary} year={data.year} />}
+            {data.summary && <HouseholdBillsSection data={data} canDispute={shareCtx.canDispute} shareCtx={shareCtx} isSettled={isSettled} />}
+            {data.paymentSummary && <PaymentSummarySection ps={data.paymentSummary} />}
             {data.paymentMethods && data.paymentMethods.length > 0 && <PaymentMethodsSection methods={data.paymentMethods} ownerId={shareCtx.ownerId} canDispute={shareCtx.canDispute} paymentSummary={data.paymentSummary} />}
             {data.paymentHistory && data.paymentHistory.payments && data.paymentHistory.payments.length > 0 && (
                 <PaymentHistorySection history={data.paymentHistory} />
@@ -273,16 +370,19 @@ function ShareHeader({ data }) {
     );
 }
 
-function MemberRow({ member, canDispute, onRequestReview, defaultExpanded }) {
+function MemberRow({ member, canDispute, onRequestReview, defaultExpanded, isSettled }) {
     const [expanded, setExpanded] = useState(defaultExpanded);
     const billCount = member.bills ? member.bills.length : 0;
     const monthlyTotal = member.bills ? member.bills.reduce((s, b) => s + (b.monthlyShare || 0), 0) : 0;
+    // Settled households get the calmer card layout; owed/unpaid keep the full
+    // itemized table so the member sees the entire breakdown of what's owed.
+    const BillsView = isSettled ? BillsCards : BillsTable;
 
     if (defaultExpanded) {
         return (
             <div className="share-member-row">
                 <h3 className="share-member-name">{member.name}</h3>
-                <BillsTable bills={member.bills} canDispute={canDispute} onRequestReview={onRequestReview} />
+                <BillsView bills={member.bills} canDispute={canDispute} onRequestReview={onRequestReview} />
             </div>
         );
     }
@@ -294,7 +394,7 @@ function MemberRow({ member, canDispute, onRequestReview, defaultExpanded }) {
                 <span>{member.name}—{billCount} {billCount === 1 ? 'bill' : 'bills'} ({formatCurrency(monthlyTotal)}/mo)</span>
             </button>
             {expanded && (
-                <BillsTable bills={member.bills} canDispute={canDispute} onRequestReview={onRequestReview} />
+                <BillsView bills={member.bills} canDispute={canDispute} onRequestReview={onRequestReview} />
             )}
         </div>
     );
@@ -342,7 +442,7 @@ function HouseholdTotalWithCredits({ allMembers, ps, serviceCredits }) {
     );
 }
 
-function HouseholdBillsSection({ data, canDispute, shareCtx }) {
+function HouseholdBillsSection({ data, canDispute, shareCtx, isSettled }) {
     const [disputeForm, setDisputeForm] = useState(null);
     const allMembers = [data.summary, ...(data.linkedMembers || [])];
     const isSingleMember = allMembers.length === 1;
@@ -367,6 +467,7 @@ function HouseholdBillsSection({ data, canDispute, shareCtx }) {
                     canDispute={canDispute}
                     onRequestReview={bill => setDisputeForm(bill)}
                     defaultExpanded={isSingleMember}
+                    isSettled={isSettled}
                 />
             ))}
 
@@ -431,41 +532,31 @@ function BillsTable({ bills, canDispute, onRequestReview }) {
     );
 }
 
-function PaymentSummarySection({ ps, year }) {
+function PaymentSummarySection({ ps }) {
     const pctPaid = ps.combinedAnnualTotal > 0 ? Math.min(100, Math.round((ps.totalPaid / ps.combinedAnnualTotal) * 100)) : 0;
     const { isOwed, isSettled } = derivePaymentState(ps);
-    const balClass = isOwed ? 'owed' : (isSettled ? 'settled-zero' : '');
-    const balLabel = isSettled ? 'Paid' : formatCurrency(ps.balanceRemaining);
 
+    // The lead callout (rendered above the bills) carries the settled/owed
+    // headline; these cards carry the supporting figures. Settled collapses to the
+    // two that still matter (share, annual); owed/unpaid keeps annual, paid, and
+    // the outstanding balance plus the progress bar.
     return (
-        <div className="share-section">
-            <h2>Payment Summary</h2>
-
-            {/* State-driven lead (#354/#355): when settled, lead with the
-                confirmation and demote the transactional detail; when owed, lead
-                with the amount due so there's no ambiguity about what to send. */}
-            {isSettled && (
-                <div className="share-callout settled">
-                    <strong>You&apos;re all settled for {year}. Thank you!</strong>
-                </div>
-            )}
-            {isOwed && (
-                <div className="share-callout outstanding">
-                    <strong>You still have an outstanding balance for {year}.</strong>
-                    <p className="share-amount-due">Amount Remaining: {formatCurrency(ps.balanceRemaining)}</p>
-                </div>
-            )}
-
+        <div className="share-section share-summary-stats">
             <div className="share-stat-grid">
-                <div className="share-stat-card"><div className="share-stat-label">Annual Total</div><div className="share-stat-value">{formatCurrency(ps.combinedAnnualTotal)}</div></div>
-                <div className="share-stat-card"><div className="share-stat-label">Monthly</div><div className="share-stat-value">{formatCurrency(ps.combinedMonthlyTotal)}</div></div>
-                {/* Paid-to-date and Balance carry no new information once settled (paid == total,
-                    balance == 0), so collapse the grid to the two figures that still do (#354). */}
-                {!isSettled && <div className="share-stat-card"><div className="share-stat-label">Paid to Date</div><div className="share-stat-value paid">{formatCurrency(ps.totalPaid)}</div></div>}
-                {!isSettled && <div className="share-stat-card"><div className="share-stat-label">Balance Remaining</div><div className={'share-stat-value ' + balClass}>{balLabel}</div></div>}
+                {isSettled ? (
+                    <>
+                        <div className="share-stat-card"><div className="share-stat-label">Your share</div><div className="share-stat-value">{formatCurrency(ps.combinedMonthlyTotal)}<span className="share-stat-unit">/mo</span></div></div>
+                        <div className="share-stat-card"><div className="share-stat-label">Annual total</div><div className="share-stat-value">{formatCurrency(ps.combinedAnnualTotal)}</div></div>
+                    </>
+                ) : (
+                    <>
+                        <div className="share-stat-card"><div className="share-stat-label">Annual Total</div><div className="share-stat-value">{formatCurrency(ps.combinedAnnualTotal)}</div></div>
+                        <div className="share-stat-card"><div className="share-stat-label">Paid to Date</div><div className="share-stat-value paid">{formatCurrency(ps.totalPaid)}</div></div>
+                        <div className="share-stat-card"><div className="share-stat-label">{isOwed ? 'Balance Due' : 'Balance Remaining'}</div><div className={'share-stat-value ' + (isOwed ? 'owed' : 'settled-zero')}>{formatCurrency(ps.balanceRemaining)}</div></div>
+                    </>
+                )}
             </div>
 
-            {/* The bar is always 100% when settled, so hide it (#354). */}
             {!isSettled && (
                 <>
                     <div className="share-progress">
@@ -479,9 +570,9 @@ function PaymentSummarySection({ ps, year }) {
 }
 
 function PaymentMethodsSection({ methods, ownerId, canDispute, paymentSummary }) {
-    const { isOwed, isSettled, balanceRemaining } = derivePaymentState(paymentSummary);
-    // Collapse the methods once settled (#354); the member can still expand them on demand.
-    const [expanded, setExpanded] = useState(!isSettled);
+    // Methods always render in full (both states); the echo surfaces the amount due
+    // on the preferred method when owed.
+    const { isOwed, balanceRemaining } = derivePaymentState(paymentSummary);
     const [qrModal, setQrModal] = useState(null);
     const [loadingQr, setLoadingQr] = useState(null);
 
@@ -592,36 +683,21 @@ function PaymentMethodsSection({ methods, ownerId, canDispute, paymentSummary })
     return (
         <div className="share-section">
             <h2>Payment Methods</h2>
-            {isSettled && !expanded ? (
-                /* Settled: collapse to a one-line "Paid via {preferred}" summary with an
-                   expand affordance, so the methods don't dominate an already-paid view (#354). */
-                <div className="share-pm-collapsed">
-                    <span className="share-pm-collapsed-note">
-                        {preferredMethod ? 'Paid via ' + preferredMethod.label + '.' : 'This balance is settled.'}
-                    </span>
-                    <button type="button" className="share-pm-expand" onClick={() => setExpanded(true)}>
-                        Show payment methods
-                    </button>
+            <p className="share-trust-note share-trust-note--secure">
+                <svg className="share-trust-lock" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                </svg>
+                <span>
+                    Payments go directly to the organizer—Friends &amp; Family Billing never processes or holds your money.
+                    {canDispute && ' That’s also why "Question this charge" exists: flag anything that looks off and the account owner is notified.'}
+                </span>
+            </p>
+            {preferredMethod && renderCard(preferredMethod, 'share-pm-card share-pm-card--preferred')}
+            {otherMethods.length > 0 && (
+                <div className="share-pm-grid">
+                    {otherMethods.map(pm => renderCard(pm, 'share-pm-card'))}
                 </div>
-            ) : (
-                <>
-                    <p className="share-trust-note share-trust-note--secure">
-                        <svg className="share-trust-lock" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-                            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-                        </svg>
-                        <span>
-                            Pay directly through the apps below—Friends &amp; Family Billing doesn&apos;t process payments.
-                            {canDispute && ' That’s also why "Question This" exists: flag anything that looks off and the account owner is notified.'}
-                        </span>
-                    </p>
-                    {preferredMethod && renderCard(preferredMethod, 'share-pm-card share-pm-card--preferred')}
-                    {otherMethods.length > 0 && (
-                        <div className="share-pm-grid">
-                            {otherMethods.map(pm => renderCard(pm, 'share-pm-card'))}
-                        </div>
-                    )}
-                </>
             )}
 
             {qrModal && (

--- a/src/app/views/ShareView.jsx
+++ b/src/app/views/ShareView.jsx
@@ -541,7 +541,7 @@ function PaymentSummarySection({ ps }) {
     // two that still matter (share, annual); owed/unpaid keeps annual, paid, and
     // the outstanding balance plus the progress bar.
     return (
-        <div className="share-section share-summary-stats">
+        <div className="share-section share-summary-stats" role="region" aria-label="Payment summary">
             <div className="share-stat-grid">
                 {isSettled ? (
                     <>

--- a/tests/react/views/ShareView.test.jsx
+++ b/tests/react/views/ShareView.test.jsx
@@ -435,7 +435,7 @@ describe('ShareView', () => {
             const { container } = render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText(/doesn't process payments/)).toBeInTheDocument();
+                expect(screen.getByText(/never processes or holds your money/)).toBeInTheDocument();
             });
 
             const note = container.querySelector('.share-trust-note--secure');
@@ -450,9 +450,9 @@ describe('ShareView', () => {
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText(/doesn't process payments/)).toBeInTheDocument();
+                expect(screen.getByText(/never processes or holds your money/)).toBeInTheDocument();
             });
-            expect(screen.getByText(/why "Question This" exists/)).toBeInTheDocument();
+            expect(screen.getByText(/why "Question this charge" exists/)).toBeInTheDocument();
         });
 
         it('omits the "Question This" rationale when the link cannot dispute (#353)', async () => {
@@ -462,9 +462,9 @@ describe('ShareView', () => {
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText(/doesn't process payments/)).toBeInTheDocument();
+                expect(screen.getByText(/never processes or holds your money/)).toBeInTheDocument();
             });
-            expect(screen.queryByText(/why "Question This" exists/)).not.toBeInTheDocument();
+            expect(screen.queryByText(/why "Question this charge" exists/)).not.toBeInTheDocument();
             expect(screen.queryAllByRole('button', { name: 'Question This' })).toHaveLength(0);
         });
     });
@@ -648,65 +648,62 @@ describe('ShareView', () => {
     // 10. PaymentSummarySection
     // -----------------------------------------------------------------------
     describe('PaymentSummarySection', () => {
-        it('shows payment stats and progress', async () => {
+        it('shows owed stat cards and progress (annual / paid / balance due)', async () => {
             setToken('abc123');
             mockPublicSharesHit();
 
-            render(<ShareView />);
+            const { container } = render(<ShareView />);
 
-            const heading = await screen.findByText('Payment Summary');
-            // Scope queries to the payment summary section
-            const section = heading.closest('.share-section');
+            await waitFor(() => expect(container.querySelector('.share-summary-stats')).toBeTruthy());
+            const section = container.querySelector('.share-summary-stats');
 
             expect(within(section).getByText('Annual Total')).toBeInTheDocument();
             expect(within(section).getByText('$135.96')).toBeInTheDocument();
-            expect(within(section).getByText('Monthly')).toBeInTheDocument();
-            expect(within(section).getByText('$11.33')).toBeInTheDocument();
             expect(within(section).getByText('Paid to Date')).toBeInTheDocument();
             expect(within(section).getByText('$50.00')).toBeInTheDocument();
-            expect(within(section).getByText('Balance Remaining')).toBeInTheDocument();
-            // $85.96 appears in both the stat card and the callout within this section
-            expect(within(section).getAllByText('$85.96').length).toBeGreaterThanOrEqual(1);
-            // Progress percentage: Math.round(50/135.96 * 100) = 37
+            expect(within(section).getByText('Balance Due')).toBeInTheDocument();
+            expect(within(section).getByText('$85.96')).toBeInTheDocument();
+            // Math.round(50/135.96 * 100) = 37
             expect(within(section).getByText('37% paid')).toBeInTheDocument();
+            // The standalone "Monthly" card is dropped in the owed redesign (it's in the bills table).
+            expect(within(section).queryByText('Monthly')).not.toBeInTheDocument();
         });
 
-        it('shows outstanding balance callout when balanceRemaining > 0', async () => {
+        it('leads with the owed callout (amount due) above the bills when balanceRemaining > 0', async () => {
             setToken('abc123');
             mockPublicSharesHit();
 
-            render(<ShareView />);
+            const { container } = render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText(/still have an outstanding balance/)).toBeInTheDocument();
+                expect(screen.getByText('$85.96 due for 2024')).toBeInTheDocument();
             });
-
-            expect(screen.getByText(/Amount Remaining: \$85.96/)).toBeInTheDocument();
+            const lead = container.querySelector('.share-lead--owed');
+            expect(lead).toBeTruthy();
+            expect(within(lead).getByText('$50.00 of $135.96 paid')).toBeInTheDocument();
         });
 
-        it('shows settled callout when balanceRemaining <= 0 and totalPaid > 0', async () => {
+        it('leads with the settled callout when balanceRemaining <= 0 and totalPaid > 0', async () => {
             setToken('abc123');
             const settledData = {
                 ...sampleShareData,
-                paymentSummary: {
-                    combinedAnnualTotal: 100,
-                    combinedMonthlyTotal: 8.33,
-                    totalPaid: 100,
-                    balanceRemaining: 0
-                }
+                paymentSummary: { combinedAnnualTotal: 100, combinedMonthlyTotal: 8.33, totalPaid: 100, balanceRemaining: 0 }
             };
             mockPublicSharesHit(settledData);
 
-            render(<ShareView />);
+            const { container } = render(<ShareView />);
 
             await waitFor(() => {
                 expect(screen.getByText(/all settled for 2024/)).toBeInTheDocument();
             });
+            const lead = container.querySelector('.share-lead--settled');
+            expect(lead).toBeTruthy();
+            expect(within(lead).getByText(/\$100\.00 paid in full/)).toBeInTheDocument();
         });
     });
 
     // -----------------------------------------------------------------------
-    // 10b. State-driven settled / owed layout (#354/#355)
+    // 10b. State-driven settled / owed layout (#354/#355) — mockup redesign
     // -----------------------------------------------------------------------
     describe('state-driven settled / owed layout', () => {
         const settledData = {
@@ -719,56 +716,64 @@ describe('ShareView', () => {
             paymentMethods: [{ id: 'pm1', type: 'venmo', label: 'Venmo', handle: '@john', preferred: true }]
         };
 
-        it('leads with the settled callout and drops the transactional cards/progress (#354)', async () => {
+        it('settled: lead callout above bill cards, two stat cards, no progress (#354)', async () => {
             setToken('abc123');
             mockPublicSharesHit(settledData);
 
-            render(<ShareView />);
+            const { container } = render(<ShareView />);
 
-            const heading = await screen.findByText('Payment Summary');
-            const section = heading.closest('.share-section');
+            await waitFor(() => expect(screen.getByText(/all settled for 2024/)).toBeInTheDocument());
 
-            expect(within(section).getByText(/all settled for 2024/)).toBeInTheDocument();
-            expect(within(section).queryByText('Paid to Date')).not.toBeInTheDocument();
-            expect(within(section).queryByText('Balance Remaining')).not.toBeInTheDocument();
-            expect(within(section).queryByText(/% paid/)).not.toBeInTheDocument();
-            expect(within(section).getByText('Annual Total')).toBeInTheDocument();
-            expect(within(section).getByText('Monthly')).toBeInTheDocument();
+            // Bills render as cards (with Paid pills), not the table.
+            expect(container.querySelectorAll('.share-bill-card').length).toBe(2);
+            expect(container.querySelector('.share-bill-paid-pill')).toBeTruthy();
+            expect(container.querySelector('.share-table')).toBeNull();
 
-            // Settled callout renders before the stat grid.
-            const callout = within(section).getByText(/all settled/).closest('.share-callout');
-            const grid = section.querySelector('.share-stat-grid');
-            expect(callout.compareDocumentPosition(grid) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+            // Stat cards collapse to share + annual; no progress / paid / balance.
+            const stats = container.querySelector('.share-summary-stats');
+            expect(within(stats).getByText('Your share')).toBeInTheDocument();
+            expect(within(stats).getByText('Annual total')).toBeInTheDocument();
+            expect(within(stats).queryByText('Paid to Date')).not.toBeInTheDocument();
+            expect(within(stats).queryByText(/% paid/)).not.toBeInTheDocument();
+
+            // The lead callout sits before the bills in the DOM.
+            const lead = container.querySelector('.share-lead--settled');
+            const firstCard = container.querySelector('.share-bill-card');
+            expect(lead.compareDocumentPosition(firstCard) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
         });
 
-        it('collapses payment methods when settled and expands on demand (#354)', async () => {
-            const user = userEvent.setup();
+        it('owed: renders the full bills table (not cards) (#354)', async () => {
             setToken('abc123');
-            mockPublicSharesHit(settledData);
+            mockPublicSharesHit(); // owed
+
+            const { container } = render(<ShareView />);
+
+            await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument());
+            expect(container.querySelector('.share-table')).toBeTruthy();
+            expect(container.querySelector('.share-bill-card')).toBeNull();
+            expect(screen.getByText('TOTAL')).toBeInTheDocument();
+        });
+
+        it('renders payment methods in full in both states — no collapse (#354)', async () => {
+            setToken('abc123');
+            mockPublicSharesHit(settledData); // settled
 
             render(<ShareView />);
 
             const heading = await screen.findByText('Payment Methods');
             const section = heading.closest('.share-section');
-
-            expect(within(section).getByText('Paid via Venmo.')).toBeInTheDocument();
-            expect(within(section).queryByText('@john')).not.toBeInTheDocument();
-
-            await user.click(within(section).getByRole('button', { name: 'Show payment methods' }));
-
+            // Method detail is visible immediately; no "Show payment methods" affordance.
             expect(within(section).getByText('@john')).toBeInTheDocument();
             expect(within(section).queryByRole('button', { name: 'Show payment methods' })).not.toBeInTheDocument();
         });
 
         it('does not echo an amount on the preferred method when settled (#355)', async () => {
-            const user = userEvent.setup();
             setToken('abc123');
             mockPublicSharesHit(settledData);
 
             render(<ShareView />);
 
             await screen.findByText('Payment Methods');
-            await user.click(screen.getByRole('button', { name: 'Show payment methods' }));
             expect(screen.queryByText(/Send \$/)).not.toBeInTheDocument();
         });
 
@@ -781,19 +786,19 @@ describe('ShareView', () => {
             await waitFor(() => {
                 expect(screen.getByText(/Send \$85\.96 via Venmo/)).toBeInTheDocument();
             });
-            expect(screen.queryByRole('button', { name: 'Show payment methods' })).not.toBeInTheDocument();
         });
 
-        it('surfaces the amount due prominently in the owed lead (#355)', async () => {
+        it('surfaces the amount due in the owed lead callout (#355)', async () => {
             setToken('abc123');
-            mockPublicSharesHit(); // sampleShareData: owed 85.96
+            mockPublicSharesHit(); // sampleShareData: owed 85.96, year 2024
 
-            render(<ShareView />);
+            const { container } = render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText(/Amount Remaining: \$85.96/)).toBeInTheDocument();
+                expect(screen.getByText('$85.96 due for 2024')).toBeInTheDocument();
             });
-            expect(screen.getByText(/Amount Remaining: \$85.96/)).toHaveClass('share-amount-due');
+            const lead = container.querySelector('.share-lead--owed');
+            expect(within(lead).getByText('$85.96 due for 2024')).toBeInTheDocument();
         });
     });
 
@@ -841,7 +846,7 @@ describe('ShareView', () => {
 
             render(<ShareView />);
 
-            await screen.findByText('Payment Summary');
+            await screen.findByText('Payment Methods');
             expect(screen.queryByText('Payment History')).not.toBeInTheDocument();
         });
 
@@ -851,7 +856,7 @@ describe('ShareView', () => {
 
             render(<ShareView />);
 
-            await screen.findByText('Payment Summary');
+            await screen.findByText('Payment Methods');
             expect(screen.queryByText('Payment History')).not.toBeInTheDocument();
         });
     });
@@ -1203,7 +1208,7 @@ describe('ShareView', () => {
             setToken('abc123');
             mockPublicSharesHit({ ...sampleShareData, refundNotices: [] });
             render(<ShareView />);
-            await waitFor(() => expect(screen.getByText('Payment Summary')).toBeInTheDocument());
+            await waitFor(() => expect(screen.getByText('Payment Methods')).toBeInTheDocument());
             expect(screen.queryByText('Your Refunds')).not.toBeInTheDocument();
         });
 
@@ -1346,7 +1351,7 @@ describe('ShareView', () => {
             render(<ShareView />);
 
             await waitFor(() => {
-                expect(screen.getByText(/Pay directly through the apps below/)).toBeInTheDocument();
+                expect(screen.getByText(/Payments go directly to the organizer/)).toBeInTheDocument();
             });
         });
     });

--- a/tests/react/views/ShareView.test.jsx
+++ b/tests/react/views/ShareView.test.jsx
@@ -652,35 +652,31 @@ describe('ShareView', () => {
             setToken('abc123');
             mockPublicSharesHit();
 
-            const { container } = render(<ShareView />);
+            render(<ShareView />);
 
-            await waitFor(() => expect(container.querySelector('.share-summary-stats')).toBeTruthy());
-            const section = container.querySelector('.share-summary-stats');
-
-            expect(within(section).getByText('Annual Total')).toBeInTheDocument();
-            expect(within(section).getByText('$135.96')).toBeInTheDocument();
-            expect(within(section).getByText('Paid to Date')).toBeInTheDocument();
-            expect(within(section).getByText('$50.00')).toBeInTheDocument();
-            expect(within(section).getByText('Balance Due')).toBeInTheDocument();
-            expect(within(section).getByText('$85.96')).toBeInTheDocument();
+            const stats = await screen.findByRole('region', { name: 'Payment summary' });
+            expect(within(stats).getByText('Annual Total')).toBeInTheDocument();
+            expect(within(stats).getByText('$135.96')).toBeInTheDocument();
+            expect(within(stats).getByText('Paid to Date')).toBeInTheDocument();
+            expect(within(stats).getByText('$50.00')).toBeInTheDocument();
+            expect(within(stats).getByText('Balance Due')).toBeInTheDocument();
+            expect(within(stats).getByText('$85.96')).toBeInTheDocument();
             // Math.round(50/135.96 * 100) = 37
-            expect(within(section).getByText('37% paid')).toBeInTheDocument();
+            expect(within(stats).getByText('37% paid')).toBeInTheDocument();
             // The standalone "Monthly" card is dropped in the owed redesign (it's in the bills table).
-            expect(within(section).queryByText('Monthly')).not.toBeInTheDocument();
+            expect(within(stats).queryByText('Monthly')).not.toBeInTheDocument();
         });
 
-        it('leads with the owed callout (amount due) above the bills when balanceRemaining > 0', async () => {
+        it('leads with the owed callout (amount due) when balanceRemaining > 0', async () => {
             setToken('abc123');
             mockPublicSharesHit();
 
-            const { container } = render(<ShareView />);
+            render(<ShareView />);
 
             await waitFor(() => {
                 expect(screen.getByText('$85.96 due for 2024')).toBeInTheDocument();
             });
-            const lead = container.querySelector('.share-lead--owed');
-            expect(lead).toBeTruthy();
-            expect(within(lead).getByText('$50.00 of $135.96 paid')).toBeInTheDocument();
+            expect(screen.getByText('$50.00 of $135.96 paid')).toBeInTheDocument();
         });
 
         it('leads with the settled callout when balanceRemaining <= 0 and totalPaid > 0', async () => {
@@ -691,14 +687,12 @@ describe('ShareView', () => {
             };
             mockPublicSharesHit(settledData);
 
-            const { container } = render(<ShareView />);
+            render(<ShareView />);
 
             await waitFor(() => {
                 expect(screen.getByText(/all settled for 2024/)).toBeInTheDocument();
             });
-            const lead = container.querySelector('.share-lead--settled');
-            expect(lead).toBeTruthy();
-            expect(within(lead).getByText(/\$100\.00 paid in full/)).toBeInTheDocument();
+            expect(screen.getByText(/\$100\.00 paid in full/)).toBeInTheDocument();
         });
     });
 
@@ -720,38 +714,40 @@ describe('ShareView', () => {
             setToken('abc123');
             mockPublicSharesHit(settledData);
 
-            const { container } = render(<ShareView />);
+            render(<ShareView />);
 
             await waitFor(() => expect(screen.getByText(/all settled for 2024/)).toBeInTheDocument());
 
-            // Bills render as cards (with Paid pills), not the table.
-            expect(container.querySelectorAll('.share-bill-card').length).toBe(2);
-            expect(container.querySelector('.share-bill-paid-pill')).toBeTruthy();
-            expect(container.querySelector('.share-table')).toBeNull();
+            // Bills render as cards: each has a "Paid" pill and a "Question this charge" control;
+            // the table (column headers) is absent.
+            expect(screen.getAllByText('Paid')).toHaveLength(2);
+            expect(screen.getAllByRole('button', { name: 'Question this charge' }).length).toBeGreaterThan(0);
+            expect(screen.queryByRole('columnheader', { name: 'Monthly' })).not.toBeInTheDocument();
 
             // Stat cards collapse to share + annual; no progress / paid / balance.
-            const stats = container.querySelector('.share-summary-stats');
+            const stats = screen.getByRole('region', { name: 'Payment summary' });
             expect(within(stats).getByText('Your share')).toBeInTheDocument();
             expect(within(stats).getByText('Annual total')).toBeInTheDocument();
             expect(within(stats).queryByText('Paid to Date')).not.toBeInTheDocument();
             expect(within(stats).queryByText(/% paid/)).not.toBeInTheDocument();
 
-            // The lead callout sits before the bills in the DOM.
-            const lead = container.querySelector('.share-lead--settled');
-            const firstCard = container.querySelector('.share-bill-card');
-            expect(lead.compareDocumentPosition(firstCard) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+            // The lead callout sits before the bills in DOM order.
+            const lead = screen.getByText(/all settled for 2024/);
+            const firstPaidPill = screen.getAllByText('Paid')[0];
+            expect(lead.compareDocumentPosition(firstPaidPill) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
         });
 
         it('owed: renders the full bills table (not cards) (#354)', async () => {
             setToken('abc123');
             mockPublicSharesHit(); // owed
 
-            const { container } = render(<ShareView />);
+            render(<ShareView />);
 
             await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument());
-            expect(container.querySelector('.share-table')).toBeTruthy();
-            expect(container.querySelector('.share-bill-card')).toBeNull();
+            // Table columns present; the card-only "Question this charge" control is absent.
+            expect(screen.getByRole('columnheader', { name: 'Monthly' })).toBeInTheDocument();
             expect(screen.getByText('TOTAL')).toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: 'Question this charge' })).not.toBeInTheDocument();
         });
 
         it('renders payment methods in full in both states — no collapse (#354)', async () => {
@@ -760,11 +756,10 @@ describe('ShareView', () => {
 
             render(<ShareView />);
 
-            const heading = await screen.findByText('Payment Methods');
-            const section = heading.closest('.share-section');
+            await screen.findByText('Payment Methods');
             // Method detail is visible immediately; no "Show payment methods" affordance.
-            expect(within(section).getByText('@john')).toBeInTheDocument();
-            expect(within(section).queryByRole('button', { name: 'Show payment methods' })).not.toBeInTheDocument();
+            expect(screen.getByText('@john')).toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: 'Show payment methods' })).not.toBeInTheDocument();
         });
 
         it('does not echo an amount on the preferred method when settled (#355)', async () => {
@@ -792,13 +787,11 @@ describe('ShareView', () => {
             setToken('abc123');
             mockPublicSharesHit(); // sampleShareData: owed 85.96, year 2024
 
-            const { container } = render(<ShareView />);
+            render(<ShareView />);
 
             await waitFor(() => {
                 expect(screen.getByText('$85.96 due for 2024')).toBeInTheDocument();
             });
-            const lead = container.querySelector('.share-lead--owed');
-            expect(within(lead).getByText('$85.96 due for 2024')).toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
## Summary

Redesigns the public share page to the Cowork design-session mockup, after a design review found the shipped #350 implementation matched the written criteria but NOT the mockup. View-layer only (src/app); follow-up to epic #350 (closed). No backend/calculations changes.

### Settled (matches the mockup)
- Lead callout at the top: green "all settled for {year}" headline with the paid-in-full subline.
- Bills render as cards with a "Paid" pill and styled inline split math.
- Stat cards collapse to "Your share" + "Annual total".

### Owed (derived; confirmed with the design owner)
- Red lead callout with the amount due + "{paid} of {annual} paid".
- The full bills table of what is owed (Bill / Monthly / Split / Share / Annual + TOTAL).
- Stat cards: Annual / Paid to date / Balance due + progress bar.

### Both states
- Payment methods render in full (dropped the prior settled-collapse), with the elevated lock trust note and the owed "Send $X via {method}" echo.
- Payment History (#357) and the Pending Charges table are kept, in the new aesthetic.

Authoring-Agent: claude

## Self-Review

- Correctness: state is derived from derivePaymentState(paymentSummary) (settled = no balance + payments made; owed = positive balance; neither = no lead). The lead callout, bill card-vs-table choice, and stat-card set all key off the same flag. Reuses formatSplitMath/formatCurrency; no calculations.js changes.
- Regression risk: moderate (restructures the layout) but contained to ShareView.jsx + shell.css. No backend, payload, or scope changes. The owed/unpaid path keeps the existing table verbatim; multi-member, linked-member, disputes, refunds, service-credit, and pending-charge paths are unchanged.
- Threshold: 454 lines changed, over the 300 external-review threshold, so this is Phase 4 (no protected paths, size-gated).
- Test coverage: rewrote the affected ShareView tests for the new structure (lead copy + class, settled cards + Paid pill, owed table, full-methods-no-collapse, owed echo, stat-card sets, graceful payment-history). 72 ShareView tests pass; full npm test green (1069 React + 68 functions + secret scan); eslint clean.
- Style: repo design tokens (periwinkle/success/danger); inline SVG icons (no new icon-font dependency).

## Visual
Confirmed against the mockup (issue #350 comment 4774420680) and a real-compiled-CSS preview (settled + owed) by the design owner before this PR.