### PR TITLE
Close billing test-coverage gaps (#366)

### DIFF
--- a/tests/functions.test.js
+++ b/tests/functions.test.js
@@ -150,6 +150,66 @@ describe('computeMemberSummary with billing frequency', () => {
     });
 });
 
+// ──────────── sum-of-shares invariant (#366, PR #339 r3448998865) ────────────
+//
+// computeMemberSummary rounds each member's per-bill annualShare independently
+// (Math.round(annualShare * 100) / 100). The reviewer-pinned invariant: summing
+// those rounded shares across a bill's members reconstructs the bill total to
+// within the rounding it introduces — at most half a cent per member — and the
+// UNrounded shares sum to the total exactly. The bounded drift is deliberate
+// (each share is a real per-member figure shown to that member), so the test pins
+// both the exactness of the raw split and the half-cent-per-member ceiling on the
+// rounded sum, so a future change that lets the rounded shares drift unbounded
+// (or that silently re-rounds the household total away from the parts) fails here.
+
+describe('computeMemberSummary — sum-of-shares invariant (#366)', () => {
+    const cents = (x) => Math.round(x * 100) / 100;
+
+    // Bill amounts chosen so annualTotal / splitCount does NOT divide evenly:
+    // $10/yr ÷ 3 = $3.333… → $3.33 each, summing to $9.99 (a deliberate 1¢ drift);
+    // $20/yr (annual) ÷ 7 → $2.86 each, summing to $20.02.
+    const driftCases = [
+        { amount: 10, billingFrequency: 'annual', n: 3 },   // 10 / 3
+        { amount: 20, billingFrequency: 'annual', n: 7 },   // 20 / 7
+        { amount: 100, billingFrequency: 'monthly', n: 3 }, // 1200 / 3 (even) — control
+        { amount: 5, billingFrequency: 'monthly', n: 6 },   // 60 / 6 (even) — control
+    ];
+
+    for (const { amount, billingFrequency, n } of driftCases) {
+        it(`${n}-way split of ${amount}/${billingFrequency} keeps rounded shares within n·½¢ of the total`, () => {
+            const members = Array.from({ length: n }, (_, i) => ({
+                id: i + 1, name: 'M' + (i + 1), email: '', linkedMembers: []
+            }));
+            const memberIds = members.map((m) => m.id);
+            const bills = [{ id: 'b1', name: 'Split bill', amount, billingFrequency, members: memberIds }];
+
+            const annualTotal = billingFrequency === 'annual' ? amount : amount * 12;
+            const rawShare = annualTotal / n;
+
+            // Each member's rounded annualShare comes straight from computeMemberSummary.
+            const roundedShares = memberIds.map((id) => {
+                const summary = computeMemberSummary(members, bills, id);
+                assert.equal(summary.bills.length, 1);
+                assert.equal(summary.bills[0].splitCount, n);
+                return summary.bills[0].annualShare;
+            });
+
+            // (1) The UNrounded split is exact: n · (annualTotal / n) === annualTotal.
+            assert.ok(Math.abs(rawShare * n - annualTotal) < 1e-9);
+
+            // (2) The rounded shares reconstruct the total to within half a cent per member.
+            const summedRounded = cents(roundedShares.reduce((s, v) => s + v, 0));
+            assert.ok(
+                Math.abs(summedRounded - annualTotal) <= n * 0.005 + 1e-9,
+                `summed rounded shares ${summedRounded} drifted from ${annualTotal} by more than ${n}·½¢`
+            );
+
+            // (3) Every member carries the same rounded share for an even split.
+            assert.ok(roundedShares.every((v) => v === roundedShares[0]));
+        });
+    }
+});
+
 // ──────────────── buildPendingChargesForShare (#317) ─────────
 
 describe('buildPendingChargesForShare', () => {

--- a/tests/react/components/ChargeNoticeDialog.test.jsx
+++ b/tests/react/components/ChargeNoticeDialog.test.jsx
@@ -81,6 +81,16 @@ describe('ChargeNoticeDialog', () => {
         expect(onClose).toHaveBeenCalled();
     });
 
+    it('closes on the document-level Escape key handler (#366)', () => {
+        // The dialog binds a keydown listener on `document` while open; pressing Escape
+        // anywhere must close it. fireEvent is the sanctioned tool for Escape handling
+        // (testing-requirements.md § Interaction testing).
+        const onClose = vi.fn();
+        renderDialog({ onClose });
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(onClose).toHaveBeenCalled();
+    });
+
     it('shows an empty state and disables Bill & Notify when there are no charges', () => {
         render(
             <ChargeNoticeDialog open memberName="Alice" charges={[]} now={JUNE} onConfirm={vi.fn()} onClose={vi.fn()} />

--- a/tests/react/lib/calculations.test.js
+++ b/tests/react/lib/calculations.test.js
@@ -1024,6 +1024,19 @@ describe('getServiceCreditTotalForMember', () => {
         // Only the 10 counts; the string/NaN/negative/missing are dropped, not coerced.
         expect(getServiceCreditTotalForMember(owedAdjustments, 1)).toBeCloseTo(10, 5);
     });
+
+    // Boundary lock for the amount parser (#366). The guard is Number.parseFloat-based,
+    // so a *leading-numeric* string is parsed to its leading number — '10abc' → 10,
+    // '12.50 USD' → 12.5 — NOT dropped. This pins that exact behavior: a future swap to
+    // a stricter parser (Number()/validated parse that rejects trailing garbage) or a
+    // looser one would flip these numbers and trip the suite, forcing a conscious choice.
+    it('parses leading-numeric strings via parseFloat (10 + 12.5 from "10abc"/"12.50 USD")', () => {
+        const owedAdjustments = [
+            { id: 'o1', memberId: 1, kind: 'service_credit', amount: '10abc', status: 'active' },
+            { id: 'o2', memberId: 1, kind: 'service_credit', amount: '12.50 USD', status: 'active' }
+        ];
+        expect(getServiceCreditTotalForMember(owedAdjustments, 1)).toBeCloseTo(22.5, 5);
+    });
 });
 
 describe('calculateSettlementMetrics — service credits (#321)', () => {
@@ -1124,6 +1137,18 @@ describe('getBilledUsageChargeTotalForMember', () => {
             { id: 'o5', memberId: 1, kind: 'usage_charge', status: 'billed' }
         ];
         expect(getBilledUsageChargeTotalForMember(owedAdjustments, 1)).toBeCloseTo(10, 5);
+    });
+
+    // Boundary lock for the amount parser (#366) — same parseFloat semantics as the
+    // service-credit total. A leading-numeric string is parsed to its leading number
+    // ('10abc' → 10, '12.50 USD' → 12.5), not dropped; pinning it makes any future
+    // change to the parser's strictness fail the suite rather than silently shift money.
+    it('parses leading-numeric strings via parseFloat (10 + 12.5 from "10abc"/"12.50 USD")', () => {
+        const owedAdjustments = [
+            { id: 'o1', memberId: 1, kind: 'usage_charge', amount: '10abc', status: 'billed' },
+            { id: 'o2', memberId: 1, kind: 'usage_charge', amount: '12.50 USD', status: 'billed' }
+        ];
+        expect(getBilledUsageChargeTotalForMember(owedAdjustments, 1)).toBeCloseTo(22.5, 5);
     });
 });
 


### PR DESCRIPTION
Authoring-Agent: claude

## What

Adds three reviewer-suggested tests for already-shipped billing code (coverage only, no production change).

- **(a) sum-of-shares invariant** (`tests/functions.test.js`) — pins that independently-rounded member shares reconstruct the bill total (drift cases like $10/yr ÷ 3 → 3×$3.33 = $9.99, plus even-split controls), cross-checked via `computeMemberSummary`.
- **(b) malformed-amount cases** (`tests/react/lib/calculations.test.js`) — adds partial-numeric inputs (`'10abc'`, `'12.50 USD'`) to the service-credit and usage-charge totals.
- **(c) Escape-to-close** (`tests/react/components/ChargeNoticeDialog.test.jsx`) — `fireEvent.keyDown(document, { key: 'Escape' })` → `expect(onClose).toHaveBeenCalled()`.

## ⚠️ Premise correction on (b) — read before closing #366

The issue assumed the amount guard is **strict** and that the new cases would prove it *rejects* trailing garbage. It does not: the production guard (`addFinitePositiveAmount`, `src/lib/calculations.js`) uses `Number.parseFloat`, which **coerces** `'10abc'`→10 and `'12.50 USD'`→12.5 and counts them. To honor "every test must pass against current code," (b) pins the **actual lenient behavior** (asserting they sum to 22.5) with comments, so any future change to the guard's strictness trips the suite. Whether the guard *should* be hardened to reject these — a behavior change touching the high-risk `calculations.js` — is a **separate decision** and is not done here.

## Verification

`npx vitest run` (calculations + ChargeNoticeDialog) → **128 passed**; `npm run test:functions` → **72 passed**; eslint clean.

## Self-Review

- **Correctness:** Each test asserts behavior that holds against current `main` (no production code is touched). (a) reconstructs the bill total from independently-rounded shares via `computeMemberSummary`; (b) pins the *actual* `parseFloat` coercion rather than an assumed strict rejection (see the premise-correction note); (c) exercises the dialog's document-level Escape handler.
- **Regression risk:** None functionally — tests-only diff (+95/-0), no `src/` or `functions/` runtime change. The risk is purely that a later behavior change (e.g. hardening the amount guard) would now correctly fail these characterization tests, which is the intent.
- **Style/conventions:** Tests follow the existing Vitest / node:test patterns in each suite; comments explain *why* each case exists so they aren't mistaken for endorsing lenient parsing.
- **Test coverage:** Net-new coverage for the sum-of-shares invariant, partial-numeric money strings, and Escape-to-close — the three gaps named in #366.
- **Security/dependency hygiene:** No new dependencies, no secrets, no production behavior change.

Closes #366

---
_Resolves the Repo-local VALID finding from the 2026-06-22 sweep (mergepath#524; rubric mergepath#236). Reviewer threads: PR#339 r3448998865, PR#329 r3447655494, PR#328 r3447513515._
