### PR TITLE
fix: move Pending Charges next to the bill/summary, not the page bottom

### DIFF
--- a/src/app/views/ShareView.jsx
+++ b/src/app/views/ShareView.jsx
@@ -341,14 +341,16 @@ export default function ShareView() {
             {data.paymentSummary && <ShareLeadCallout ps={data.paymentSummary} year={data.year} />}
             {data.summary && <HouseholdBillsSection data={data} canDispute={shareCtx.canDispute} shareCtx={shareCtx} isSettled={isSettled} />}
             {data.paymentSummary && <PaymentSummarySection ps={data.paymentSummary} />}
+            {/* Pending Charges sit right after the bill/summary they relate to (mockup
+                placement), not at the bottom of the page. */}
+            {data.pendingCharges && data.pendingCharges.charges && data.pendingCharges.charges.length > 0 && (
+                <PendingChargesSection pendingCharges={data.pendingCharges} year={data.year} />
+            )}
             {data.paymentMethods && data.paymentMethods.length > 0 && <PaymentMethodsSection methods={data.paymentMethods} ownerId={shareCtx.ownerId} canDispute={shareCtx.canDispute} paymentSummary={data.paymentSummary} />}
             {data.paymentHistory && data.paymentHistory.payments && data.paymentHistory.payments.length > 0 && (
                 <PaymentHistorySection history={data.paymentHistory} />
             )}
             {data.refundNotices && data.refundNotices.length > 0 && <RefundNoticesSection notices={data.refundNotices} shareCtx={shareCtx} />}
-            {data.pendingCharges && data.pendingCharges.charges && data.pendingCharges.charges.length > 0 && (
-                <PendingChargesSection pendingCharges={data.pendingCharges} year={data.year} />
-            )}
             {data.disputes && data.disputes.length > 0 && <DisputesSection disputes={data.disputes} shareCtx={shareCtx} />}
         </div>
     );

--- a/tests/react/views/ShareView.test.jsx
+++ b/tests/react/views/ShareView.test.jsx
@@ -1597,6 +1597,19 @@ describe('ShareView', () => {
             expect(screen.getAllByText('$27.50').length).toBeGreaterThanOrEqual(1);
         });
 
+        it('renders Pending Charges above Payment Methods (mockup placement)', async () => {
+            setToken('abc123');
+            mockPublicSharesHit(withPendingCharges);
+
+            render(<ShareView />);
+
+            await waitFor(() => expect(screen.getByText('Pending Charges')).toBeInTheDocument());
+            // The upcoming charges sit next to the bill/summary, not at the bottom of the page.
+            const pending = screen.getByText('Pending Charges');
+            const methods = screen.getByText('Payment Methods');
+            expect(pending.compareDocumentPosition(methods) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        });
+
         it('labels the pending charges as not yet due', async () => {
             setToken('abc123');
             mockPublicSharesHit(withPendingCharges);


### PR DESCRIPTION
## Summary

Fixes the placement of Pending Charges on the redesigned share page. The mockup shows the upcoming-charges notice right after the bill and stat cards, but the live render put Pending Charges near the bottom (after payment methods, history, and refunds). Reorders the share-page render so Pending Charges follows the Payment Summary stat cards, before Payment Methods. View-layer only; follow-up to the #350 redesign (#362).

Authoring-Agent: claude

## Self-Review

- Correctness: pure render-order change in the ShareView top-level; Pending Charges moved to immediately after PaymentSummarySection. No data, scope, or component-internal changes. Still gated on a non-empty pendingCharges.
- Regression risk: minimal (one block moved). The pending-charges component, its content, and every other section are unchanged.
- Threshold: 21 lines changed, under the 300 external-review threshold, no protected paths, so internal review.
- Test coverage: adds an order test (Pending Charges renders before Payment Methods via compareDocumentPosition); existing pending-charges tests unchanged and green. 73 ShareView tests pass; full npm test green (1070 React + 68 functions + secret scan); eslint clean.

## Visual
Matches the mockup placement (upcoming charges next to the bill/summary, not the page bottom).