### PR TITLE
sync: bulk reconcile to mergepath@fd103f8

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -986,33 +986,826 @@ jobs:
           wait_seconds=${TEST_CHECK_WAIT_SECONDS:-1200}
           poll_seconds=${TEST_CHECK_POLL_SECONDS:-15}
           deadline=$((SECONDS + wait_seconds))
-          sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid)
+          pr_view_json=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid,isCrossRepository,baseRefName,headRefName)
+          sha=$(echo "$pr_view_json" | jq -r .headRefOid)
+          # #655 Codex P2 round 9 ("wait for valid push-only annex
+          # workflows"): a push-only annex trigger only fires IN THIS REPO
+          # for a same-repo PR (a fork PRs push lands in the fork, never
+          # registering a push event here) -- isCrossRepository is gh pr
+          # view's own field for this, no extra API call needed.
+          annex_same_repo_pr=$(echo "$pr_view_json" | jq -r 'if .isCrossRepository then "false" else "true" end')
+          # #655 Codex P2 round 11 ("evaluate base-branch filters before
+          # passing"): a pull_request branches/branches-ignore filter is
+          # matched against the PRs BASE ref; a push branches/branches-ignore
+          # filter is matched against the ref actually being pushed, which
+          # for a same-repo PRs synchronize event is the PRs own HEAD ref
+          # (the feature branch), not base. Both already on this same
+          # pr_view_json call, no extra API call needed.
+          annex_base_branch=$(echo "$pr_view_json" | jq -r '.baseRefName // ""')
+          annex_head_branch=$(echo "$pr_view_json" | jq -r '.headRefName // ""')
+          # #655 Codex P2 round 16 ("wait for path-matched annex
+          # workflows", narrowed in round 17 -- "use the event diff when
+          # emulating path filters", found on the codex-review-check.sh
+          # copy and mirrored here): paginated the same way as the reviews
+          # fetch above (flatten with jq -s BEFORE deriving filenames).
+          # #655 Codex P2 round 17 ("fail closed when the changed-file
+          # lookup fails", Codex; "don't silently treat changed-files API
+          # failures as filtered out", CodeRabbit): the round-16 version
+          # piped stderr into stdout (2>&1) with no failure check, so a
+          # failed gh api call fed an error message into jq, which failed
+          # too, silently collapsing annex_changed_files_json to empty --
+          # indistinguishable from "genuinely fetched, zero files" on the
+          # ruby side, wrongly treated as "paths definitely does not
+          # match". Explicit success/failure branching keeps a failed
+          # fetch as an EXPLICITLY empty string (never touched by jq),
+          # which the ruby probe treats as "unknown", not "no files".
+          if annex_changed_files_raw=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" 2>&1); then
+            annex_changed_files_json=$(printf '%s' "$annex_changed_files_raw" | jq -s 'add // []' | jq -c '[.[].filename]')
+          else
+            annex_changed_files_json=""
+            echo "::warning::Could not fetch PR changed files ($annex_changed_files_raw) -- paths/paths-ignore annex filters will be treated as unresolvable (conservative default, #655 round 17)."
+          fi
+
+          # #655: a consumer's optional, never-propagated repo_lint_local.yml
+          # annex (#601) produces a check run that branch protection does not
+          # require, and this step — before this fix — did not observe either,
+          # so native auto-merge could arm with a red or missing annex check.
+          # Probe the PR HEAD commit for the annex file via the Contents API
+          # (not this job's own checkout — its ref is not guaranteed to be the
+          # PR head on every trigger shape this workflow handles) and require
+          # its check run(s) too when present. Absent (the common case,
+          # including mergepath itself) is a no-op: only `lint` is required,
+          # unchanged from before.
+          #
+          # required_checks_json stays scoped to ONLY the canonical
+          # `required_check_name` entry -- it is a hard requirement this
+          # loop waits for, up to the shared deadline, and fails closed on
+          # timeout. The repo_lint_local.yml annex must NOT be enforced the
+          # same way (#655 Codex P2 round 6, "avoid forcing path-filtered
+          # annex jobs to start"): a consumer annex scoped by workflow-level
+          # `paths`/`paths-ignore` legitimately produces NO check run at all
+          # for a PR outside those paths, and earlier rounds forcing its
+          # derived name(s) into this hard-required list made this loop
+          # wait out the full deadline and refuse auto-merge on every such
+          # PR, forever. Annex enforcement instead runs as a separate
+          # workflow-wide scan below (annex_workflow), each poll iteration,
+          # mirroring codex-review-check.sh gate (a): match by
+          # .workflowName rather than by a specific name, block immediately
+          # on any REPORTED bad conclusion, keep polling (bounded by this
+          # same shared deadline) while anything for that workflow is still
+          # in flight, and treat "nothing reported for this workflow at all"
+          # as non-blocking -- the same trade-off gate (a) already made and
+          # validated across #655 rounds 2-5.
+          required_checks_json=$(jq -n --arg name "$required_check_name" '[{name: $name, workflow: ""}]')
+          annex_workflow=""
+          annex_unfiltered="false"
+          annex_probe_err=$(mktemp)
+          if annex_content=$(gh api "repos/$REPO/contents/.github/workflows/repo_lint_local.yml?ref=$sha" --jq .content 2>"$annex_probe_err"); then
+            # The annex contract (scripts/ci/check_ci_scripts_wired) only requires
+            # a real push/pull_request-triggered workflow that wires local
+            # checks — it does NOT require the job (and therefore check-run)
+            # name to be `repo-lint-local` (Codex P2 on #655), nor does it ban
+            # path filters. Derive the annex's own top-level workflow name the
+            # same way check_ci_scripts_wired parses its `on:` trigger
+            # (safe_load + rescue), rather than assuming the filename
+            # convention or that the workflow is unconditionally triggered.
+            #
+            # Matrix-strategy jobs are skipped during NAME derivation (#655
+            # Codex P2 round 3): GitHub expands a matrix job into one check
+            # run per combination with a name this static YAML read cannot
+            # reproduce. They are NOT invisible to enforcement, though (#655
+            # Codex P1 round 6, "observe matrix annex jobs before
+            # auto-merge") -- annex_workflow is captured regardless of
+            # whether any job names were derived, so the workflow-wide scan
+            # below still catches a reported matrix-leg failure by workflow
+            # identity, without needing to know its expanded name in advance.
+            # ruby's stderr is NOT redirected here (unlike the base64
+            # decode) so the skip notice surfaces in the workflow log.
+            annex_probe_raw=$(printf '%s' "$annex_content" | base64 -d 2>/dev/null | ANNEX_SAME_REPO_PR="$annex_same_repo_pr" ANNEX_BASE_BRANCH="$annex_base_branch" ANNEX_HEAD_BRANCH="$annex_head_branch" ANNEX_CHANGED_FILES_JSON="$annex_changed_files_json" ruby -ryaml -rjson -e '
+              raw = STDIN.read
+              # #655 Codex P1 round 7 ("parse valid annex workflows that use
+              # YAML aliases"): GitHub Actions supports anchors/aliases in
+              # workflow files, but Psych safe_load defaults to
+              # aliases:false specifically to block the "billion laughs"
+              # DoS (a small file whose nested aliases expand
+              # exponentially at parse time). This parses a PRs OWN branch
+              # content, so any repo accepting external contributions is
+              # exposed to a crafted repo_lint_local.yml exhausting CI
+              # runner memory/CPU. Allow aliases, but bound the attack
+              # surface first: a byte-size cap (legitimate CI configs are a
+              # few KB) plus a raw anchor/alias token count cap (the
+              # exploit needs many alias references to achieve exponential
+              # blowup; a legitimate DRY job template reuses one or two) --
+              # counted on the RAW text before parsing, since the danger is
+              # in the expansion itself, not the input size.
+              if raw.bytesize > 100_000
+                STDERR.puts "repo_lint_local.yml exceeds 100000 bytes -- refusing to parse (defensive cap, not a realistic legitimate size, #655)"
+                exit
+              end
+              # #655 Codex P2 round 8 ("avoid treating path globs as YAML
+              # aliases"): a naive `[&*]word` scan over-counts, since an
+              # ordinary glob like `**/*.ts` in a paths:/paths-ignore: list
+              # starts with `*` too -- inflating the count on a perfectly
+              # legitimate annex with a longer filter list past the cap. A
+              # real YAML anchor/alias can ONLY appear immediately after a
+              # structural position: start of text; a block-sequence dash
+              # (which requires being the first non-whitespace character
+              # on its line, with a MANDATORY space before the value --
+              # narrowed in round 9, see below); or `:`, `,`, `[`, `{`
+              # anywhere, optionally followed by whitespace. A glob string
+              # value is never in that position unquoted (a bare scalar
+              # starting with `*` is itself a YAML syntax error, confirmed
+              # empirically), and a QUOTED glob has a leading quote
+              # character that breaks the match.
+              #
+              # #655 Codex P2 round 9 ("do not count glob hyphens as YAML
+              # aliases"): the round 8 version accepted a bare `-` ANYWHERE
+              # in the text (with optional trailing whitespace) as a
+              # structural position, which also matched an internal hyphen
+              # inside a glob directly before a `*` (e.g.
+              # "src/component-*.ts") with no space between them --
+              # inflating the count on a filter list using hyphenated
+              # names. A real block-sequence dash is anchored to the start
+              # of its line (only preceded by indentation) and REQUIRES at
+              # least one space before its value, unlike a mid-string
+              # hyphen.
+              if raw.scan(/(?:\A|^[ \t]*-\s+|[:,\[{]\s*)[&*][A-Za-z0-9_.-]+/).length > 40
+                STDERR.puts "repo_lint_local.yml has an unusually high anchor/alias token count -- refusing to parse (defensive cap against a YAML alias-expansion DoS, #655)"
+                exit
+              end
+              begin
+                doc = YAML.safe_load(raw, aliases: true)
+              rescue Psych::Exception
+                exit
+              end
+              exit unless doc.is_a?(Hash) && doc["jobs"].is_a?(Hash)
+              # #655 Codex P2 round 6: when the annex omits a top-level
+              # `name:`, GitHub displays (and reports into
+              # statusCheckRollup .workflowName as) the workflow FILE PATH,
+              # not an empty string -- an empty workflow_name would disable
+              # the workflow-wide scan below, even for a valid annex with
+              # reported job failures.
+              workflow_name = doc["name"] ? doc["name"].to_s : ".github/workflows/repo_lint_local.yml"
+              jobs = []
+              doc["jobs"].each do |id, job|
+                if job.is_a?(Hash) && job["strategy"].is_a?(Hash) && job["strategy"]["matrix"]
+                  STDERR.puts "skipping matrix-strategy job #{id} -- its expanded check-run name(s) cannot be derived from the static job definition (#655)"
+                  next
+                end
+                name = (job.is_a?(Hash) && job["name"]) ? job["name"] : id
+                jobs << { "name" => name.to_s, "workflow" => workflow_name }
+              end
+              # #655 Codex P1 round 7 ("wait for unfiltered annex workflow
+              # to appear before merging"): distinguish an annex trigger
+              # with NO restricting filter (which is GUARANTEED to
+              # eventually produce a check run for this PR -- it just may
+              # not have been scheduled yet) from one that IS filtered
+              # (which may legitimately never run for this diff). YAML 1.1
+              # coerces the bareword `on:` key to the boolean true
+              # (yes/no/on/off/y/n are all boolean literals -- the "Norway
+              # problem"), so doc["on"] is nil for the overwhelmingly
+              # common unquoted `on:`; only a quoted "on": key would ever
+              # land as the string "on".
+              #
+              # #655 Codex P2 round 9 ("honor non-path pull_request
+              # filters before waiting"): round 8 checked only
+              # paths/paths-ignore on the pull_request config. GitHub
+              # Actions pull_request triggers also support branches,
+              # branches-ignore, and types -- a types list that excludes
+              # synchronize (e.g. types: [opened] only) means this
+              # workflow will NEVER run for a resynchronized PRs current
+              # HEAD, so treating that as unfiltered would wait forever:
+              # the exact permanent-deadlock class rounds 2-5 already
+              # fought to eliminate for the paths case.
+              #
+              # #655 Codex P1 round 10 ("treat synchronize-enabled types
+              # as runnable", found on the codex-review-check.sh copy of
+              # this same logic and mirrored here): round 9 disqualified
+              # "unfiltered" on the MERE presence of a types key, but
+              # types is not a narrowing filter the way paths/branches
+              # are -- it selects WHICH pull_request activities trigger
+              # this workflow at all, and the GitHub default (when types
+              # is omitted) is [opened, synchronize, reopened]. An
+              # explicit types list that STILL includes synchronize (the
+              # activity that fires for a resynchronized PRs current
+              # HEAD) is therefore just as unfiltered as omitting types
+              # entirely -- the common explicit form
+              # `types: [opened, synchronize, reopened]` was being
+              # wrongly disqualified. Only a types list that EXCLUDES
+              # synchronize actually means this workflow never runs for
+              # that HEAD, so types gets its own check below rather than
+              # joining the generic filter-key list.
+              #
+              # #655 Codex P2 round 9 ("wait for valid push-only annex
+              # workflows"): check_ci_scripts_wired accepts push OR
+              # pull_request as valid wiring, but a push-only annex was
+              # never classified as unfiltered at all (no pull_request
+              # trigger present), so this wait never waited for it. A push
+              # trigger only fires IN THIS REPO for a same-repo PR (a fork
+              # PRs push lands in the fork, never here), so
+              # annex_same_repo_pr (computed above from gh pr views own
+              # isCrossRepository field) gates whether an unfiltered push
+              # trigger counts.
+              #
+              # #655 Codex P2 round 11 ("evaluate base-branch filters
+              # before passing", found on the codex-review-check.sh copy
+              # of this same logic and mirrored here): rounds 9-10
+              # blanket-disqualified "unfiltered" on the MERE PRESENCE of
+              # branches/branches-ignore, but GitHub schedules the
+              # workflow whenever the actual ref matches -- e.g.
+              # `pull_request: {branches: [main]}` still runs for every PR
+              # targeting main. Evaluated against the real ref instead:
+              # pull_request compares the PRs BASE ref (annex_base_branch,
+              # computed above); push compares the ref actually being
+              # pushed, which for a same-repo PRs synchronize is the PRs
+              # own HEAD ref (annex_head_branch), not base. Matching uses
+              # Matching translates each pattern into an equivalent Ruby
+              # Regexp rather than using File.fnmatch, refined per #655
+              # round 13 ("use an Actions-compatible branch glob matcher",
+              # found on the codex-review-check.sh copy and mirrored here)
+              # to correct a gap in the round-12 fnmatch version: GitHub
+              # documented branch patterns support a `+` repetition
+              # quantifier on a preceding character/class (e.g.
+              # `v[12].[0-9]+.[0-9]+`, matching semver branches) -- a real
+              # regex feature fnmatch has no equivalent for (it always
+              # treats `+` as a literal character and returns false).
+              # Regexp natively supports quantifiers AND character classes,
+              # so translating once and matching via Regexp#match? handles
+              # the full documented syntax (*, **, ?, [...], +) with one
+              # mechanism instead of patching fnmatch further. `**` crosses
+              # `/` (translated to `.*`); a lone `*` does not (translated to
+              # `[^/]*`); `[...]` and a following `+` are copied through
+              # verbatim, since Ruby regex character-class and quantifier
+              # syntax already matches the GitHub semantics. A backslash
+              # escapes the next special character into a literal match, as
+              # GitHub documents for branch/tag names that contain glob
+              # metacharacters. Everything else is regex-escaped. Patterns
+              # are evaluated IN ORDER with an optional `!` prefix negating a
+              # prior match (a later pattern overrides an earlier one for the
+              # same ref), which a plain `any?` check ignored entirely. An
+              # unknown/unresolvable branch still conservatively disqualifies
+              # rather than guessing.
+              #
+              # #655 Codex P2 round 11 ("treat tag-only push annexes as
+              # filtered", narrowed in round 13 -- "do not treat tag
+              # filters as excluding branch pushes", found on the
+              # codex-review-check.sh copy and mirrored here): a push
+              # trigger scoped ONLY by tags/tags-ignore (no branches/
+              # branches-ignore at all) only fires for TAG ref pushes,
+              # never an ordinary branch push. But GitHub documents
+              # branches and tags as combinable on the SAME push trigger
+              # (runs for a matching branch push OR a matching tag push),
+              # so a trigger with BOTH keys must still be evaluated by its
+              # branches filter -- the round-11 version disqualified on
+              # tags presence alone, before branches ever got a chance to
+              # match, which wrongly filtered an annex GitHub would
+              # actually run for a matching branch push (the exact same
+              # push a same-repo PRs synchronize always is). Tags now only
+              # disqualifies when there is no branches/branches-ignore key
+              # at all to independently evaluate.
+              on = doc.key?("on") ? doc["on"] : doc[true]
+              def branch_pattern_to_regex(pattern)
+                # #655 Codex P2 round 16 ("honor ? as an optional-character
+                # filter", found on the codex-review-check.sh copy and
+                # mirrored here): GitHub documents `?` as matching zero or
+                # one of the PRECEDING character (e.g. `release?` matches
+                # base branch `release` itself), not "exactly one arbitrary
+                # character" the way POSIX glob/fnmatch define it. Building
+                # a TOKEN LIST (one entry per translated glob unit) instead
+                # of one flat string lets `?` wrap the LAST token in
+                # `(?:...)?` -- correctly quantifying whatever unit came
+                # before it (a literal char, an escaped char, or a whole
+                # `[...]` class), not just a single output character. A
+                # leading `?` (no preceding token) is a no-op. `tokens.
+                # join` reconstructs the exact same concatenation the old
+                # flat-string version produced for every other case,
+                # including `+` (still a bare postfix quantifier on
+                # whatever token precedes it).
+                tokens = []
+                chars = pattern.chars
+                i = 0
+                while i < chars.length
+                  c = chars[i]
+                  if c == "\\" && chars[i + 1]
+                    tokens << Regexp.escape(chars[i + 1])
+                    i += 2
+                  elsif c == "*" && chars[i + 1] == "*"
+                    tokens << ".*"
+                    i += 2
+                  elsif c == "*"
+                    tokens << "[^/]*"
+                    i += 1
+                  elsif c == "?"
+                    tokens[-1] = "(?:#{tokens[-1]})?" if tokens.any?
+                    i += 1
+                  elsif c == "["
+                    j = i + 1
+                    j += 1 while j < chars.length && chars[j] != "]"
+                    tokens << chars[i..j].join
+                    i = j + 1
+                  elsif c == "+"
+                    tokens << "+"
+                    i += 1
+                  else
+                    tokens << Regexp.escape(c)
+                    i += 1
+                  end
+                end
+                Regexp.new("\\A#{tokens.join}\\z")
+              end
+              def branch_matches?(pattern, branch)
+                return false unless pattern.is_a?(String) && branch.is_a?(String)
+                branch_pattern_to_regex(pattern).match?(branch)
+              rescue RegexpError, ArgumentError
+                false
+              end
+              def push_tag_only_excludes?(cfg)
+                (cfg.key?("tags") || cfg.key?("tags-ignore")) && !(cfg.key?("branches") || cfg.key?("branches-ignore"))
+              end
+              def branch_matches_list?(patterns, branch)
+                return false unless patterns.is_a?(Array)
+                included = false
+                patterns.each do |raw|
+                  next unless raw.is_a?(String)
+                  if raw.start_with?("!")
+                    included = false if branch_matches?(raw[1..], branch)
+                  else
+                    included = true if branch_matches?(raw, branch)
+                  end
+                end
+                included
+              end
+              def branch_filter_excludes?(cfg, branch)
+                return true if (cfg.key?("branches") || cfg.key?("branches-ignore")) && !(branch.is_a?(String) && !branch.empty?)
+                if cfg.key?("branches")
+                  return true unless branch_matches_list?(cfg["branches"], branch)
+                end
+                if cfg.key?("branches-ignore")
+                  return true if branch_matches_list?(cfg["branches-ignore"], branch)
+                end
+                false
+              end
+              # #655 Codex P2 round 16 ("wait for path-matched annex
+              # workflows", narrowed in round 17 -- "use the event diff
+              # when emulating path filters", found on the
+              # codex-review-check.sh copy and mirrored here): a paths/
+              # paths-ignore key was previously treated as unconditionally
+              # filtered on mere presence, even when the PRs actual
+              # changed files match the filter. Path glob syntax
+              # documents the SAME tokens as branch/tag patterns, so
+              # branch_matches_list? is reused. `paths` requires at least
+              # one changed file to match; `paths-ignore` excludes only
+              # when EVERY changed file matches the ignore patterns.
+              # GitHub evaluates a PUSH triggers path filter against the
+              # two-dot diff of JUST that push, not the whole-PR
+              # three-dot diff this fetch provides -- an earlier commit
+              # already in the PR could have touched a matching path
+              # while the CURRENT push does not, wrongly keeping this
+              # "unfiltered" and blocking auto-merge forever waiting for a
+              # check that will never report. The three-dot PR-wide diff
+              # genuinely matches what GitHub documents for the
+              # pull_request event, so only that event gets the real
+              # evaluation; push keeps the round-16-era always-filtered
+              # default. GitHub also only considers the first 300 changed
+              # files for path-filter evaluation, so the list is capped
+              # the same way before matching.
+              def paths_filter_excludes?(event, cfg, changed_files, changed_files_known)
+                return false unless cfg.key?("paths") || cfg.key?("paths-ignore")
+                return true if event == "push"
+                return false unless changed_files_known
+                capped_files = changed_files.first(300)
+                if cfg.key?("paths")
+                  return true unless capped_files.any? { |f| branch_matches_list?(cfg["paths"], f) }
+                end
+                if cfg.key?("paths-ignore")
+                  return true if capped_files.all? { |f| branch_matches_list?(cfg["paths-ignore"], f) }
+                end
+                false
+              end
+              # #655 Codex P2 round 17 (do not silently treat changed-files
+              # API failures as filtered out, CodeRabbit; "fail closed
+              # when the changed-file lookup fails", Codex): the bash
+              # layer above now leaves annex_changed_files_json as an
+              # EXPLICITLY empty string on a fetch failure (never touched
+              # by jq), which changed_files_known distinguishes from a
+              # genuinely-fetched, genuinely-empty array -- unknown data
+              # must not silently read as "paths definitely do not match".
+              changed_files_known = !(ENV["ANNEX_CHANGED_FILES_JSON"] || "").empty?
+              changed_files = begin
+                changed_files_known ? JSON.parse(ENV["ANNEX_CHANGED_FILES_JSON"]) : []
+              rescue JSON::ParserError
+                []
+              end
+              trigger_unfiltered = lambda do |event, relevant_branch|
+                case on
+                when String then on == event
+                when Array then on.include?(event)
+                when Hash
+                  next false unless on.key?(event)
+                  cfg = on[event]
+                  next true unless cfg.is_a?(Hash)
+                  next false if paths_filter_excludes?(event, cfg, changed_files, changed_files_known)
+                  next false if event == "push" && push_tag_only_excludes?(cfg)
+                  next false if branch_filter_excludes?(cfg, relevant_branch)
+                  # #655 Codex P2 round 16 (do not skip opened-only annex
+                  # runs), REVERTED in round 17 ("do not infer
+                  # opened-only runs from committer date", found on the
+                  # codex-review-check.sh copy and mirrored here): round
+                  # 16 tried to distinguish "still on the PRs opening
+                  # commit" from "synchronized since" by comparing the
+                  # HEAD committer date against the PRs created_at.
+                  # Confirmed live: a genuinely-new synchronize push whose
+                  # commit preserves an OLDER committer date (a
+                  # rebase/cherry-pick of a stale commit) still satisfies
+                  # that comparison, so the heuristic can say "unfiltered"
+                  # for a trigger that will NEVER report again on this
+                  # HEAD -- injecting a permanent PENDING/wait state. No
+                  # reliable, non-spoofable signal is available from the
+                  # data already on hand, and a permanent deadlock is
+                  # strictly worse than the narrower gap being reopened.
+                  # Reverted to the simple, safe round-10 rule: only a
+                  # types list that explicitly includes synchronize
+                  # counts as unfiltered.
+                  next (cfg["types"].is_a?(Array) && cfg["types"].include?("synchronize")) if cfg.key?("types")
+                  true
+                else
+                  false
+                end
+              end
+              pr_unfiltered = trigger_unfiltered.call("pull_request", ENV["ANNEX_BASE_BRANCH"])
+              push_unfiltered = trigger_unfiltered.call("push", ENV["ANNEX_HEAD_BRANCH"])
+              same_repo_pr = ENV["ANNEX_SAME_REPO_PR"] == "true"
+              unfiltered = pr_unfiltered || (push_unfiltered && same_repo_pr)
+              puts JSON.generate({ "workflow" => workflow_name, "jobs" => jobs, "unfiltered" => unfiltered })
+            ' || true)
+            if [ -z "$annex_probe_raw" ]; then
+              # ruby never reached its `puts` line: the YAML itself did not
+              # parse or had no `jobs:` hash -- genuinely unparseable, not
+              # just empty. The workflow name is unknown too (parsing never
+              # got that far), so there is nothing to scope a workflow-wide
+              # scan to either. Unlike pre-round-6 behavior, do NOT fall back
+              # to forcing the conventional name into required_checks_json:
+              # that name might not be the real one, risking the exact
+              # deadlock this redesign removes. codex-review-check.sh's gate
+              # (a) still independently enforces this annex on its own
+              # schedule (it is safe from this deadlock: an unreported
+              # required name there is a no-op, never an injected failure).
+              echo "::warning::repo_lint_local.yml annex present at $sha but could not be parsed as a workflow (invalid YAML or no jobs) — cannot determine its check name(s) or workflow identity, so this run cannot enforce it (gate (a) / codex-review-check.sh still will) (#655)."
+            else
+              annex_workflow=$(echo "$annex_probe_raw" | jq -r '.workflow')
+              annex_unfiltered=$(echo "$annex_probe_raw" | jq -r '.unfiltered')
+              annex_jobs=$(echo "$annex_probe_raw" | jq -c '.jobs')
+              if [ "$(echo "$annex_jobs" | jq 'length')" -eq 0 ]; then
+                echo "::warning::repo_lint_local.yml annex present at $sha but every job is matrix-strategy (skipped) — its expanded check-run name(s) cannot be derived; its workflow ($annex_workflow, unfiltered=$annex_unfiltered) is still scanned below for any reported failure (#655)."
+              else
+                echo "::notice::repo_lint_local.yml annex present at $sha — its workflow ($annex_workflow, unfiltered=$annex_unfiltered) will be scanned for any reported failure (#655): $(echo "$annex_jobs" | jq -r '[.[].name] | join(" ")')."
+              fi
+            fi
+          elif grep -q 'HTTP 404' "$annex_probe_err"; then
+            : # genuinely absent (confirmed 404) — no annex, no-op, unchanged from before.
+          elif grep -q 'HTTP 403' "$annex_probe_err"; then
+            # #655 Codex P2 round 4: a 403 (token lacks Contents: read) is
+            # USUALLY persistent, not transient -- forcing enforcement here
+            # would permanently affect native auto-merge on EVERY future PR
+            # too (the same 403 recurs every time), not just ones with an
+            # actual annex. Do not enforce; warn loudly so the token's scope
+            # gets fixed instead.
+            echo "::warning::repo_lint_local.yml probe at $sha got HTTP 403 (AUTHOR_MERGE_TOKEN likely lacks Contents: read) — NOT failing closed, since a persistent 403 would otherwise force an unresolvable synthetic check on every future PR too. Grant the token Contents: read to restore annex enforcement (#655)."
+          else
+            # An indeterminate but plausibly-transient read failure (rate
+            # limit, 5xx, network) must not be treated the same as a
+            # confirmed absence -- but unlike pre-round-6 behavior, this run
+            # cannot fail closed by forcing a guessed name into
+            # required_checks_json without risking the same deadlock #655
+            # round 6 removed. codex-review-check.sh's gate (a) is a safer
+            # place for this fallback (an unreported required name there is
+            # inert, never an injected failure) and re-evaluates on its own
+            # schedule, so this narrower run simply logs and moves on.
+            echo "::warning::Could not determine whether repo_lint_local.yml exists at $sha (API error, not a confirmed 404) — this run cannot enforce it (gate (a) / codex-review-check.sh still will) (#655): $(cat "$annex_probe_err")"
+          fi
+          rm -f "$annex_probe_err"
+
+          # #655 Codex P2 round 11 ("restrict the lint wait to the required
+          # workflow"): gh pr view --json statusCheckRollup has no field for
+          # "is this specific entry actually required by branch protection",
+          # so the workflow=="" (name-only) canonical-check match below could
+          # not distinguish the REAL required "lint" from an unrelated,
+          # non-required check that coincidentally shares its bare name in a
+          # different workflow (e.g. an experimental local job) -- requiring
+          # that unrelated check to ALSO be green, per the round-5 "every
+          # group must be green" rule. Both GraphQL CheckRun and
+          # StatusContext expose isRequired(pullRequestNumber:), the
+          # ground-truth answer, but only when queried directly (the fixed
+          # --json shape from gh pr view omits it,
+          # and querying it through commits.nodes.commit loses the implicit
+          # PR context, erroring "A pull request ID or pull request number is
+          # required" -- confirmed empirically), so this switches from
+          # `gh pr view --json` to a raw graphql call and reshapes the result
+          # into the same {statusCheckRollup: [...]} shape the rest of this
+          # loop already expects, adding isRequired as an extra field.
+          repo_owner="${REPO%%/*}"
+          repo_name="${REPO#*/}"
           while :; do
-            run=$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" \
-              | jq -c --arg check "$required_check_name" '[.check_runs[] | select(.name == $check)] | sort_by(.started_at // .created_at) | last // empty')
-            if [ -n "$run" ]; then
-              status=$(printf '%s' "$run" | jq -r '.status')
-              conclusion=$(printf '%s' "$run" | jq -r '.conclusion // ""')
-              if [ "$status" = "completed" ]; then
-                if [ "$conclusion" = "success" ]; then
-                  echo "CURRENT_HEAD_SHA=$sha" >> "$GITHUB_ENV"
-                  echo "Required check run '$required_check_name' is successful on current HEAD $sha."
-                  exit 0
-                fi
-                echo "::error::Required check run '$required_check_name' failed on current HEAD $sha (conclusion=${conclusion:-none}); refusing auto-merge."
+            all_done=1
+            check_count=$(echo "$required_checks_json" | jq 'length')
+            # #655 Codex P1 round 12 ("paginate the status check rollup"):
+            # a PR with more than 100 statusCheckRollup contexts (this PR
+            # itself already has 160+, confirmed live while working on
+            # this fix) silently hid every entry past the first page from
+            # both the required-check and annex workflow-wide scans below
+            # -- auto-merge could arm while an unobserved check past page
+            # 1 was still red. Page through with the Relay cursor
+            # (pageInfo.hasNextPage/endCursor) rather than raising the
+            # page size, since the rollup can grow without bound as more
+            # checks/review rounds accumulate on a long-lived PR. Pass a null
+            # cursor for the first page and the returned Relay cursor for each
+            # later page.
+            rollup_contexts="[]"
+            cursor=""
+            while :; do
+              cursor_args=(-F cursor=null)
+              if [ -n "$cursor" ]; then
+                cursor_args=(-f cursor="$cursor")
+              fi
+              page_json=$(gh api graphql -f query='
+                query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      commits(last: 1) {
+                        nodes {
+                          commit {
+                            statusCheckRollup {
+                              contexts(first: 100, after: $cursor) {
+                                pageInfo { hasNextPage endCursor }
+                                nodes {
+                                  __typename
+                                  ... on CheckRun {
+                                    name
+                                    status
+                                    conclusion
+                                    startedAt
+                                    completedAt
+                                    isRequired(pullRequestNumber: $number)
+                                    checkSuite { workflowRun { workflow { name resourcePath } } }
+                                  }
+                                  ... on StatusContext {
+                                    context
+                                    state
+                                    createdAt
+                                    isRequired(pullRequestNumber: $number)
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }' -f owner="$repo_owner" -f name="$repo_name" -F number="$PR_NUMBER" "${cursor_args[@]}")
+              page_nodes=$(echo "$page_json" | jq -c '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.nodes // [])')
+              rollup_contexts=$(jq -c -n --argjson a "$rollup_contexts" --argjson b "$page_nodes" '$a + $b')
+              has_next=$(echo "$page_json" | jq -r '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage // false)')
+              cursor=$(echo "$page_json" | jq -r '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.endCursor // "")')
+              [ "$has_next" = "true" ] || break
+            done
+            # workflowPath (#655 round 13, "disambiguate annex workflows
+            # beyond display name", found on the codex-review-check.sh copy
+            # and mirrored here): derived from the workflow FILE's
+            # GraphQL-reported resourcePath rather than its freely-editable
+            # display name, since the annex contract does not guarantee a
+            # unique .name across a consumer's workflows.
+            rollup_json=$(echo "$rollup_contexts" | jq '{
+              statusCheckRollup: (map({
+                  name: .name,
+                  context: .context,
+                  workflowName: (.checkSuite.workflowRun.workflow.name // null),
+                  workflowPath: (((.checkSuite.workflowRun.workflow.resourcePath // "") | split("/") | last) // ""),
+                  status: .status,
+                  conclusion: .conclusion,
+                  state: .state,
+                  startedAt: .startedAt,
+                  completedAt: .completedAt,
+                  isRequired: .isRequired
+                }))
+            }')
+            for ((i = 0; i < check_count; i++)); do
+              check_name=$(echo "$required_checks_json" | jq -r ".[$i].name")
+              check_workflow=$(echo "$required_checks_json" | jq -r ".[$i].workflow")
+              # #655 (Codex P2 round 5): group matching entries by workflow
+              # identity, not just by name, before deciding "is this check
+              # done". Two failure modes this closes:
+              #   - Stale-vs-pending (a same-name/same-workflow rerun): a
+              #     completed success from an earlier trigger (e.g. push)
+              #     alongside a still-QUEUED rerun from a later trigger
+              #     (e.g. pull_request synchronize) has NEITHER startedAt
+              #     nor completedAt on the queued entry, so a naive
+              #     sort_by(...) | last ranked the queued entry BEFORE the
+              #     completed one (empty string sorts first) and this loop
+              #     could wrongly report the stale success. Any
+              #     non-completed entry in a workflow's group is now
+              #     treated as "still pending" regardless of timestamps.
+              #   - Same-name collision (a consumer's local job also called
+              #     "lint", allowed by the annex contract): for the
+              #     workflow=="" (name-only) canonical `lint` requirement,
+              #     the name-only select matches EITHER workflow's "lint"
+              #     runs. Without grouping, picking one "winner" by
+              #     timestamp could let a newer successful annex "lint"
+              #     mask an older FAILED canonical "lint", arming auto-merge
+              #     without canonical lint actually being green. Grouping by
+              #     workflow and requiring EVERY group's winner to be green
+              #     means a same-named annex job can never stand in for the
+              #     canonical check.
+              # #655 Codex P2 round 6 ("treat successful status contexts as
+              # complete"): a StatusContext entry has no .status field at
+              # all (only CheckRun does), so `.status != "COMPLETED"` was
+              # true for EVERY status context regardless of .state,
+              # including state=="SUCCESS" -- pending forever. A
+              # StatusContext is non-terminal only when .state is literally
+              # "PENDING"; every other .state (SUCCESS/FAILURE/ERROR/
+              # EXPECTED) is terminal. A CheckRun is non-terminal whenever
+              # .status is present and not "COMPLETED", unchanged.
+              #
+              # #655 Codex P2 round 11 ("restrict the lint wait to the
+              # required workflow"): the round-5 "group by workflow, require
+              # every group green" rule closed the mask-the-canonical-check
+              # risk, but left the OPPOSITE risk open for the workflow==""
+              # (canonical) match specifically -- a coincidentally same-
+              # named but NON-required check from an unrelated workflow
+              # would ALSO become a mandatory group, wrongly blocking on
+              # ITS failure even though branch protection never required
+              # it. isRequired (ground truth from the graphql query above,
+              # scoped to this PR) now additionally filters the workflow==""
+              # case to required entries when any same-name entry reports
+              # required=true. If none do, keep the configured-check wait
+              # behavior instead of treating branch-protection metadata as a
+              # hard prerequisite for this workflow to wait on its configured
+              # check name. A name-scoped annex match ($workflow != "") is
+              # unaffected, since annex checks are not expected to be
+              # required at all.
+              #
+              # Self-caught while porting this winner-selection pattern into
+              # codex-review-check.sh for #655 round 13 ("ignore stale annex
+              # runs after a green rerun"): `["PENDING","EXPECTED"] |
+              # index(.state // "")` rebinds `.` to the piped-in array
+              # literal for the REST of that expression, so `.state` tries
+              # to index an array with a string and jq hard-errors --
+              # exactly the same "sub-pipeline rebinds dot" hazard the
+              # required-name filter in codex-review-check.sh already
+              # documents and guards against for `$label_name`. Latent since
+              # round 6/11 (never triggered here because every entry seen so
+              # far has been a CheckRun with a non-null .status, so the
+              # buggy StatusContext-only `else` branch never actually ran),
+              # but a classic Statuses-API context reaching this branch
+              # would fail the whole jq call regardless of its .state value.
+              # Fixed by binding .state to $ann_state BEFORE the array-literal
+              # pipe, verified against both CheckRun- and StatusContext-shaped
+              # entries (PENDING/EXPECTED/SUCCESS/absent .state) directly.
+              winners=$(echo "$rollup_json" | jq -c --arg name "$check_name" --arg workflow "$check_workflow" '
+                [.statusCheckRollup[]
+                  | select((.name // .context // "") == $name)
+                  | select($workflow == "" or (.workflowName // "") == $workflow)
+                ] as $name_matches
+                | ([$name_matches[] | select(.isRequired == true)]) as $required_matches
+                | (if $workflow == "" and ($required_matches | length) > 0
+                   then $required_matches
+                   else $name_matches
+                   end) as $matches
+                | ($matches | group_by(.workflowName // "")) as $groups
+                | [
+                    $groups[]
+                    | (map(select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end))) as $pending
+                    | if ($pending | length) > 0
+                      then $pending[0]
+                      else (sort_by(.completedAt // .startedAt // "") | last)
+                      end
+                  ]')
+              winner_count=$(echo "$winners" | jq 'length')
+              if [ "$winner_count" -eq 0 ]; then
+                echo "::notice::Required check run '$check_name' is absent on current HEAD $sha; waiting for it to start."
+                all_done=0
+                continue
+              fi
+              pending_count=$(echo "$winners" | jq '[.[] | select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end)] | length')
+              if [ "$pending_count" -gt 0 ]; then
+                pending_status=$(echo "$winners" | jq -r '[.[] | select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end)][0].status // .state // ""')
+                echo "::notice::Required check run '$check_name' is $pending_status on current HEAD $sha; waiting for completion."
+                all_done=0
+                continue
+              fi
+              # success/skipped/neutral are all non-blocking conclusions
+              # (#655 Codex P2 round 2): a conditional annex job GitHub
+              # completes as skipped is not a failure, and neutral is a
+              # passing conclusion for required checks too. Mirrors the
+              # same acceptance set codex-review-check.sh's BAD_CHECKS
+              # filter already uses. Every group's winner must be green
+              # (#655 round 5) -- see the comment above the query.
+              bad=$(echo "$winners" | jq -c '[.[] | select((.conclusion // .state // "") as $r | ($r != "SUCCESS" and $r != "SKIPPED" and $r != "NEUTRAL"))]')
+              bad_count=$(echo "$bad" | jq 'length')
+              if [ "$bad_count" -gt 0 ]; then
+                bad_summary=$(echo "$bad" | jq -r '[.[] | (.conclusion // .state // "none")] | join(", ")')
+                echo "::error::Required check run '$check_name' failed on current HEAD $sha (conclusion=$bad_summary); refusing auto-merge."
                 exit 1
               fi
-              echo "::notice::Required check run '$required_check_name' is $status on current HEAD $sha; waiting for completion."
-            else
-              echo "::notice::Required check run '$required_check_name' is absent on current HEAD $sha; waiting for it to start."
+              conclusion_summary=$(echo "$winners" | jq -r '[.[] | (.conclusion // .state // "none")] | join(", ")')
+              echo "Required check run '$check_name' is $conclusion_summary on current HEAD $sha."
+            done
+
+            if [ -n "$annex_workflow" ]; then
+              # #655 Codex round 6 (P1 "wait for annex checks before
+              # clearing the label", P1 "observe matrix annex jobs before
+              # auto-merge", P2 "avoid forcing path-filtered annex jobs to
+              # start"): scan the annex's own workflow for any REPORTED
+              # entry rather than requiring a specific derived name, same
+              # design as codex-review-check.sh gate (a)'s
+              # ANNEX_WORKFLOW_BAD scan. A still-in-progress entry is
+              # deliberately treated as pending (not bad) here -- unlike
+              # gate (a) (a repeatedly re-evaluated snapshot, where
+              # in-progress correctly counts as "not yet clean"), this loop
+              # can just keep polling for it, bounded by the same shared
+              # deadline as every other required check. Zero reported
+              # entries for this workflow is non-blocking: forcing a wait
+              # for one that may legitimately never exist (a path-filtered
+              # annex outside this PR's diff) would time out and refuse
+              # auto-merge on every such PR, forever.
+              #
+              # #655 Codex P2 round 13 ("disambiguate annex workflows beyond
+              # display name", found on the codex-review-check.sh copy and
+              # mirrored here): matching on .workflowName risked either
+              # masking the real annex behind an unrelated same-named
+              # workflow (false clean, auto-merge arms early) or blocking on
+              # an unrelated same-named workflow's failure (false red,
+              # refuses auto-merge forever). .workflowPath is derived from
+              # the GraphQL-reported resourcePath of the workflow FILE
+              # itself, not its freely-editable display name, so match on
+              # the known, fixed annex filename instead. A StatusContext
+              # (no checkSuite at all) safely resolves workflowPath to ""
+              # and can never collide with this literal.
+              annex_matches=$(echo "$rollup_json" | jq -c '
+                [.statusCheckRollup[] | select((.workflowPath // "") == "repo_lint_local.yml")]')
+              annex_match_count=$(echo "$annex_matches" | jq 'length')
+              if [ "$annex_match_count" -eq 0 ] && [ "$annex_unfiltered" = "true" ]; then
+                # #655 Codex P1 round 7 ("wait for unfiltered annex workflow
+                # to appear before merging"): an annex with NO workflow-level
+                # paths/paths-ignore filter is GUARANTEED to eventually
+                # produce a check run for this PR -- zero entries right now
+                # means Actions has not scheduled it yet, not that it never
+                # will (unlike a path-filtered annex, where zero entries is
+                # genuinely ambiguous between "not yet" and "never for this
+                # diff"). Keep polling instead of treating this the same as
+                # the path-filtered case; bounded by the same shared
+                # deadline as every other required check, so this cannot
+                # deadlock forever if something is actually wrong.
+                echo "::notice::repo_lint_local.yml annex workflow '$annex_workflow' has not reported yet (unfiltered trigger, so it is expected to); waiting for it to start on current HEAD $sha (#655)."
+                all_done=0
+              else
+                annex_pending=$(echo "$annex_matches" | jq -c '[.[] | select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end)]')
+                annex_pending_count=$(echo "$annex_pending" | jq 'length')
+                if [ "$annex_pending_count" -gt 0 ]; then
+                  echo "::notice::repo_lint_local.yml annex workflow '$annex_workflow' has $annex_pending_count check-run(s) still in progress on current HEAD $sha; waiting for completion (#655)."
+                  all_done=0
+                else
+                  # #655 Codex P2 round 13 ("ignore stale annex runs after a
+                  # green rerun", found on the codex-review-check.sh copy
+                  # and mirrored here): every entry reaching this branch is
+                  # already terminal (annex_pending above is zero), but the
+                  # annex's own workflow can legitimately report more than
+                  # one TERMINAL entry per job name for the current SHA -- a
+                  # failed push-triggered run followed by a successful
+                  # pull_request run, or a failed job manually rerun to a
+                  # later success. Without grouping, an old superseded
+                  # FAILURE never leaves the rollup and would refuse
+                  # auto-merge forever even after the same-named job went
+                  # green. Group by check name and keep only the
+                  # latest-completed entry per name (mirrors the required-
+                  # check winners query above, minus the pending branch
+                  # already handled by annex_pending) before judging
+                  # bad-ness.
+                  annex_bad=$(echo "$annex_matches" | jq -c '
+                    group_by(.name // .context // "?")
+                    | [.[] | (sort_by(.completedAt // .startedAt // "") | last)]
+                    | [.[] | select((.conclusion // .state // "") as $r | ($r != "SUCCESS" and $r != "SKIPPED" and $r != "NEUTRAL"))]')
+                  annex_bad_count=$(echo "$annex_bad" | jq 'length')
+                  if [ "$annex_bad_count" -gt 0 ]; then
+                    annex_bad_summary=$(echo "$annex_bad" | jq -r '[.[] | (.conclusion // .state // "none")] | join(", ")')
+                    echo "::error::repo_lint_local.yml annex workflow '$annex_workflow' has $annex_bad_count non-passing reported check-run(s) after winner-selection on current HEAD $sha (conclusion=$annex_bad_summary); refusing auto-merge (#655)."
+                    exit 1
+                  fi
+                fi
+              fi
+            fi
+            if [ "$all_done" -eq 1 ]; then
+              echo "CURRENT_HEAD_SHA=$sha" >> "$GITHUB_ENV"
+              echo "All required check run(s) are successful on current HEAD $sha."
+              exit 0
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "::error::Required check run '$required_check_name' did not complete successfully within ${wait_seconds}s on current HEAD $sha; refusing auto-merge."
+              echo "::error::Required check run(s) did not all complete successfully within ${wait_seconds}s on current HEAD $sha; refusing auto-merge."
               exit 1
             fi
             sleep "$poll_seconds"
           done
-          echo "::error::Required check run '$required_check_name' wait loop ended unexpectedly; refusing auto-merge."
+          echo "::error::Required check run wait loop ended unexpectedly; refusing auto-merge."
           exit 1
 
       - name: Re-verify blocking labels after test wait

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -29,11 +29,33 @@ on:
   # Actions — only for external CI providers. Without workflow_run,
   # the common path of "reviewer approves → Actions CI catches up →
   # gate now passes" produced no event and the label stayed stuck.
+  #
+  # "repo-lint-local" (#655) is a consumer's optional, never-propagated
+  # repo_lint_local.yml annex (#601) — a per-consumer workflow named
+  # exactly this (verified against a live consumer annex; mergepath
+  # itself carries no such workflow, so this entry never fires here).
+  # Without it, this workflow's re-evaluation of a consumer's
+  # needs-external-review label only learns about a repo-lint-local
+  # completion via the 5-minute scheduled sweep below, not immediately.
+  # codex-review-check.sh's gate (a) is what actually enforces a red
+  # repo-lint-local as blocking (see scripts/codex-review-check.sh);
+  # this entry only improves how promptly that re-evaluation runs.
+  #
+  # #655 Codex P3 round 11 ("include the unnamed annex workflow
+  # trigger"): workflow_run matches by the target workflow's displayed
+  # NAME, which for an annex that omits a top-level `name:` (a case the
+  # gate code has explicitly supported since round 6) is the workflow
+  # FILE PATH, not the literal "repo-lint-local" above. Listing the file
+  # path too closes that gap for this promptness-only trigger; the
+  # scheduled sweep below still covers it either way, just less
+  # immediately.
   workflow_run:
     workflows:
       - "PR Review Policy"
       - "Agent Review Pipeline"
       - "repo-lint"
+      - "repo-lint-local"
+      - ".github/workflows/repo_lint_local.yml"
     types: [completed]
   # Periodic sweep — catches the 👍-after-last-push case (codex
   # reacts on the PR issue but no synchronize / review / workflow_run

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -27,7 +27,12 @@ name: Merge Clearance Gate
 #
 # Re-runs on every push to a PR AND on review-related events, so a
 # dismissed approval (rebase push), a fresh reviewer approval, or a Codex
-# clearance flips the check without manual intervention.
+# clearance flips the check without manual intervention. It also re-runs when
+# the propagation lane verifies a sync PR's head — the lane sends a
+# repository_dispatch right after posting its marker, since the GITHUB_TOKEN
+# marker comment itself creates no workflow run — so a verified sync PR clears
+# promptly instead of waiting for the sweep (#658 — see the repository_dispatch
+# trigger + dispatch-recheck job below).
 #
 # Trigger shape note: identical to codex-p1-gate.yml. GitHub Actions does
 # NOT support pull_request_review_thread as a workflow trigger, so we
@@ -50,6 +55,23 @@ on:
   # review-submission event (external-review path).
   pull_request_review_comment:
     types: [created, edited, deleted]
+  # #658: the propagation lane posts its head-pinned verified-head marker as
+  # a github-actions[bot] ISSUE comment. After #657 stopped the label
+  # add/remove dance, nothing re-ran this gate when the marker landed, and a
+  # verified sync PR sat on a fail-closed spurious-red Merge clearance gate
+  # until the */15 sweep. An issue_comment trigger cannot fix this: the marker
+  # is posted with the workflow's GITHUB_TOKEN, and GITHUB_TOKEN-authored
+  # events create NO workflow runs (the #315/#324 lesson) — so an issue_comment
+  # trigger would never fire for the marker. Instead pr-review-policy.yml's
+  # lane, right after posting a fresh marker, sends a repository_dispatch (PAT-
+  # driven, best-effort) that DOES create a run. The dispatch only SCHEDULES a
+  # re-evaluation — the dispatch-recheck job below re-derives clearance from the
+  # (head-pinned, github-actions[bot]) marker via lane_verified(), never trusts
+  # the dispatch payload for clearance, and POSTs a check_run to the PR head
+  # (like the sweep — a repository_dispatch run has no PR-head association).
+  # Keep the event type `merge-clearance-recheck` in sync with the lane.
+  repository_dispatch:
+    types: [merge-clearance-recheck]
   # Periodic sweep — the only backstop for transitions that fire no
   # Actions event (👍 reaction, UI label resolve, GITHUB_TOKEN relabel).
   # 15-min cadence mirrors codex-p1-gate.yml.
@@ -57,9 +79,9 @@ on:
     - cron: "*/15 * * * *"
 
 # Least-privilege default for the whole workflow: read-only. `checks: write`
-# is granted ONLY to the scheduled-sweep job below (it POSTs check_runs);
-# the event-driven job produces its check natively and needs no write scope
-# (CodeRabbit ⚠️ on PR #429).
+# is granted ONLY to the jobs that POST check_runs (the scheduled-sweep and
+# the #658 dispatch-recheck job); the event-driven job produces its check
+# natively and needs no write scope (CodeRabbit ⚠️ on PR #429).
 #
 # `issues: read` is required (Codex P2 on PR #429): the gate reads
 # /issues/{pr}/comments for the propagation-lane marker, and the delegated
@@ -77,10 +99,15 @@ jobs:
   merge-clearance-gate:
     name: Merge clearance gate
     runs-on: ubuntu-latest
-    # Event-driven path. The scheduled sweep below runs the same gate but
-    # on every open PR via the Checks API; gating this job to non-schedule
-    # events avoids paying for an empty no-op run.
-    if: github.event_name != 'schedule'
+    # Event-driven path (native check on the PR head). The scheduled sweep
+    # and the #658 dispatch-recheck job run the same gate via the Checks API;
+    # gating this job to the PR/review events avoids paying for an empty
+    # no-op run AND keeps its native check correct — a repository_dispatch run
+    # has no PR-head commit association, so that path is handled by
+    # dispatch-recheck (Checks API POST), never here.
+    if: >-
+      github.event_name != 'schedule'
+      && github.event_name != 'repository_dispatch'
     steps:
       - name: Checkout repo (default branch — trusted gate scripts)
         # Pin to the default branch, NOT the PR HEAD. This is a REQUIRED
@@ -297,5 +324,123 @@ jobs:
           done <<<"$PRS"
           if [ "$had_infra_error" -ne 0 ]; then
             echo "::error::Sweep finished with one or more infra errors"
+            exit 1
+          fi
+
+  dispatch-recheck:
+    name: Merge clearance dispatch re-evaluation
+    # #658: re-evaluate promptly when the propagation lane sends a
+    # `merge-clearance-recheck` repository_dispatch right after posting its
+    # head-pinned verified-head marker. The marker itself is a GITHUB_TOKEN
+    # issue comment, which creates no workflow run — so the lane nudges the
+    # gate with a PAT-driven dispatch instead (best-effort; if it never
+    # arrives, the */15 sweep still recovers the gate). This job does NOT
+    # trust the dispatch for clearance: it only re-runs
+    # scripts/merge-clearance-gate.sh, which re-derives clearance from the
+    # (head-pinned, github-actions[bot]) marker via lane_verified() on the
+    # CURRENT head, then POSTs the honest result. A dispatch with any pr
+    # payload can therefore only trigger an honest re-evaluation — never force
+    # a pass — so no guard on the payload is needed beyond validating it is a
+    # PR number. Label events are still not a trigger (not head-pinned proof —
+    # #429 round-3 P1).
+    if: github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    # checks:write to POST the check_run (same as the sweep). issues:read for
+    # the gate script's /issues/{pr}/comments marker read + the delegated
+    # codex-review-check.sh /issues/{pr}/reactions read.
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      checks: write
+    steps:
+      - name: Checkout repo (default branch — trusted gate scripts)
+        # Same trusted-checkout posture as the other jobs: run the gate script
+        # from the DEFAULT branch, never the PR head, so a PR cannot edit the
+        # script to satisfy its own required check.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Re-evaluate gate for the dispatched PR and post check_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The PR number the lane put in the dispatch payload. Passed via env
+          # (not interpolated into the script) and validated as a positive
+          # integer below, so an arbitrary client_payload cannot inject shell.
+          PR: ${{ github.event.client_payload.pr }}
+          REPO: ${{ github.repository }}
+          # Check name MUST match the event-driven job name above AND the
+          # sweep CHECK_NAME so branch protection resolves every source as the
+          # same required check (GitHub keys required checks on (head_sha,
+          # name); a fresh check_run with the same name supersedes the stale
+          # one).
+          CHECK_NAME: "Merge clearance gate"
+        run: |
+          set -euo pipefail
+          # Validate the dispatched PR number before it reaches any API call —
+          # the payload is attacker-influenceable (anyone with repo write can
+          # dispatch), so reject anything that is not a bare positive integer.
+          case "$PR" in
+            ''|*[!0-9]*)
+              echo "::error::repository_dispatch client_payload.pr is not a positive integer: '$PR'"
+              exit 1
+              ;;
+          esac
+          # The check_run must pin to the PR head (required checks key on
+          # (head_sha, name)). A repository_dispatch run checks out the default
+          # branch and has NO PR-head commit association, so POST explicitly to
+          # the head SHA like the scheduled sweep. Resolve that head
+          # AUTHORITATIVELY from the open-PR list query — the same list source
+          # the sweep uses (#465 D1), never the attacker-influenceable dispatch
+          # payload (#658 P1): binding the posted head to the dispatched PR's
+          # own current state means a hostile dispatch cannot reuse a passing
+          # PR's evaluation to post a green check onto a different, blocked PR
+          # head. $PR is validated as a positive integer above, so
+          # interpolating it into the jq filter is injection-safe. Fail closed
+          # if the PR is not in the open list.
+          head_sha=$(gh pr list --repo "$REPO" --state open --limit 500 \
+            --json number,headRefOid \
+            --jq ".[] | select(.number == $PR) | .headRefOid" 2>/dev/null || true)
+          if [ -z "$head_sha" ] || [ "$head_sha" = "null" ]; then
+            echo "::error::PR #$PR not found in the open-PR list; cannot resolve its head to refresh the Merge clearance gate (fail closed, #658/#465)."
+            exit 1
+          fi
+          set +e
+          output=$(scripts/merge-clearance-gate.sh "$PR" "$REPO" 2>&1)
+          rc=$?
+          set -e
+          echo "$output"
+          check_title="Merge clearance gate (propagation-lane dispatch re-evaluation)"
+          case "$rc" in
+            0) conclusion="success" ;;
+            1) conclusion="failure" ;;
+            *)
+              echo "::error::merge-clearance-gate.sh rc=$rc on PR #$PR (config/usage/infra error)"
+              conclusion="failure"
+              check_title="Merge clearance gate — infra/config error (rc=$rc)"
+              ;;
+          esac
+          # Truncate to stay under GitHub's 65535-char summary limit. Bash
+          # slice, NOT `printf | head -c`: under `set -euo pipefail` a >60KB
+          # output makes head close the pipe early, printf takes SIGPIPE, and
+          # the command substitution aborts the job before the POST (Codex P2
+          # on the sweep). Slicing is pipefail-safe + char-based.
+          summary="${output:0:60000}"
+          # Posting the check_run IS this job's whole purpose — it supersedes
+          # the stale required check on the PR head after the marker lands
+          # (or pins a fail-closed red on infra error). A failed POST means the
+          # job did not do its job; that's an infra error.
+          if ! gh api -X POST "repos/$REPO/check-runs" \
+            -f name="$CHECK_NAME" \
+            -f head_sha="$head_sha" \
+            -f status="completed" \
+            -f conclusion="$conclusion" \
+            -f "output[title]=$check_title" \
+            -f "output[summary]=$summary" \
+            >/dev/null; then
+            echo "::error::Failed to post check_run for PR #$PR — stale required check not refreshed."
             exit 1
           fi

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -342,9 +342,13 @@ jobs:
           # agent-review.yml's `unlabeled` settle re-arm, and GITHUB_TOKEN-driven
           # events create no workflow runs (the #315/#324 auto-clear lesson) —
           # a GITHUB_TOKEN removal here leaves an approved, settled PR
-          # CLEAN-but-unmerged. PAT-scoped to the removal command ONLY: the
-          # lane-marker comment below stays github-actions-authored for its
-          # #429 consumers, and every other command keeps the restricted
+          # CLEAN-but-unmerged. The PAT is scoped to the two commands that must
+          # create workflow runs GITHUB_TOKEN cannot: the label removal below,
+          # and the #658 merge-clearance-recheck repository_dispatch. The
+          # lane-marker comment itself deliberately stays on GITHUB_TOKEN so it
+          # remains github-actions-authored for its #429 consumers — but that is
+          # exactly why it fires no run, hence the PAT dispatch that nudges
+          # merge-clearance-gate. Every other command keeps the restricted
           # default token.
           LABEL_REMOVAL_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -410,6 +414,25 @@ jobs:
           > Automated check per .github/review-policy.yml
           EOF
           )"
+            # #658: the marker just posted is a GITHUB_TOKEN github-actions[bot]
+            # issue comment, and GITHUB_TOKEN-authored events create no workflow
+            # runs — so merge-clearance-gate.yml cannot re-run via issue_comment
+            # for this freshly verified head. Nudge it directly with a
+            # repository_dispatch (its `merge-clearance-recheck` trigger) so a
+            # verified sync PR clears the Merge clearance gate promptly instead
+            # of waiting up to 15 min for the scheduled sweep. PAT-driven: the
+            # workflow token is contents:read (cannot POST /dispatches), and
+            # keeping the dispatch on the PAT avoids widening the GITHUB_TOKEN
+            # scope. Best-effort — the gate re-derives clearance from THIS marker
+            # (lane_verified, head-pinned) and never trusts the dispatch payload,
+            # so on any failure the */15 sweep still recovers the gate; a failed
+            # dispatch must never fail the lane. Keep the event type in sync with
+            # merge-clearance-gate.yml's repository_dispatch trigger.
+            GH_TOKEN="$LABEL_REMOVAL_TOKEN" gh api -X POST \
+              "repos/${{ github.repository }}/dispatches" \
+              -f event_type=merge-clearance-recheck \
+              -F "client_payload[pr]=$PR_NUMBER" \
+              || echo "note: merge-clearance-recheck dispatch failed (#658); the */15 scheduled sweep will recover the Merge clearance gate."
           fi
 
           # If a prior run (or a stale label-prefixed edit) applied

--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -161,6 +161,24 @@ jobs:
       - name: check_audit_codex_latency
         run: ./scripts/ci/check_audit_codex_latency
 
+      # Offline fixture suite for the #623 CodeRabbit + phase-4b latency
+      # retune audit (scripts/audit-review-latency.sh) — guards its
+      # normalize + pairing + events-only replay the same way
+      # check_audit_codex_latency guards the Codex half. Hub-only; SKIPs on
+      # consumer checkouts via the standard sync-to-downstream marker idiom.
+      - name: check_audit_review_latency
+        run: ./scripts/ci/check_audit_review_latency
+
+      # Offline PATH-shim suite for the #691 statusCheckRollup pagination in
+      # scripts/admin-merge-codeowners-blocked.sh's Gate 2 — guards against a
+      # regression to the truncating `gh pr view --json statusCheckRollup`
+      # read that silently dropped a failing check beyond the first 100
+      # contexts, letting the --admin escape hatch merge past an off-page red
+      # check. Hub-only; SKIPs on consumer checkouts via the standard
+      # sync-to-downstream marker idiom.
+      - name: check_admin_merge_codeowners_blocked
+        run: ./scripts/ci/check_admin_merge_codeowners_blocked
+
       # check_verify_propagation_pr exercises the faithful-mirror
       # verifier (scripts/workflow/verify-propagation-pr.sh) that is
       # the security teeth of the propagation-PR review lane — it is
@@ -334,6 +352,20 @@ jobs:
         # travel to consumers → the referencing tool fails closed there).
         # Shares the yq install with check_sync_manifest above.
         run: ./scripts/ci/check_propagation_closure
+
+      - name: check_project_doc_sync
+        # Hub-only project-doc-sync regression suite (#642): PRD/spec
+        # mirror drift detection, orphan sweeps, manifest validation, and
+        # cache-safety guards for scripts/project-doc-sync.sh. Consumer
+        # checkouts SKIP inside the wrapper (script + suite are hub-only;
+        # no consumer has a docs/projects/ tree). Requires mikefarah/yq —
+        # installed by install_yq_for_sync_manifest above; placed after
+        # the yq-dependent checks (not immediately after check_wave_audit,
+        # which needs no yq) so this step actually exercises the suite
+        # instead of silently SKIPping on a fresh runner (Codex P2 on
+        # PR #680, the same #616-style ordering hazard already fixed for
+        # check_resolve_pr_threads / check_sync_manifest above).
+        run: ./scripts/ci/check_project_doc_sync
 
       - name: check_sync_overrides
         # Exercises tests/test_sync_overrides.sh — verifies the

--- a/scripts/ci/check_admin_merge_codeowners_blocked
+++ b/scripts/ci/check_admin_merge_codeowners_blocked
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check_admin_merge_codeowners_blocked
+#
+# Runs tests/test_admin_merge_codeowners_blocked.sh — the offline PATH-shim
+# suite for scripts/admin-merge-codeowners-blocked.sh's Gate 2 green-checks
+# pagination (#691). Without this wiring, a regression back to the
+# truncating `gh pr view --json statusCheckRollup` read (which silently drops
+# a failing check beyond the first 100 contexts on a long-lived PR) could
+# ship without CI noticing, letting the --admin escape hatch merge past an
+# off-page red check.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_admin_merge_codeowners_blocked.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  # Consumer-safety guard (#601): repo_lint.yml is manifest-canonical, so
+  # consumers run this wrapper too — but admin-merge-codeowners-blocked.sh +
+  # its suite are hub-only (not manifest-propagated; this is a mergepath
+  # break-glass admin tool). scripts/sync-to-downstream.sh is the standard
+  # hub marker: both absent → consumer checkout → SKIP. Marker present → hub
+  # lost the test (accidental delete/rename) → hard error, preserving
+  # fail-closed hub behavior. Mirrors check_audit_codex_latency.
+  if [ ! -f "$REPO_ROOT/scripts/sync-to-downstream.sh" ]; then
+    echo "check_admin_merge_codeowners_blocked: SKIP (consumer checkout: tests/test_admin_merge_codeowners_blocked.sh + scripts/sync-to-downstream.sh both absent)"
+    exit 0
+  fi
+  echo "check_admin_merge_codeowners_blocked: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"
+echo "check_admin_merge_codeowners_blocked: PASS"

--- a/scripts/ci/check_audit_review_latency
+++ b/scripts/ci/check_audit_review_latency
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check_audit_review_latency
+#
+# Runs tests/test_audit_review_latency.sh — the offline fixture suite for
+# scripts/audit-review-latency.sh's normalize + pairing + replay phases
+# (the #623 CodeRabbit + phase-4b latency retune). Without this wiring,
+# edits to the audit script could break the published, replayable
+# analysis without CI noticing — the same gap check_audit_codex_latency
+# closes for the Codex half of the study.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_audit_review_latency.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  # Consumer-safety guard (#601): repo_lint.yml is manifest-canonical, so
+  # consumers run this wrapper too — but the audit script + suite are
+  # hub-only (not manifest-propagated). scripts/sync-to-downstream.sh is
+  # the standard hub marker: both absent → consumer checkout → SKIP.
+  # Marker present → hub lost the test (accidental delete/rename) → hard
+  # error, preserving fail-closed hub behavior.
+  if [ ! -f "$REPO_ROOT/scripts/sync-to-downstream.sh" ]; then
+    echo "check_audit_review_latency: SKIP (consumer checkout: tests/test_audit_review_latency.sh + scripts/sync-to-downstream.sh both absent)"
+    exit 0
+  fi
+  echo "check_audit_review_latency: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"
+echo "check_audit_review_latency: PASS"

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -155,7 +155,12 @@ fi
 # workflow_run must listen to the EXACT upstream workflow names. A
 # rename or typo on either side would silently break the auto-clear
 # without this test catching it. CR Trivial on PR #202 r2.
-for wf in 'PR Review Policy' 'Agent Review Pipeline' 'repo-lint'; do
+# "repo-lint-local" added for #655 — the consumer-local repo_lint_local.yml
+# annex (#601), verified against a live consumer's annex workflow name.
+# ".github/workflows/repo_lint_local.yml" added for #655 round 11 —
+# workflow_run matches by displayed name, which is the workflow FILE PATH
+# when the annex omits a top-level `name:` key (round 6's fallback case).
+for wf in 'PR Review Policy' 'Agent Review Pipeline' 'repo-lint' 'repo-lint-local' '.github/workflows/repo_lint_local.yml'; do
   if grep -qF -- "- \"$wf\"" "$WORKFLOW"; then
     pass=$((pass + 1))
     echo "  PASS: workflow_run listens to '$wf'"

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -906,6 +906,14 @@ case "$1" in
         # empty and the existing clearance path is unchanged).
         repos/nathanjohnpayne/mergepath/issues/99999/comments) printf '[]\n' ;;
         repos/nathanjohnpayne/mergepath/issues/99999/reactions) reactions_json ;;
+        # #655 round 16: codex-review-check.sh now fetches the PR's real
+        # changed-file list to evaluate paths/paths-ignore annex filters
+        # for real instead of blanket-disqualifying on their presence.
+        # These Bug 4 fixtures carry no annex at all (confirmed 404 further
+        # below), so the changed-files list is never actually consulted by
+        # the annex-scan branch that matters here -- an empty list is a
+        # harmless, honest stand-in.
+        repos/nathanjohnpayne/mergepath/pulls/99999/files) printf '[]\n' ;;
         *) printf 'unexpected paginated endpoint: %s\n' "${1:-}" >&2; exit 9 ;;
       esac
       exit 0
@@ -926,6 +934,33 @@ JSON
         ;;
       repos/nathanjohnpayne/mergepath/branches/main/protection/required_status_checks)
         exit 1
+        ;;
+      repos/nathanjohnpayne/mergepath/contents/.github/workflows/repo_lint_local.yml?ref=headsha)
+        # #655: this fixture repo carries no repo_lint_local.yml annex --
+        # simulate the real gh CLI's 404 shape (a genuine "Not Found" HTTP
+        # response) so codex-review-check.sh's gate (a) annex probe takes
+        # its "genuinely absent" branch instead of its indeterminate-error
+        # fail-closed branch, matching what a real repo without the annex
+        # returns. Without this the probe's own catch-all "unexpected
+        # endpoint" response (exit 9, no "HTTP 404" text) was
+        # misinterpreted as an indeterminate error, injecting a synthetic
+        # repo-lint-local=MISSING requirement these Bug 4 fixtures never
+        # intended to exercise.
+        echo 'gh: Not Found (HTTP 404)' >&2
+        exit 1
+        ;;
+      graphql)
+        # #655 round 13: codex-review-check.sh's statusCheckRollup fetch
+        # switched from `gh pr view --json statusCheckRollup` (the now-dead
+        # `pr view` stub below) to a paginated `gh api graphql` query, to
+        # fix a real bug where a PR with more than 100 status contexts
+        # silently hid every entry past the first page. These Bug 4
+        # fixtures exercise Codex bot clearance (gate c), not CI-check
+        # status (gate a), so an empty, single-page rollup preserves the
+        # same "zero reported checks" shape the old stub returned.
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}]}}}}}
+JSON
         ;;
       *) printf 'unexpected endpoint: %s\n' "${1:-}" >&2; exit 9 ;;
     esac

--- a/scripts/ci/check_codex_scripts
+++ b/scripts/ci/check_codex_scripts
@@ -66,8 +66,14 @@ echo "check_codex_scripts: running codex-review-check gate (c) resolution tests"
 echo "check_codex_scripts: running codex-review-check verdict-comment clearance tests (#600)"
 "$REPO_ROOT/tests/test_codex_review_check_verdict.sh"
 
+echo "check_codex_scripts: running codex-review-check gate (a) required-check scoping tests (#655)"
+"$REPO_ROOT/tests/test_codex_review_check_required_checks.sh"
+
 echo "check_codex_scripts: running #465 fail-closed structural guards"
 "$REPO_ROOT/tests/test_465_fail_closed.sh"
+
+echo "check_codex_scripts: running #655 repo-lint-local observation structural guards"
+"$REPO_ROOT/tests/test_655_repo_lint_local_observed.sh"
 
 echo "check_codex_scripts: running codex-record-feedback tests"
 "$REPO_ROOT/tests/test_codex_record_feedback.sh"

--- a/scripts/ci/check_merge_clearance_gate
+++ b/scripts/ci/check_merge_clearance_gate
@@ -85,6 +85,33 @@ if [ -f "$WORKFLOW" ]; then
     FAILED=1
   fi
 
+  # #658: the propagation lane's head-pinned verified-head marker is posted as
+  # a GITHUB_TOKEN github-actions[bot] ISSUE comment, and GITHUB_TOKEN-authored
+  # events create no workflow runs — so an issue_comment trigger could never
+  # re-run the gate for it. Instead pr-review-policy.yml's lane sends a
+  # `merge-clearance-recheck` repository_dispatch right after posting the
+  # marker. Require that trigger AND the dispatch-recheck wiring (the dispatch
+  # type + resolving the PR from github.event.client_payload.pr), so a verified
+  # sync PR clears promptly instead of riding a fail-closed spurious-red until
+  # the */15 sweep. No payload trust is added: the dispatch only schedules a
+  # re-run; the gate re-derives clearance from the head-pinned
+  # github-actions[bot] marker in scripts/merge-clearance-gate.sh
+  # lane_verified(). Keep the `merge-clearance-recheck` type in sync with the
+  # lane. Label events are never a trigger here (#429 round-3 P1).
+  if ! grep -qE "^[[:space:]]*repository_dispatch:" "$WORKFLOW"; then
+    echo "FAIL: $WORKFLOW missing the repository_dispatch trigger."
+    echo "      The propagation-lane verified-head marker is a GITHUB_TOKEN issue comment (creates no workflow run); without the merge-clearance-recheck repository_dispatch a verified sync PR rides a fail-closed spurious-red gate until the scheduled sweep (#658)."
+    FAILED=1
+  fi
+  dispatch_wiring_missing=0
+  grep -qF "merge-clearance-recheck" "$WORKFLOW" || dispatch_wiring_missing=1
+  grep -qF "github.event.client_payload.pr" "$WORKFLOW" || dispatch_wiring_missing=1
+  if [ "$dispatch_wiring_missing" -ne 0 ]; then
+    echo "FAIL: $WORKFLOW repository_dispatch path is not wired for the marker re-trigger."
+    echo "      It must accept the 'merge-clearance-recheck' dispatch type AND resolve the PR from github.event.client_payload.pr in a check_run-posting job (#658)."
+    FAILED=1
+  fi
+
   # The required-check display name (job name) must match the name the
   # scheduled-sweep posts AND the entry in audit-branch-protection.sh's
   # CANONICAL_REQUIRED_CHECKS. Branch protection keys on the job name, so

--- a/scripts/ci/check_project_doc_sync
+++ b/scripts/ci/check_project_doc_sync
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# scripts/ci/check_project_doc_sync — run the project-doc-sync regression suite (#642).
+#
+# Wraps tests/test_project_doc_sync.sh, the hermetic suite for
+# scripts/project-doc-sync.sh: PRD/spec mirror drift detection, orphan
+# mirror sweeps (both project-scoped and central-decommission sweeps),
+# manifest validation, path-traversal hardening, and the read-only-repo
+# cache-safety guards. Both the script and the suite are HUB-ONLY
+# (deliberately not in .mergepath-sync.yml; no consumer has a
+# docs/projects/ tree or its own project-doc-sync.sh), so a consumer
+# checkout SKIPs via the same marker disambiguation check_wave_audit uses
+# (#624): wrapped test absent + scripts/sync-to-downstream.sh absent →
+# consumer checkout → SKIP; test absent but the hub marker present → the
+# hub lost the suite → hard error; test present → run it regardless of
+# the marker.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_project_doc_sync.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  if [ ! -f "$REPO_ROOT/scripts/sync-to-downstream.sh" ]; then
+    echo "check_project_doc_sync: SKIP (consumer checkout: wrapped test + scripts/sync-to-downstream.sh both absent; hub-only project-doc-sync suite)"
+    exit 0
+  fi
+  echo "check_project_doc_sync: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_propagation_closure
+++ b/scripts/ci/check_propagation_closure
@@ -261,16 +261,25 @@ ALLOW_LIST=(
   #     SKIPs on consumers via the manifest-absent guard)
   #   - check_audit_codex_latency   → test_audit_codex_latency.sh
   #     (both-absent marker SKIP, #601; the #623 latency-study suite)
+  #   - check_audit_review_latency  → test_audit_review_latency.sh
+  #     (both-absent marker SKIP, #601; the #623 CodeRabbit + phase-4b
+  #     latency-retune suite; scripts/audit-review-latency.sh is hub-only)
   #   - check_wave_audit            → test_wave_audit.sh
   #     (both-absent marker SKIP; the #662/#663 wave-audit suite —
   #     scripts/wave-audit.sh is hub-only, so the suite cannot run on a
   #     consumer and legitimately does not travel)
+  #   - check_project_doc_sync      → test_project_doc_sync.sh
+  #     (both-absent marker SKIP; the #642 project-doc-sync suite —
+  #     scripts/project-doc-sync.sh is hub-only, so the suite cannot run
+  #     on a consumer and legitimately does not travel)
   "tests/test_eslint_policy_check.sh"
   "tests/test_check_mktemp_portability.sh"
   "tests/test_session_finalization_check.sh"
   "tests/test_check_sync_manifest.sh"
   "tests/test_audit_codex_latency.sh"
+  "tests/test_audit_review_latency.sh"
   "tests/test_wave_audit.sh"
+  "tests/test_project_doc_sync.sh"
 
   # The #623 Codex-latency audit script — hub-only operator tooling for
   # this pass (a consumer-repo sweep is a possible follow-up, at which
@@ -280,6 +289,13 @@ ALLOW_LIST=(
   # to travel.
   "scripts/audit-codex-latency.sh"
 
+  # The #623 CodeRabbit + phase-4b latency-retune audit — hub-only operator
+  # tooling that mines CodeRabbit review latency across the consumer fleet
+  # (reads only) and the local phase-4b loop logs. Same posture as
+  # audit-codex-latency.sh: check_audit_review_latency runs the hermetic
+  # TEST, which SKIPs on consumers via the both-absent marker idiom.
+  "scripts/audit-review-latency.sh"
+
   # The #662/#663 wave-audit driver — hub-only operator tooling (one
   # scoped automated review per propagation wave, run from the hub
   # against the canary; consumers never run wave audits). Referenced
@@ -287,6 +303,26 @@ ALLOW_LIST=(
   # consumers via the both-absent marker idiom, so neither file needs
   # to travel.
   "scripts/wave-audit.sh"
+
+  # The #642 project-doc-sync driver — hub-only operator tooling (PRD/
+  # spec mirror audit + materialize, run against the central docs repo;
+  # no consumer has a docs/projects/ tree to audit). Referenced from
+  # wrapper/allow-list comments only; the wrapped test SKIPs on
+  # consumers via the both-absent marker idiom, so neither file needs
+  # to travel.
+  "scripts/project-doc-sync.sh"
+
+  # The #691 admin-merge statusCheckRollup pagination guard — hub-only
+  # break-glass operator tooling. scripts/admin-merge-codeowners-blocked.sh
+  # is the --admin CODEOWNERS-deadlock escape hatch (mergepath-only; no
+  # consumer runs it), and its offline PATH-shim suite rides with it.
+  # check_admin_merge_codeowners_blocked ships via the scripts/ci/ kit and
+  # names both in comments, but the wrapper runs the TEST, which SKIPs on
+  # consumers via the both-absent marker idiom, so neither file needs to
+  # travel. repo_lint.yml's wiring comment names the script for the same
+  # reason. Same posture as audit-codex-latency.sh above.
+  "scripts/admin-merge-codeowners-blocked.sh"
+  "tests/test_admin_merge_codeowners_blocked.sh"
 
   # The #601 consumer-safety net itself — hub-only BY DESIGN: it encodes
   # the hub-only removal list (this ALLOW_LIST + the bootstrap mirror

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -980,7 +980,7 @@ else
 fi
 if grep -Fq "Require current-head check success" .github/workflows/agent-review.yml && \
    grep -Fq "REQUIRED_HEAD_CHECK_NAME: lint" .github/workflows/agent-review.yml && \
-   grep -Fq 'select(.name == $check)' .github/workflows/agent-review.yml && \
+   grep -Fq 'select((.name // .context // "") == $name)' .github/workflows/agent-review.yml && \
    grep -Fq "Re-verify blocking labels after test wait" .github/workflows/agent-review.yml && \
    grep -Fq 'CURRENT_HEAD_SHA=$sha' .github/workflows/agent-review.yml && \
    grep -Fq -- "--match-head-commit" .github/workflows/agent-review.yml && \
@@ -991,6 +991,43 @@ if grep -Fq "Require current-head check success" .github/workflows/agent-review.
 else
   echo "  FAIL: agent-review auto-merge must wait for configured current-head check success, recheck labels, and bind merge to the checked HEAD" >&2
   fail=$((fail + 1))
+fi
+
+echo
+echo "agent-review.yml required-check wait: workflow-disambiguated check matching (#655 Codex P2 rounds 4-5, 11)"
+if grep -Fq 'select($workflow == "" or (.workflowName // "") == $workflow)' .github/workflows/agent-review.yml && \
+   grep -Fq 'group_by(.workflowName // "")' .github/workflows/agent-review.yml && \
+   grep -Fq 'sort_by(.completedAt // .startedAt // "")' .github/workflows/agent-review.yml; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review required-check wait matches by (name, workflow) via statusCheckRollup, grouping by workflow and picking the latest completed run per group when nothing is pending (#655)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review required-check wait must disambiguate by workflow via statusCheckRollup and pick the latest run per check (#655)" >&2
+fi
+
+# #655 Codex P2 round 11 ("restrict the lint wait to the required
+# workflow"): gh pr view --json statusCheckRollup has no field for "is
+# this specific entry actually required by branch protection", so the
+# workflow=="" (canonical) match could not tell a coincidentally
+# same-named but non-required check apart from the real one. Switched to
+# a direct graphql call (gh pr view's fixed --json shape omits
+# isRequired, and it is only resolvable when queried directly, not
+# through commits.nodes.commit) so isRequired(pullRequestNumber:) can
+# additionally scope the workflow=="" match to only entries branch
+# protection actually requires when GitHub reports at least one such
+# entry. If no same-name entry reports required=true, keep the configured
+# check wait instead of treating branch-protection metadata as mandatory.
+echo
+echo "agent-review.yml required-check wait: isRequired-preferred canonical match (#655 Codex P2 round 11/15)"
+if grep -Fq 'gh api graphql -f query=' .github/workflows/agent-review.yml && \
+   grep -Fq 'isRequired(pullRequestNumber: $number)' .github/workflows/agent-review.yml && \
+   grep -Fq '([$name_matches[] | select(.isRequired == true)]) as $required_matches' .github/workflows/agent-review.yml && \
+   grep -Fq 'if $workflow == "" and ($required_matches | length) > 0' .github/workflows/agent-review.yml; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review required-check wait fetches statusCheckRollup via graphql and prefers isRequired==true entries when present (#655 round 11/15)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review required-check wait does not fetch isRequired or prefer required matches with a configured-check fallback (#655 round 11/15)" >&2
 fi
 
 echo "dependabot-auto-merge.yml author-token equality regression (#426)"

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -29,10 +29,11 @@
 #
 #   3. **HEAD freshness.** Auto-merge-on-approval workflows in downstream
 #      repos race CodeRabbit: an internal reviewer can post APPROVED before
-#      CodeRabbit's ~2–3 minute review lands, and the PR auto-merges
-#      pre-review. The script only returns "cleared" when CodeRabbit has
-#      posted a non-rate-limited, non-in-progress comment on or after the
-#      HEAD committer date. See nathanjohnpayne/mergepath#136.
+#      CodeRabbit's review lands (measured p50 ~6 min, p99 ~19 min — #623,
+#      not the old "~2–3 min" folklore), and the PR auto-merges pre-review.
+#      The script only returns "cleared" when CodeRabbit has posted a
+#      non-rate-limited, non-in-progress comment on or after the HEAD
+#      committer date. See nathanjohnpayne/mergepath#136.
 #
 # It also surfaces — without re-invoking — the other detectable reasons
 # CodeRabbit auto-review never fires: a PR base branch matched by none of
@@ -59,7 +60,7 @@
 #              $OP_PREFLIGHT_REVIEWER_PAT after preflight.
 #
 # Behavior:
-#   1. Reads coderabbit.max_wait_seconds (default 300) and
+#   1. Reads coderabbit.max_wait_seconds (default 1245; measured full-fleet max + one poll interval, #623) and
 #      coderabbit.max_rate_limit_retries (default 2) from
 #      .github/review-policy.yml.
 #   2. Fetches PR HEAD SHA + committer date.
@@ -363,8 +364,24 @@ coderabbit_yml_drafts() {
   ' "$CODERABBIT_YML"
 }
 
+# max_wait_seconds: the poll ceiling before an advisory exit 4. Default 1245s
+# is measured (#623): the mined CodeRabbit review latency (commit → first
+# body-bearing review, rate-limited rounds excluded) across ALL EIGHT
+# CodeRabbit-active consumers is p50 414s / p90 861s / p99 1136s / max 1219s
+# (n=142, docs/audits/data/review-latency-2026-07/). The prior 300s sat below
+# even the p50, so >50% of PRs timed the wait out before CodeRabbit reviewed —
+# reopening the #136 pre-review-merge race. 1245s = 83 × POLL_INTERVAL_SECONDS
+# = one full poll interval BEYOND the observed max (1219s): the loop below
+# checks ELAPSED >= MAX_WAIT_SECONDS at the TOP of each iteration and times out
+# with no final scan, so a review landing in the last poll window would be
+# missed by a ceiling set exactly at the tail (Codex P2 on #688 caught both the
+# blind spot and that a 5-repo subset understated the max at 1136s). One
+# interval of headroom guarantees the slowest observed review still gets a poll
+# scan before the timeout. It is a CEILING (the poll returns as soon as the
+# review lands, ~p50 7 min); paused/rate-limit/skip fast-paths short-circuit
+# genuinely-stuck rounds.
 MAX_WAIT_SECONDS=$(coderabbit_field max_wait_seconds)
-MAX_WAIT_SECONDS=${MAX_WAIT_SECONDS:-300}
+MAX_WAIT_SECONDS=${MAX_WAIT_SECONDS:-1245}
 if ! [[ "$MAX_WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "ERROR: coderabbit.max_wait_seconds must be an integer; got '$MAX_WAIT_SECONDS'" >&2
   exit 3

--- a/scripts/codex-record-feedback.sh
+++ b/scripts/codex-record-feedback.sh
@@ -331,8 +331,19 @@ fi
 
 # Exact feedback solicitation Codex appends to every finding it wants graded.
 # Detection is substring-based so surrounding markdown/whitespace does not
-# defeat the match, but the phrase itself must appear verbatim.
+# defeat the match, but the phrase itself must appear verbatim once BODY is
+# whitespace-normalized below.
 SOLICITATION='Useful? React with 👍 / 👎.'
+
+# #682: the live chatgpt-codex-connector[bot] comment renders the space
+# immediately before the slash as U+00A0 (NO-BREAK SPACE, UTF-8 bytes c2 a0),
+# not the regular space (0x20) SOLICITATION uses above -- byte-verified via
+# `gh api repos/OWNER/REPO/pulls/comments/<id>` on a real finding (PR #680,
+# comment 3525276576). Rather than hard-code the NBSP into SOLICITATION
+# (which would silently re-break if Codex ever reverts to a plain space),
+# normalize NBSP to a regular space in BODY before the match so either form
+# is accepted.
+NBSP=$'\xc2\xa0'
 
 # --- collect findings -------------------------------------------------------
 
@@ -575,7 +586,10 @@ while IFS= read -r finding; do
   BODY=$(echo "$finding" | jq -r '.body // ""')
 
   # Solicitation gate — never react on a finding that does not ask for it.
-  case "$BODY" in
+  # #682: normalize NBSP to a regular space before matching (see the NBSP
+  # note above SOLICITATION) so the gate tolerates either whitespace form.
+  BODY_NORMALIZED=${BODY//$NBSP/ }
+  case "$BODY_NORMALIZED" in
     *"$SOLICITATION"*) : ;;
     *)
       log "comment $CID does not solicit feedback — skipping"

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -620,8 +620,568 @@ log "gate (a): checking CI state"
 # recovered. Caught by codex P1 on PR #328 round 1. The retry diagnostics
 # still surface in the workflow log via stderr, so the visibility cost
 # is zero.
-ROLLUP_JSON=$(with_gh_retry gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup) \
-  || die 3 "failed to fetch statusCheckRollup (see stderr above for retry diagnostics)"
+#
+# #655 Codex P1 round 13 ("page the rollup before scanning annex
+# checks"): `gh pr view --json statusCheckRollup` only requests the first
+# 100 contexts with no pagination, exactly the bug already found and
+# fixed in agent-review.yml's wait loop (#655 round 12, verified live
+# against this PR's own 160+ contexts) -- this script has the identical
+# gap and was missed when that fix landed. Switched to the same
+# Relay-cursor-paginated graphql query, each page wrapped in
+# with_gh_retry individually so a transient failure on page 2 does not
+# discard page 1's already-fetched data. Also adds workflowPath (#655
+# round 13, "disambiguate annex workflows beyond display name" -- see
+# below) alongside the existing workflowName, since the annex contract
+# does not guarantee a unique display name across a consumer's workflows.
+REPO_OWNER="${REPO%%/*}"
+REPO_NAME="${REPO#*/}"
+ROLLUP_CONTEXTS="[]"
+ROLLUP_CURSOR=""
+while :; do
+  ROLLUP_CURSOR_ARGS=(-F cursor=null)
+  if [ -n "$ROLLUP_CURSOR" ]; then
+    ROLLUP_CURSOR_ARGS=(-f cursor="$ROLLUP_CURSOR")
+  fi
+  ROLLUP_PAGE=$(with_gh_retry gh api graphql -f query='
+    query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          commits(last: 1) {
+            nodes {
+              commit {
+                statusCheckRollup {
+                  contexts(first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      __typename
+                      ... on CheckRun {
+                        name
+                        status
+                        conclusion
+                        startedAt
+                        completedAt
+                        checkSuite { workflowRun { workflow { name resourcePath } } }
+                      }
+                      ... on StatusContext {
+                        context
+                        state
+                        createdAt
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F number="$PR_NUMBER" "${ROLLUP_CURSOR_ARGS[@]}") \
+    || die 3 "failed to fetch statusCheckRollup page (see stderr above for retry diagnostics)"
+  ROLLUP_PAGE_NODES=$(echo "$ROLLUP_PAGE" | jq -c '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.nodes // [])')
+  ROLLUP_CONTEXTS=$(jq -c -n --argjson a "$ROLLUP_CONTEXTS" --argjson b "$ROLLUP_PAGE_NODES" '$a + $b')
+  ROLLUP_HAS_NEXT=$(echo "$ROLLUP_PAGE" | jq -r '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage // false)')
+  ROLLUP_CURSOR=$(echo "$ROLLUP_PAGE" | jq -r '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.endCursor // "")')
+  [ "$ROLLUP_HAS_NEXT" = "true" ] || break
+done
+ROLLUP_JSON=$(echo "$ROLLUP_CONTEXTS" | jq '{
+  statusCheckRollup: (map({
+      name: .name,
+      context: .context,
+      workflowName: (.checkSuite.workflowRun.workflow.name // null),
+      workflowPath: (((.checkSuite.workflowRun.workflow.resourcePath // "") | split("/") | last) // ""),
+      status: .status,
+      conclusion: .conclusion,
+      state: .state,
+      startedAt: .startedAt,
+      completedAt: .completedAt
+    }))
+}')
+# #655 Codex P1 round 7 ("keep rollup when annex only has matrix jobs"): a
+# frozen copy taken BEFORE any branch-protection-driven scoping/wiping below
+# can touch $ROLLUP_JSON. The annex workflow-wide scan intentionally bypasses
+# the required-name filter entirely (see its own comment further down), so it
+# must never be starved by logic that clears $ROLLUP_JSON for OTHER reasons --
+# e.g. the empty-required-checks branch below always wipes it (branch
+# protection configured nothing, so the required-name filter has nothing to
+# enforce), which would otherwise silently hide the annex from that filter
+# too; ANNEX_SCAN_ROLLUP_JSON keeps the workflow-wide scan working regardless.
+ANNEX_SCAN_ROLLUP_JSON="$ROLLUP_JSON"
+
+# #655 (Codex P2 round 2): a consumer's repo_lint_local.yml annex's check
+# name may not be "repo-lint-local" (check_ci_scripts_wired's annex contract
+# does not require that literal), and if the annex workflow has not yet
+# started for this PR (a job/path conditional the PR happens to skip, or
+# simply not run yet), it never appears in ROLLUP_JSON at all -- a
+# rollup-presence-only check can neither find a custom-named check nor
+# notice a required annex check that is silently missing. Proactively probe
+# the annex file at the PR HEAD (mirrors agent-review.yml's #655 probe) and
+# derive its job name(s) for logging/observability, so a human reading gate
+# (a)'s log can see what was derived from the annex.
+#
+# ANNEX_CHECKS_JSON carries { name, workflow } pairs, not bare names (#655
+# round 3 P2): the annex contract does not require unique job names, so a
+# consumer whose local job happens to share a name with an unrelated check
+# (e.g. "lint") would otherwise let that unrelated check's success silently
+# satisfy the annex requirement, or (round 10) let an unrelated check's
+# FAILURE wrongly block gate (a). workflow is the annex's own top-level
+# `name:` (statusCheckRollup's .workflowName for CheckRun entries).
+# ANNEX_CHECKS_JSON is NOT merged into the required-name filter below (#655
+# round 10, "preserve workflow identity for annex checks") -- that merge
+# used to be how the annex got force-checked, but it is name-only (like
+# every other required-check match in this script), so a same-named
+# unrelated check could wrongly become "required" too. The workflow-wide
+# scan (ANNEX_WORKFLOW_BAD, further down) now independently and safely
+# enforces the annex by workflow identity instead, so no merge is needed.
+#
+# Matrix-strategy jobs are skipped during NAME derivation (#655 round 3 P2):
+# GitHub expands a matrix job into one check run per combination with a name
+# this static YAML read cannot reproduce, so treating the unexpanded job
+# id/name as "the" check would force-require a name that will never exist.
+# ANNEX_WORKFLOW_NAME is still captured separately (#655 round 5) so the
+# workflow-wide scan below can catch a REPORTED matrix-leg failure by
+# workflow identity, without needing to know its expanded name in advance.
+# ruby's own stderr (not redirected here, unlike the base64 decode)
+# surfaces the matrix-skip notice in the workflow log.
+HEAD_SHA_FOR_ANNEX=$(echo "$PR_JSON" | jq -r '.head.sha')
+# #655 Codex P2 round 9 ("wait for valid push-only annex workflows"): a
+# push-only annex trigger (no pull_request key at all) is a VALID wiring
+# per check_ci_scripts_wired's contract (push OR pull_request suffices),
+# but only fires "push" events IN THIS REPO for a same-repo PR -- a
+# fork-based PR's pushes land in the fork, never registering a push event
+# here. Compare head/base repo full_name (REST PR object fields) rather
+# than adding another API call.
+ANNEX_SAME_REPO_PR=$(echo "$PR_JSON" | jq -r '(.head.repo.full_name // "head-unknown") == (.base.repo.full_name // "base-unknown")')
+# #655 Codex P2 round 11 ("evaluate base-branch filters before passing"): a
+# pull_request branches/branches-ignore filter is matched against the PRs
+# BASE ref (the target branch, e.g. "main"); a push branches/branches-ignore
+# filter is matched against the ref actually being pushed, which for a
+# same-repo PRs synchronize event is the PRs own HEAD ref (the feature
+# branch), not the base. Both are already on PR_JSON with no extra API call.
+ANNEX_BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.base.ref // ""')
+ANNEX_HEAD_BRANCH=$(echo "$PR_JSON" | jq -r '.head.ref // ""')
+# #655 Codex P2 round 16 ("wait for path-matched annex workflows",
+# narrowed in round 17 -- "use the event diff when emulating path
+# filters"): a pull_request trigger scoped by paths/paths-ignore was
+# previously treated as unconditionally filtered on mere key presence,
+# even when the PR's actual changed files match the filter (GitHub
+# schedules the workflow in that case). Fetching the real changed-file
+# list lets the ruby probe evaluate the filter for real instead of
+# guessing (scoped to pull_request only -- see the ruby-side comment for
+# why push does not get the same treatment). Paginated like TIMELINE_JSON
+# above, since a large PR can have more than one page of files;
+# fetch_api_array dies on a genuine fetch failure (#655 Codex P2 round
+# 17, "fail closed when the changed-file lookup fails" / CodeRabbit,
+# "don't silently treat changed-files API failures as filtered out") so
+# ANNEX_CHANGED_FILES_JSON is never silently wrong here -- either a valid
+# array, or the whole script has already aborted.
+ANNEX_CHANGED_FILES_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/files" "PR changed files" | jq -c '[.[].filename]')
+ANNEX_CHECKS_JSON='[]'
+ANNEX_WORKFLOW_NAME=""
+ANNEX_UNFILTERED="false"
+ANNEX_CONFIRMED_ABSENT=0
+if [ -n "$HEAD_SHA_FOR_ANNEX" ] && [ "$HEAD_SHA_FOR_ANNEX" != "null" ]; then
+  annex_probe_err=$(mktemp)
+  if annex_content=$(gh api "repos/$REPO/contents/.github/workflows/repo_lint_local.yml?ref=$HEAD_SHA_FOR_ANNEX" --jq .content 2>"$annex_probe_err"); then
+    annex_probe_raw=$(printf '%s' "$annex_content" | base64 -d 2>/dev/null | ANNEX_SAME_REPO_PR="$ANNEX_SAME_REPO_PR" ANNEX_BASE_BRANCH="$ANNEX_BASE_BRANCH" ANNEX_HEAD_BRANCH="$ANNEX_HEAD_BRANCH" ANNEX_CHANGED_FILES_JSON="$ANNEX_CHANGED_FILES_JSON" ruby -ryaml -rjson -e '
+      raw = STDIN.read
+      # #655 Codex P1 round 7 ("parse valid annex workflows that use YAML
+      # aliases"): GitHub Actions supports anchors/aliases in workflow
+      # files, but Psych safe_load defaults to aliases:false specifically
+      # to block the "billion laughs" DoS (a small file whose nested
+      # aliases expand exponentially at parse time). This parses a PRs
+      # OWN branch content, so any repo accepting external contributions
+      # is exposed to a crafted repo_lint_local.yml exhausting CI runner
+      # memory/CPU. Allow aliases, but bound the attack surface first: a
+      # byte-size cap (legitimate CI configs are a few KB) plus a raw
+      # anchor/alias token count cap (the exploit needs many alias
+      # references to achieve exponential blowup; a legitimate DRY job
+      # template reuses one or two) -- counted on the RAW text before
+      # parsing, since the danger is in the expansion itself, not the
+      # input size.
+      if raw.bytesize > 100_000
+        STDERR.puts "repo_lint_local.yml exceeds 100000 bytes -- refusing to parse (defensive cap, not a realistic legitimate size, #655)"
+        exit
+      end
+      # #655 Codex P2 round 8 ("avoid treating path globs as YAML aliases"):
+      # a naive `[&*]word` scan over-counts, since an ordinary glob like
+      # `**/*.ts` in a paths:/paths-ignore: list starts with `*` too --
+      # inflating the count on a perfectly legitimate annex with a longer
+      # filter list past the cap, disabling the workflow-wide scan for a
+      # real, currently-failing local check. A real YAML anchor/alias can
+      # ONLY appear immediately after a structural position: start of
+      # text; a block-sequence dash (which requires being the first
+      # non-whitespace character on its line, with a MANDATORY space
+      # before the value -- narrowed in round 9, see below); or `:`, `,`,
+      # `[`, `{` anywhere, optionally followed by whitespace. A glob
+      # string value is never in that position unquoted (a bare scalar
+      # starting with `*` is itself a YAML syntax error, confirmed
+      # empirically: Psych raises "did not find expected alphabetic or
+      # numeric character while scanning an alias"), and a QUOTED glob has
+      # a leading quote character that breaks the match.
+      #
+      # #655 Codex P2 round 9 ("do not count glob hyphens as YAML
+      # aliases"): the round 8 version accepted a bare `-` ANYWHERE in the
+      # text (with optional trailing whitespace) as a structural position,
+      # which also matched an internal hyphen inside a glob directly before a
+      # `*` (e.g. "src/component-*.ts") with no space between them --
+      # inflating the count on a filter list using hyphenated names, a
+      # false positive round 8 did not catch. A real block-sequence dash
+      # is anchored to the start of its line (`^[ \t]*-`, i.e. only
+      # preceded by indentation) and REQUIRES at least one space before
+      # its value, unlike a mid-string hyphen. Verified against the exact
+      # round-9 false-positive case (0 matches now), a real block-sequence
+      # alias and a mapping alias (both still counted), a 20-entry
+      # hyphenated quoted glob list (0 matches), and the round-7 synthetic
+      # billion-laughs payload (91 matches, still caught).
+      if raw.scan(/(?:\A|^[ \t]*-\s+|[:,\[{]\s*)[&*][A-Za-z0-9_.-]+/).length > 40
+        STDERR.puts "repo_lint_local.yml has an unusually high anchor/alias token count -- refusing to parse (defensive cap against a YAML alias-expansion DoS, #655)"
+        exit
+      end
+      begin
+        doc = YAML.safe_load(raw, aliases: true)
+      rescue Psych::Exception
+        exit
+      end
+      exit unless doc.is_a?(Hash) && doc["jobs"].is_a?(Hash)
+      # #655 Codex P2 round 6: when the annex omits a top-level `name:`,
+      # GitHub displays (and reports into statusCheckRollup .workflowName
+      # as) the workflow FILE PATH, not an empty string -- an empty
+      # workflow_name would disable the entire workflow-wide scan below,
+      # even for a valid annex with reported job failures.
+      workflow_name = doc["name"] ? doc["name"].to_s : ".github/workflows/repo_lint_local.yml"
+      jobs = []
+      doc["jobs"].each do |id, job|
+        if job.is_a?(Hash) && job["strategy"].is_a?(Hash) && job["strategy"]["matrix"]
+          STDERR.puts "skipping matrix-strategy job #{id} -- its expanded check-run name(s) cannot be derived from the static job definition (#655)"
+          next
+        end
+        name = (job.is_a?(Hash) && job["name"]) ? job["name"] : id
+        jobs << { "name" => name.to_s, "workflow" => workflow_name }
+      end
+      # #655 Codex P2 round 8 ("wait for unreported unfiltered annex
+      # checks" on gate (a), mirroring agent-review.yml round 7/8): an
+      # annex whose pull_request trigger has NO restricting filter is
+      # GUARANTEED to eventually produce a check run for this PR, so zero
+      # reported entries means "not scheduled yet", not "will never run"
+      # -- unlike a genuinely filtered annex. YAML 1.1 coerces the
+      # bareword `on:` key to the boolean true (the "Norway problem"), so
+      # doc["on"] is nil for the overwhelmingly common unquoted `on:`.
+      #
+      # #655 Codex P2 round 9 ("honor non-path pull_request filters
+      # before waiting"): round 8 checked only paths/paths-ignore on the
+      # pull_request config. GitHub Actions pull_request triggers also
+      # support branches, branches-ignore, and types -- a types list that
+      # excludes synchronize (e.g. types: [opened] only) means this
+      # workflow will NEVER run for a resynchronized PRs current HEAD, so
+      # treating that as unfiltered would inject a synthetic PENDING entry
+      # that can never clear: the exact permanent-deadlock class rounds
+      # 2-5 already fought to eliminate for the paths case.
+      #
+      # #655 Codex P1 round 10 ("treat synchronize-enabled types as
+      # runnable"): round 9 disqualified "unfiltered" on the MERE presence
+      # of a types key, but types is not a narrowing filter the way
+      # paths/branches are -- it selects WHICH pull_request activities
+      # trigger this workflow at all, and the GitHub default (when types
+      # is omitted) is [opened, synchronize, reopened]. An explicit types
+      # list that STILL includes synchronize (the activity that fires for
+      # a resynchronized PRs current HEAD) is therefore just as unfiltered
+      # as omitting types entirely -- the common explicit form
+      # `types: [opened, synchronize, reopened]` was being wrongly
+      # disqualified. Only a types list that EXCLUDES synchronize actually
+      # means this workflow never runs for that HEAD, so types gets its
+      # own check below rather than joining the generic filter-key list.
+      #
+      # #655 Codex P2 round 9 ("wait for valid push-only annex
+      # workflows"): check_ci_scripts_wired accepts push OR pull_request
+      # as valid wiring, but a push-only annex was never classified as
+      # unfiltered at all (no pull_request trigger present), so gate (a)
+      # never waited for it. A push trigger only fires IN THIS REPO for a
+      # same-repo PR (a fork PRs push lands in the fork, never here), so
+      # ANNEX_SAME_REPO_PR (computed in bash from the PR REST objects
+      # head/base repo full_name, passed in via env since this ruby
+      # invocation only reads the YAML over stdin) gates whether an
+      # unfiltered push trigger counts.
+      #
+      # #655 Codex P2 round 11 ("evaluate base-branch filters before
+      # passing"): rounds 9-10 blanket-disqualified "unfiltered" on the
+      # MERE PRESENCE of branches/branches-ignore, but GitHub schedules
+      # the workflow whenever the actual ref matches -- e.g.
+      # `pull_request: {branches: [main]}` still runs for every PR
+      # targeting main, so blanket-disqualifying it for THIS PR (which
+      # may well target main) wrongly treats a genuinely-unfiltered-for-
+      # this-PR annex as filtered. Evaluated against the real ref instead:
+      # pull_request compares the PRs BASE ref (ANNEX_BASE_BRANCH); push
+      # compares the ref actually being pushed, which for a same-repo PRs
+      # synchronize is the PRs own HEAD ref (ANNEX_HEAD_BRANCH), not base.
+      # Matching translates each pattern into an equivalent Ruby Regexp
+      # rather than using File.fnmatch, refined per #655 round 13 ("use
+      # an Actions-compatible branch glob matcher") to correct a gap
+      # found in the round-12 fnmatch version: GitHub documented branch
+      # patterns support a `+` repetition quantifier on a preceding
+      # character/class (e.g. `v[12].[0-9]+.[0-9]+`, matching semver
+      # branches) -- a real regex feature fnmatch has no equivalent for
+      # (it always treats `+` as a literal character and returns false).
+      # Regexp natively supports quantifiers AND character classes, so
+      # translating once and matching via Regexp#match? handles the full
+      # documented syntax (*, **, ?, [...], +) with one mechanism instead
+      # of patching fnmatch further. `**` crosses `/` (translated to
+      # `.*`); a lone `*` does not (translated to `[^/]*`); `[...]` and a
+      # following `+` are copied through verbatim, since Ruby regex
+      # character-class and quantifier syntax already matches the GitHub
+      # semantics. A backslash escapes the next special character into a
+      # literal match, as GitHub documents for branch/tag names that contain
+      # glob metacharacters. Everything else is regex-escaped. Verified
+      # against the GitHub-documented single-star/double-star examples, the
+      # semver example above, an escaped literal-* case, and (round 12) an
+      # ordered `!`-negation case.
+      #
+      # #655 Codex P2 round 11 ("treat tag-only push annexes as
+      # filtered", narrowed in round 13 -- "do not treat tag filters as
+      # excluding branch pushes"): a push trigger scoped ONLY by tags/
+      # tags-ignore (no branches/branches-ignore at all) only fires for
+      # TAG ref pushes, never an ordinary branch push. But GitHub
+      # documents branches and tags as combinable on the SAME push
+      # trigger (runs for a matching branch push OR a matching tag
+      # push), so a trigger with BOTH keys must still be evaluated by
+      # its branches filter -- the round-11 version disqualified on tags
+      # presence alone, before branches ever got a chance to match, which
+      # wrongly filtered an annex GitHub would actually run for a
+      # matching branch push. Tags now only disqualifies when there is
+      # no branches/branches-ignore key at all to independently evaluate.
+      on = doc.key?("on") ? doc["on"] : doc[true]
+      def branch_pattern_to_regex(pattern)
+        # #655 Codex P2 round 16 ("honor ? as an optional-character
+        # filter"): GitHub documents `?` as matching zero or one of the
+        # PRECEDING character (e.g. `release?` matches base branch
+        # `release` itself), not "exactly one arbitrary character" the way
+        # POSIX glob/fnmatch define it. Building a TOKEN LIST (one entry
+        # per translated glob unit) instead of one flat string lets `?`
+        # wrap the LAST token in `(?:...)?` -- correctly quantifying
+        # whatever unit came before it (a literal char, an escaped char, or
+        # a whole `[...]` class), not just a single output character. A
+        # leading `?` (no preceding token) is a no-op: "zero or one of
+        # nothing" contributes nothing to the match either way. `tokens.
+        # join` reconstructs the exact same concatenation the old flat-
+        # string version produced for every other case, including `+`
+        # (still a bare postfix quantifier on whatever token precedes it).
+        tokens = []
+        chars = pattern.chars
+        i = 0
+        while i < chars.length
+          c = chars[i]
+          if c == "\\" && chars[i + 1]
+            tokens << Regexp.escape(chars[i + 1])
+            i += 2
+          elsif c == "*" && chars[i + 1] == "*"
+            tokens << ".*"
+            i += 2
+          elsif c == "*"
+            tokens << "[^/]*"
+            i += 1
+          elsif c == "?"
+            tokens[-1] = "(?:#{tokens[-1]})?" if tokens.any?
+            i += 1
+          elsif c == "["
+            j = i + 1
+            j += 1 while j < chars.length && chars[j] != "]"
+            tokens << chars[i..j].join
+            i = j + 1
+          elsif c == "+"
+            tokens << "+"
+            i += 1
+          else
+            tokens << Regexp.escape(c)
+            i += 1
+          end
+        end
+        Regexp.new("\\A#{tokens.join}\\z")
+      end
+      def branch_matches?(pattern, branch)
+        return false unless pattern.is_a?(String) && branch.is_a?(String)
+        branch_pattern_to_regex(pattern).match?(branch)
+      rescue RegexpError, ArgumentError
+        false
+      end
+      def push_tag_only_excludes?(cfg)
+        (cfg.key?("tags") || cfg.key?("tags-ignore")) && !(cfg.key?("branches") || cfg.key?("branches-ignore"))
+      end
+      def branch_matches_list?(patterns, branch)
+        return false unless patterns.is_a?(Array)
+        included = false
+        patterns.each do |raw|
+          next unless raw.is_a?(String)
+          if raw.start_with?("!")
+            included = false if branch_matches?(raw[1..], branch)
+          else
+            included = true if branch_matches?(raw, branch)
+          end
+        end
+        included
+      end
+      def branch_filter_excludes?(cfg, branch)
+        return true if (cfg.key?("branches") || cfg.key?("branches-ignore")) && !(branch.is_a?(String) && !branch.empty?)
+        if cfg.key?("branches")
+          return true unless branch_matches_list?(cfg["branches"], branch)
+        end
+        if cfg.key?("branches-ignore")
+          return true if branch_matches_list?(cfg["branches-ignore"], branch)
+        end
+        false
+      end
+      # #655 Codex P2 round 16 ("wait for path-matched annex workflows",
+      # narrowed in round 17 -- "use the event diff when emulating path
+      # filters"): a paths/paths-ignore key was previously treated as
+      # unconditionally filtered on mere presence, even when the PRs
+      # actual changed files match the filter. Path glob syntax documents
+      # the SAME tokens (*, **, ?, [...], +, \) as branch/tag patterns, so
+      # branch_matches_list? is reused rather than reimplementing path
+      # matching. `paths` requires at least one changed file to match (in
+      # order, with `!` negation); `paths-ignore` excludes only when EVERY
+      # changed file matches the ignore patterns. GitHub evaluates a PUSH
+      # triggers path filter against the two-dot diff of JUST that push,
+      # not the whole-PR three-dot diff this fetch provides -- an earlier
+      # commit already in the PR could have touched a matching path while
+      # the CURRENT push does not, wrongly keeping this "unfiltered" and
+      # injecting a PENDING entry that never resolves. The three-dot
+      # PR-wide diff genuinely matches what GitHub documents for the
+      # pull_request event, so only that event gets the real evaluation;
+      # push keeps the round-16-era always-filtered default rather than
+      # risk a diff-scope mismatch. GitHub also only considers the first
+      # 300 changed files for path-filter evaluation, so the list is
+      # capped the same way before matching.
+      def paths_filter_excludes?(event, cfg, changed_files, changed_files_known)
+        return false unless cfg.key?("paths") || cfg.key?("paths-ignore")
+        return true if event == "push"
+        return false unless changed_files_known
+        capped_files = changed_files.first(300)
+        if cfg.key?("paths")
+          return true unless capped_files.any? { |f| branch_matches_list?(cfg["paths"], f) }
+        end
+        if cfg.key?("paths-ignore")
+          return true if capped_files.all? { |f| branch_matches_list?(cfg["paths-ignore"], f) }
+        end
+        false
+      end
+      # #655 Codex P2 round 17 (do not silently treat changed-files API
+      # failures as filtered out, CodeRabbit; "fail closed when the
+      # changed-file lookup fails", Codex): ANNEX_CHANGED_FILES_JSON is
+      # only ever empty here because fetch_api_array (bash layer above)
+      # dies on a genuine fetch failure -- but the ENV var is unset (not
+      # merely "[]") in that dead-script case, so an EXPLICITLY empty
+      # string still distinguishes "never got this far" from "genuinely
+      # parsed to []" for the (unlikely but not impossible) zero-file
+      # case. changed_files_known gates the real evaluation above:
+      # unknown data must not silently read as "paths definitely do not
+      # match" (which would wrongly filter out an annex that could
+      # actually run).
+      changed_files_known = !(ENV["ANNEX_CHANGED_FILES_JSON"] || "").empty?
+      changed_files = begin
+        changed_files_known ? JSON.parse(ENV["ANNEX_CHANGED_FILES_JSON"]) : []
+      rescue JSON::ParserError
+        []
+      end
+      trigger_unfiltered = lambda do |event, relevant_branch|
+        case on
+        when String then on == event
+        when Array then on.include?(event)
+        when Hash
+          next false unless on.key?(event)
+          cfg = on[event]
+          next true unless cfg.is_a?(Hash)
+          next false if paths_filter_excludes?(event, cfg, changed_files, changed_files_known)
+          next false if event == "push" && push_tag_only_excludes?(cfg)
+          next false if branch_filter_excludes?(cfg, relevant_branch)
+          # #655 Codex P2 round 16 (do not skip opened-only annex runs),
+          # REVERTED in round 17 ("do not infer opened-only runs from
+          # committer date"): round 16 tried to distinguish "still on the
+          # PRs opening commit" (types: [opened] would still fire) from
+          # "synchronized since" (opened will never fire again) by
+          # comparing the HEAD committer date against the PRs created_at.
+          # Confirmed live: a genuinely-new synchronize push whose commit
+          # preserves an OLDER committer date (a rebase/cherry-pick of a
+          # stale commit) still satisfies committer_date <= created_at,
+          # so the heuristic can say "unfiltered" for a trigger that will
+          # NEVER report again on this HEAD -- injecting a permanent
+          # PENDING entry via the zero-match branch below, a real
+          # deadlock. No reliable, non-spoofable signal for "has
+          # synchronize happened since open" is available from the data
+          # this script already has, and a permanent deadlock is strictly
+          # worse than the narrower gap being reopened (a brand-new PRs
+          # opened-only annex not being waited for before its first
+          # report) -- reverted to the simple, safe round-10 rule: only a
+          # types list that explicitly includes synchronize counts as
+          # unfiltered.
+          next (cfg["types"].is_a?(Array) && cfg["types"].include?("synchronize")) if cfg.key?("types")
+          true
+        else
+          false
+        end
+      end
+      pr_unfiltered = trigger_unfiltered.call("pull_request", ENV["ANNEX_BASE_BRANCH"])
+      push_unfiltered = trigger_unfiltered.call("push", ENV["ANNEX_HEAD_BRANCH"])
+      same_repo_pr = ENV["ANNEX_SAME_REPO_PR"] == "true"
+      unfiltered = pr_unfiltered || (push_unfiltered && same_repo_pr)
+      puts JSON.generate({ "workflow" => workflow_name, "jobs" => jobs, "unfiltered" => unfiltered })
+    ' || true)
+    if [ -z "$annex_probe_raw" ]; then
+      # ruby never reached its `puts` line at all: the YAML itself did not
+      # parse (Psych exception) or had no `jobs:` hash -- genuinely
+      # unparseable, not just empty. The workflow name is unknown too
+      # (parsing never got that far), so the workflow-wide scan below has
+      # nothing to key on for this case; the conventional-name fallback
+      # scan further down (#655 round 10) covers it instead, without
+      # forcing a requirement that name ever exist.
+      log "gate (a): repo_lint_local.yml annex present at $HEAD_SHA_FOR_ANNEX but could not be parsed as a workflow (invalid YAML or no jobs) — falling back to scanning for the conventional repo-lint-local check name (#655)."
+    else
+      ANNEX_WORKFLOW_NAME=$(echo "$annex_probe_raw" | jq -r '.workflow')
+      ANNEX_UNFILTERED=$(echo "$annex_probe_raw" | jq -r '.unfiltered')
+      annex_jobs=$(echo "$annex_probe_raw" | jq -c '.jobs')
+      if [ "$(echo "$annex_jobs" | jq 'length')" -eq 0 ]; then
+        # ruby parsed a valid jobs hash but every job was matrix-strategy and
+        # skipped: the annex genuinely exists and has jobs, we simply cannot
+        # derive any of their expanded check-run names. Do not force any
+        # specific name-based requirement -- ANNEX_WORKFLOW_NAME (still
+        # captured above) covers it via the workflow-wide scan below instead.
+        log "gate (a): repo_lint_local.yml annex present at $HEAD_SHA_FOR_ANNEX but every job is matrix-strategy (skipped) — its expanded check-run name(s) cannot be derived, so no specific check is force-required for it; its workflow ($ANNEX_WORKFLOW_NAME) is still scanned for any reported failure (#655)."
+      else
+        ANNEX_CHECKS_JSON="$annex_jobs"
+        log "gate (a): repo_lint_local.yml annex present at $HEAD_SHA_FOR_ANNEX (#655) — check run(s): $(echo "$ANNEX_CHECKS_JSON" | jq -r '[.[].name] | join(" ")')"
+      fi
+    fi
+  elif grep -q 'HTTP 404' "$annex_probe_err"; then
+    ANNEX_CONFIRMED_ABSENT=1 # genuinely absent (confirmed 404) — no annex, ANNEX_CHECKS_JSON stays [].
+  elif grep -q 'HTTP 403' "$annex_probe_err"; then
+    # #655 Codex P2 round 4: a 403 (token lacks Contents: read) is USUALLY a
+    # persistent, systemic condition, not a transient blip -- unlike the
+    # other-error branch below. Forcing a synthetic repo-lint-local
+    # REQUIREMENT here would inject a check name that can NEVER exist on
+    # THIS repo (the same 403 recurs on every future evaluation too),
+    # permanently blocking Phase 4 label-clearing and merge-gate checks on
+    # every PR, not just ones with an actual annex. Do not force a
+    # requirement; warn loudly so the token's scope gets fixed instead of
+    # masking the gap.
+    #
+    # #655 Codex P1 round 10 ("fail closed when the annex probe is
+    # unauthorized"): a 403 previously left BOTH the required-name filter
+    # and the workflow-wide scan blind to a red repo-lint-local outside
+    # branch protection, silently passing gate (a) regardless of the
+    # annex's real state. ANNEX_WORKFLOW_NAME stays empty here (we still
+    # cannot know the real workflow identity without Contents: read), but
+    # the conventional-name fallback scan further down now still catches a
+    # REPORTED bad conclusion under the literal name "repo-lint-local" --
+    # without requiring its presence, so a persistent 403 still cannot
+    # deadlock the gate the way a forced requirement would.
+    log "gate (a): WARNING — repo_lint_local.yml probe at $HEAD_SHA_FOR_ANNEX got HTTP 403 (token likely lacks Contents: read) — not forcing a requirement (a persistent 403 would make it unresolvable on every future PR too), but still scanning for a reported repo-lint-local failure by conventional name (#655). Grant the merge-gate token Contents: read to restore full annex enforcement."
+  else
+    # An indeterminate but plausibly-transient read failure (rate limit,
+    # 5xx, network) must not be treated the same as a confirmed absence --
+    # this is likely to resolve on the next gate evaluation (this script
+    # runs on every relevant event plus a 5-minute sweep). The
+    # conventional-name fallback scan further down covers this case too.
+    log "gate (a): WARNING — could not determine whether repo_lint_local.yml exists at $HEAD_SHA_FOR_ANNEX (API error, not a confirmed 404) — scanning for a reported repo-lint-local failure by conventional name in the meantime (#655)."
+  fi
+  rm -f "$annex_probe_err"
+fi
 
 # statusCheckRollup mixes two entry types:
 #   - CheckRun (GitHub Actions jobs): uses .name, .workflowName,
@@ -685,13 +1245,31 @@ if [ "$protection_readable" -eq 0 ]; then
   REQUIRED_JSON='[]'
 elif [ -z "$REQUIRED_CHECK_NAMES" ]; then
   # Read succeeded; branch protection lists NO required checks (404 or empty
-  # contexts). Nothing to enforce — gate (a) imposes no required-check
-  # filter (the other gates still run).
-  log "gate (a): branch protection for $BASE_BRANCH lists no required checks; gate (a) imposes no required-check filter."
+  # contexts). Nothing to enforce for any OTHER check — gate (a) imposes no
+  # required-check filter (the other gates still run). The repo_lint_local.yml
+  # annex (#601), when present, is enforced independently below via the
+  # workflow-wide ANNEX_WORKFLOW_BAD scan reading ANNEX_SCAN_ROLLUP_JSON (a
+  # copy frozen BEFORE this branch's own wipe, #655 round 7) -- so wiping
+  # ROLLUP_JSON here unconditionally does NOT hide the annex the way it used
+  # to before that scan existed (#655 round 1's original problem).
+  log "gate (a): branch protection for $BASE_BRANCH lists no required checks; gate (a) imposes no required-check filter beyond the independent annex workflow-wide scan."
   ROLLUP_JSON='{"statusCheckRollup":[]}'
   REQUIRED_JSON='[]'
 else
-  # Build a jq array of required check names.
+  # #655 Codex P2 round 10 ("preserve workflow identity for annex
+  # checks"): earlier rounds merged the annex's derived bare NAME(s) into
+  # this required-name list so a red or missing annex check would not be
+  # silently excluded from gate (a) when branch protection already
+  # requires some other checks. That merge is name-only (no workflow
+  # disambiguation), so a consumer whose annex job happens to share a bare
+  # name with an unrelated, non-required check from a DIFFERENT workflow
+  # (e.g. both are called "test") would make that unrelated check
+  # mandatory too -- a failing unrelated "test" could block gate (a) even
+  # with a fully green annex. The annex is independently and safely
+  # enforced below via ANNEX_WORKFLOW_BAD, which matches by .workflowName
+  # rather than by name, so it cannot be confused by a same-named
+  # unrelated check. No annex-name merge is needed here any more; only
+  # branch protection's own required names apply to this filter.
   REQUIRED_JSON=$(echo "$REQUIRED_CHECK_NAMES" | jq -R . | jq -s .)
 fi
 
@@ -737,6 +1315,161 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:
   ]
 ')
 
+# #655 (Codex P2 round 5): rather than inventing a synthetic MISSING
+# requirement for a derived check name that has not reported (rounds 2-4's
+# approach, removed above), which repeated review rounds found ways to turn
+# into a permanent deadlock (a 403 that recurs on every future PR, an
+# all-matrix annex whose unexpanded name will never exist, a path-filtered
+# annex that legitimately never runs for a given PR's diff), scan the
+# rollup for any REPORTED entry belonging to the annex's own workflow
+# (matched by .workflowName, not by a specific check name) and union any
+# non-green one into BAD_CHECKS directly, bypassing the required-name
+# filter above entirely. This also catches a failing matrix-expanded leg
+# (#655 round 5) without needing to reconstruct its expanded name: matrix
+# jobs are excluded from the name-based requirement above, but their
+# REPORTED check-runs still carry the annex's own workflow name. An annex
+# that has not reported ANYTHING yet for this workflow is NOT treated as
+# blocking -- narrower than the removed MISSING-injection, but this gate
+# re-evaluates on every relevant event plus a 5-minute sweep, so a brief
+# "hasn't started yet" window self-resolves on the next evaluation; unlike
+# the failure modes above, it never turns into a permanent block.
+#
+# A still-IN_PROGRESS entry is deliberately INCLUDED, not filtered out: its
+# .conclusion is empty (result=="" falls through to "not SUCCESS/SKIPPED/
+# NEUTRAL"), so a running-but-unfinished annex job counts as not-yet-clear
+# here, same as the canonical required-check filter above already treats an
+# in-progress entry. This is intentional (#655 Codex P1 round 6, "wait for
+# annex checks before clearing the label"): once the annex workflow has
+# actually appeared in the rollup (queued or running), gate (a) must not
+# report clean until it finishes, so a fast-completing sibling workflow
+# (e.g. the canonical lint/review-policy checks) cannot let
+# auto-clear-blocking-labels.yml clear needs-external-review while the
+# slower local annex is still in flight and might yet fail.
+#
+# #655 Codex P2 round 8 ("wait for unreported unfiltered annex checks"):
+# the gap the paragraph above does NOT close is zero rollup entries at
+# all (the annex workflow has not been SCHEDULED yet) -- previously
+# indistinguishable from a path-filtered annex that will never run for
+# this diff. ANNEX_UNFILTERED (derived from the annex's pull_request
+# trigger having no paths/paths-ignore filter) now resolves that
+# ambiguity: when unfiltered, the annex is GUARANTEED to eventually
+# report, so zero entries means "not yet", not "never" -- treated as not
+# yet clean via a synthetic PENDING entry, exactly like an in-progress
+# one above. A path-filtered (or classification-unknown) annex with zero
+# entries is still non-blocking, preserving round 5/6's fix for that case.
+if [ -n "$ANNEX_WORKFLOW_NAME" ]; then
+  # #655 Codex P2 round 13 ("disambiguate annex workflows beyond display
+  # name"): the annex contract lets a consumer set any top-level workflow
+  # `name:`, so matching on .workflowName risks either masking the real
+  # annex behind an unrelated same-named workflow (false clean) or blocking
+  # on an unrelated same-named workflow's failure (false red). .workflowPath
+  # (added to ROLLUP_JSON above, round 13) is derived from the
+  # GraphQL-reported resourcePath of the workflow FILE itself, not its
+  # freely-editable display name, so match on the known, fixed annex
+  # filename instead. A StatusContext (no checkSuite at all) safely
+  # resolves workflowPath to "" and can never collide with this literal.
+  ANNEX_WORKFLOW_MATCHES=$(echo "$ANNEX_SCAN_ROLLUP_JSON" | jq --arg workflow_path "repo_lint_local.yml" '
+    [.statusCheckRollup[] | select((.workflowPath // "") == $workflow_path)]
+  ')
+  ANNEX_WORKFLOW_MATCH_COUNT=$(echo "$ANNEX_WORKFLOW_MATCHES" | jq 'length')
+  if [ "$ANNEX_WORKFLOW_MATCH_COUNT" -eq 0 ] && [ "$ANNEX_UNFILTERED" = "true" ]; then
+    log "gate (a): repo_lint_local.yml annex workflow ($ANNEX_WORKFLOW_NAME) has an unfiltered pull_request trigger but has not reported anything yet for $HEAD_SHA_FOR_ANNEX (#655 round 8) — treating as not-yet-clean rather than silently passing, since it is guaranteed to eventually run."
+    BAD_CHECKS=$(echo "$BAD_CHECKS" | jq --arg workflow "$ANNEX_WORKFLOW_NAME" '(. + [{label: "(not yet reported)", workflow: $workflow, result: "PENDING"}]) | unique')
+  else
+    # #655 Codex P2 round 13 ("ignore stale annex runs after a green
+    # rerun"): the annex's own workflow can legitimately report more than
+    # one entry per job name for the same head SHA -- a failed
+    # push-triggered attempt followed by a successful pull_request
+    # attempt, or a failed job manually rerun to a later success. Without
+    # grouping, an old superseded FAILURE never leaves the rollup and
+    # would block gate (a) forever even after the same-named job goes
+    # green. Group matches by check name and pick one winner per name
+    # before judging bad-ness, mirroring the exact pending-preferred /
+    # else-latest-completed rule agent-review.yml's required-check wait
+    # loop already uses (#655 round 5) -- a still-non-terminal entry in a
+    # name's group always wins over any completed sibling regardless of
+    # timestamps (an empty startedAt/completedAt on a freshly-queued rerun
+    # must not be outranked by an older completed one), and only when
+    # every entry in the group is terminal does the latest-completed one
+    # (by completedAt, falling back to startedAt) win.
+    ANNEX_WORKFLOW_BAD=$(echo "$ANNEX_WORKFLOW_MATCHES" | jq '
+      group_by(.name // .context // "?")
+      | [
+          .[]
+          | (map(select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end))) as $pending
+          | if ($pending | length) > 0
+            then $pending[0]
+            else (sort_by(.completedAt // .startedAt // "") | last)
+            end
+        ] as $winners
+      | [$winners[]
+          | {
+              label: (.name // .context // "?"),
+              workflow: (.workflowName // ""),
+              result: (.conclusion // .state // "")
+            }
+          | select((.result != "SUCCESS") and (.result != "SKIPPED") and (.result != "NEUTRAL"))
+        ]
+    ')
+    ANNEX_WORKFLOW_BAD_COUNT=$(echo "$ANNEX_WORKFLOW_BAD" | jq 'length')
+    if [ "$ANNEX_WORKFLOW_BAD_COUNT" -gt 0 ]; then
+      log "gate (a): repo_lint_local.yml annex workflow ($ANNEX_WORKFLOW_NAME) has $ANNEX_WORKFLOW_BAD_COUNT non-passing reported check-run(s) after winner-selection (#655) — included below regardless of required-name scoping."
+      BAD_CHECKS=$(echo "$BAD_CHECKS" | jq --argjson extra "$ANNEX_WORKFLOW_BAD" '(. + $extra) | unique')
+    fi
+  fi
+else
+  if [ "$ANNEX_CONFIRMED_ABSENT" -eq 1 ]; then
+    log "gate (a): repo_lint_local.yml annex is confirmed absent at $HEAD_SHA_FOR_ANNEX; skipping the conventional repo-lint-local fallback scan (#655)."
+  else
+    # #655 Codex P1 round 10 ("fail closed when the annex probe is
+    # unauthorized"): ANNEX_WORKFLOW_NAME is empty here -- the probe
+    # either got a 403 (no Contents: read), a genuinely-unparseable annex,
+    # or an indeterminate error, so the REAL workflow identity is unknown
+    # and the workflow-wide scan above cannot run. Fall back to scanning
+    # for the conventional job/check name #601 documents by default
+    # ("repo-lint-local") directly by NAME rather than by workflow, since
+    # that is the only identity we can guess in these cases. Never blocks
+    # on absence (only a REPORTED bad conclusion), so a persistent 403 or
+    # a permanently-unparseable annex still cannot deadlock this gate the
+    # way requiring its presence would -- this only closes the narrower
+    # gap of an annex that already reports under the exact conventional
+    # name while we cannot confirm anything more precise.
+    #
+    # #655 Codex P2 round 13: this fallback has the same stale-vs-fresh
+    # rerun exposure the workflow-wide scan above just fixed (a name match
+    # alone doesn't dedupe multiple reported attempts), so apply the same
+    # group-by-name, pending-preferred-else-latest-completed winner
+    # selection here too -- there is exactly one possible name group
+    # ("repo-lint-local", enforced by the select() below) but group_by
+    # still resolves the zero-matches case to an empty array with no extra
+    # branching.
+    ANNEX_NAME_FALLBACK_BAD=$(echo "$ANNEX_SCAN_ROLLUP_JSON" | jq '
+      [.statusCheckRollup[] | select((.name // .context // "") == "repo-lint-local")]
+      | group_by(.name // .context // "?")
+      | [
+          .[]
+          | (map(select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end))) as $pending
+          | if ($pending | length) > 0
+            then $pending[0]
+            else (sort_by(.completedAt // .startedAt // "") | last)
+            end
+        ] as $winners
+      | [$winners[]
+          | {
+              label: (.name // .context // "?"),
+              workflow: (.workflowName // ""),
+              result: (.conclusion // .state // "")
+            }
+          | select((.result != "SUCCESS") and (.result != "SKIPPED") and (.result != "NEUTRAL"))
+        ]
+    ')
+    ANNEX_NAME_FALLBACK_BAD_COUNT=$(echo "$ANNEX_NAME_FALLBACK_BAD" | jq 'length')
+    if [ "$ANNEX_NAME_FALLBACK_BAD_COUNT" -gt 0 ]; then
+      log "gate (a): a check named repo-lint-local has $ANNEX_NAME_FALLBACK_BAD_COUNT non-passing reported result(s), and the annex probe could not confirm a workflow identity to scan more precisely (403/unparseable/error) — included below as a conventional-name fallback (#655 round 10)."
+      BAD_CHECKS=$(echo "$BAD_CHECKS" | jq --argjson extra "$ANNEX_NAME_FALLBACK_BAD" '(. + $extra) | unique')
+    fi
+  fi
+fi
 BAD_COUNT=$(echo "$BAD_CHECKS" | jq 'length')
 
 if [ "$BAD_COUNT" -gt 0 ]; then

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -46,8 +46,10 @@
 #      the trigger is posted, never WHETHER Codex participates.
 #   1. Reads codex.review_timeout_seconds, codex.ack_wait_seconds,
 #      codex.max_ack_retries, and codex.bot_login from
-#      .github/review-policy.yml (defaults: 600 / 60 / 1 /
-#      chatgpt-codex-connector[bot]).
+#      .github/review-policy.yml (defaults: 840 / 30 / 1 /
+#      chatgpt-codex-connector[bot]; the 840s review_timeout and 30s
+#      ack_wait are measured retunes — see #623 and the per-constant
+#      comments below).
 #   2. Fetches the PR's current HEAD commit SHA and committer date. Any
 #      Codex review is only considered "current" if it is anchored on
 #      this commit (commit_id == HEAD_SHA). Any Codex +1 reaction is
@@ -284,8 +286,21 @@ policy_top_field() {
 AUTHOR_IDENTITY=$(policy_top_field author_identity)
 AUTHOR_IDENTITY=${AUTHOR_IDENTITY:-nathanjohnpayne}
 
+# review_timeout_seconds: foreground poll budget for a Codex terminal signal
+# on HEAD. Default 840s is measured, not folklore (#623): the trigger→verdict
+# distribution is p50 217s / p90 426s / p99 630s / max 830s (n=100), and the
+# 👍-clearance endpoint this poll also breaks on is p99 829s (n=60, #646) —
+# both from the committed extract docs/audits/data/codex-latency-2026-07/. The
+# prior 600s sat BELOW p99(verdict)=630s, so the slowest ~1% of clean rounds
+# (and the 830s max) timed out and routed to Phase 4b needlessly. 840s
+# (= 56 × the 15s POLL_INTERVAL, so the final poll lands exactly on the
+# deadline) covers the full observed clean-verdict tail and stays under the
+# 900s phase-4b adapter ceiling. It is deliberately NOT sized to the
+# dropped/rate-limited non-response tail (~19–21% of triggers, #570): that is
+# not a slow verdict and no foreground wait can catch it — --trigger-only +
+# event-driven pickup remains its escape path (#489).
 TIMEOUT_SECONDS=$(codex_field review_timeout_seconds)
-TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-600}
+TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-840}
 if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "ERROR: codex.review_timeout_seconds must be an integer; got '$TIMEOUT_SECONDS'" >&2
   exit 3
@@ -388,8 +403,16 @@ if ! [[ "$REACTION_FRESHNESS_SECONDS" =~ ^[0-9]+$ ]]; then
   exit 3
 fi
 
+# ack_wait_seconds: the 👀 eyes-ack window (#419). Default 30s aligned to the
+# shipped policy value (#647) from the measured ack latency (#623): healthy
+# acks land in p50 9s / p99 13s / max 13s (n=14, the full recorded ack
+# corpus), so 30s is ~2.3× p99 — it clears every observed healthy ack with
+# margin yet fails over fast on a dropped/rate-limited trigger. The measurement
+# sizes the WINDOW; the retry COUNT (max_ack_retries) is unchanged, so the full
+# failover budget is 30s × (1 + max_ack_retries) = 60s, halved from the prior
+# 60s × 2 = 120s. Was 60s folklore.
 ACK_WAIT_SECONDS=$(codex_field ack_wait_seconds)
-ACK_WAIT_SECONDS=${ACK_WAIT_SECONDS:-60}
+ACK_WAIT_SECONDS=${ACK_WAIT_SECONDS:-30}
 if ! [[ "$ACK_WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "ERROR: codex.ack_wait_seconds must be an integer; got '$ACK_WAIT_SECONDS'" >&2
   exit 3

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1874,6 +1874,31 @@ INLINE_GH_AS_AUTHOR_IDENTITY_SET=0
 INLINE_GH_AS_REVIEWER_IDENTITY_SET=0
 STANDALONE_GH_AS_AUTHOR_IDENTITY_SET=0
 STANDALONE_GH_AS_REVIEWER_IDENTITY_SET=0
+# Inline MERGEPATH_AGENT prefix (#671). The reviewer wrapper resolves its
+# identity via GH_AS_REVIEWER_IDENTITY, then nathanpayne-$MERGEPATH_AGENT,
+# then its hardcoded default — and the documented cross-agent approval
+# form passes MERGEPATH_AGENT as a same-segment prefix assignment
+# (MERGEPATH_AGENT=codex scripts/gh-as-reviewer.sh -- gh pr review
+# --approve ...). The self-approve sub-guard must resolve the reviewer the
+# same way the wrapper will, so the DEFINITELY-effective inline prefix is
+# captured here. Standalone / export / eval MERGEPATH_AGENT assignments
+# are deliberately NOT modeled: an unmodeled form falls back to the
+# hook-environment chain (env MERGEPATH_AGENT, then OP_PREFLIGHT_AGENT,
+# then the hardcoded default). For the documented workflows that residual
+# is a false BLOCK (fail closed); a false allow requires a deliberately
+# adversarial compound (e.g. a standalone export of the authoring agent in
+# the same command), which stays out of scope per this hook's best-effort
+# tokenizer posture (#619) — and the wrapper itself still token-verifies
+# whatever identity it actually resolves.
+INLINE_MERGEPATH_AGENT=""
+INLINE_MERGEPATH_AGENT_SET=0
+# OP_PREFLIGHT_AGENT — the wrapper chain's third link — gets the same
+# inline capture and unset tracking (#679 round 2): the approve sub-guard
+# reads the hook environment for it, so an `env -u OP_PREFLIGHT_AGENT` or
+# inline override on the command must be modeled or the sub-guard would
+# trust a stale environment value the wrapper will not see.
+INLINE_OP_PREFLIGHT_AGENT=""
+INLINE_OP_PREFLIGHT_AGENT_SET=0
 GLOBAL_REPO=""
 PR_SUBCOMMAND=""
 PR_SUBCOMMAND_INDEX=-1    # index in TOKENS where the gh pr subcommand was found
@@ -2027,6 +2052,14 @@ for i in "${!TOKENS[@]}"; do
           INLINE_GH_AS_REVIEWER_IDENTITY=""
           INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
           ;;
+        MERGEPATH_AGENT)
+          INLINE_MERGEPATH_AGENT=""
+          INLINE_MERGEPATH_AGENT_SET=1
+          ;;
+        OP_PREFLIGHT_AGENT)
+          INLINE_OP_PREFLIGHT_AGENT=""
+          INLINE_OP_PREFLIGHT_AGENT_SET=1
+          ;;
       esac
     fi
     PENDING_PREFIX_FLAG=""
@@ -2111,6 +2144,14 @@ for i in "${!TOKENS[@]}"; do
       INLINE_GH_AS_REVIEWER_IDENTITY=""
       INLINE_GH_AS_AUTHOR_IDENTITY_SET=0
       INLINE_GH_AS_REVIEWER_IDENTITY_SET=0
+      # MERGEPATH_AGENT / OP_PREFLIGHT_AGENT are reset unconditionally:
+      # only a same-segment prefix (definitely in the wrapper's
+      # environment) is honored by the self-approve sub-guard; a
+      # standalone assignment falls back to the env/default chain (#671).
+      INLINE_MERGEPATH_AGENT=""
+      INLINE_MERGEPATH_AGENT_SET=0
+      INLINE_OP_PREFLIGHT_AGENT=""
+      INLINE_OP_PREFLIGHT_AGENT_SET=0
       SEGMENT_HAS_COMMAND=0
       continue
       ;;
@@ -2138,10 +2179,63 @@ for i in "${!TOKENS[@]}"; do
       GH_AS_AUTHOR_IDENTITY=*)
         INLINE_GH_AS_AUTHOR_IDENTITY="${tok#GH_AS_AUTHOR_IDENTITY=}"
         INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
+        # Append an adjacent placeholder (see the MERGEPATH_AGENT arm
+        # below): a dynamic identity value must reach the byline candidate
+        # model as UNVERIFIABLE, not as its empty/literal prefix, or the
+        # candidate falls back while the wrapper uses the substituted
+        # identity (#679 round-2 P1 class).
+        case "${TOKENS[$((i+1))]:-}" in
+          __MERGEPATH_CMDSUB__|__MERGEPATH_CMDSUB_LITERAL__)
+            INLINE_GH_AS_AUTHOR_IDENTITY="${INLINE_GH_AS_AUTHOR_IDENTITY}${TOKENS[$((i+1))]}"
+            ;;
+        esac
         ;;
       GH_AS_REVIEWER_IDENTITY=*)
         INLINE_GH_AS_REVIEWER_IDENTITY="${tok#GH_AS_REVIEWER_IDENTITY=}"
         INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+        # Same placeholder capture as the author arm: with an empty
+        # capture, GH_AS_REVIEWER_IDENTITY=$(...) MERGEPATH_AGENT=codex
+        # resolved as a codex approval while the wrapper would use the
+        # substituted (higher-priority) identity — a same-agent approval
+        # could post on a claude-authored PR (#679 round-2 P1). Recording
+        # the placeholder makes the consistency loop compare it against
+        # the expected reviewer and fail closed.
+        case "${TOKENS[$((i+1))]:-}" in
+          __MERGEPATH_CMDSUB__|__MERGEPATH_CMDSUB_LITERAL__)
+            INLINE_GH_AS_REVIEWER_IDENTITY="${INLINE_GH_AS_REVIEWER_IDENTITY}${TOKENS[$((i+1))]}"
+            ;;
+        esac
+        ;;
+      MERGEPATH_AGENT=*)
+        INLINE_MERGEPATH_AGENT="${tok#MERGEPATH_AGENT=}"
+        INLINE_MERGEPATH_AGENT_SET=1
+        # A flattened $(...) in the assignment splits into this token plus
+        # an adjacent placeholder token: MERGEPATH_AGENT=$(x) arrives as an
+        # EMPTY assignment + placeholder (the #611 r9 tokenization), and an
+        # embedded form (MERGEPATH_AGENT=cla$(x)e) arrives as the literal
+        # prefix + placeholder (#679 round-2 P1). Either way the real value
+        # is dynamic, so record the placeholder INTO the capture —
+        # appended, not only on empty — and the approve sub-guard fails
+        # closed on it instead of trusting the literal prefix or falling
+        # through to the env/default chain (#679 review P2).
+        case "${TOKENS[$((i+1))]:-}" in
+          __MERGEPATH_CMDSUB__|__MERGEPATH_CMDSUB_LITERAL__)
+            INLINE_MERGEPATH_AGENT="${INLINE_MERGEPATH_AGENT}${TOKENS[$((i+1))]}"
+            ;;
+        esac
+        ;;
+      OP_PREFLIGHT_AGENT=*)
+        INLINE_OP_PREFLIGHT_AGENT="${tok#OP_PREFLIGHT_AGENT=}"
+        INLINE_OP_PREFLIGHT_AGENT_SET=1
+        # Same capture posture as MERGEPATH_AGENT: the wrapper chain's
+        # third link reads OP_PREFLIGHT_AGENT from its environment, so an
+        # inline prefix is definitely effective and a dynamic value is
+        # unverifiable (#679 round-2 P1).
+        case "${TOKENS[$((i+1))]:-}" in
+          __MERGEPATH_CMDSUB__|__MERGEPATH_CMDSUB_LITERAL__)
+            INLINE_OP_PREFLIGHT_AGENT="${INLINE_OP_PREFLIGHT_AGENT}${TOKENS[$((i+1))]}"
+            ;;
+        esac
         ;;
     esac
   fi
@@ -2256,7 +2350,35 @@ for i in "${!TOKENS[@]}"; do
       continue
       ;;
     [A-Za-z_]*=*)
-      # Env assignment. Stay in command position.
+      # Env assignment. Stay in command position. A PLACEHOLDER adjacent
+      # to a NON-EMPTY assignment value is the flattened remainder of an
+      # embedded substitution — FOO=a$(x)b splits into FOO=a, the
+      # placeholder, and b (#679 round 2). The walk cannot know where the
+      # assignment's fragments end, so the placeholder would land in
+      # command position, the REAL command would be classified as
+      # unrelated-command args, and a following guarded gh write would
+      # escape scanning entirely (verified: FOO=a$(x)b gh pr merge was
+      # allowed). Fail closed when this segment goes on to run gh or a
+      # write wrapper; otherwise consume the placeholder like the bare
+      # NAME= arm above and keep walking.
+      case "${TOKENS[$((i+1))]:-}" in
+        __MERGEPATH_CMDSUB__|__MERGEPATH_CMDSUB_LITERAL__)
+          LOOKAHEAD_K=$((i + 2))
+          while [ "$LOOKAHEAD_K" -lt "${#TOKENS[@]}" ]; do
+            LOOKAHEAD_TOK="${TOKENS[$LOOKAHEAD_K]}"
+            case "$LOOKAHEAD_TOK" in
+              "&&"|"||"|";"|"|"|"|&"|"&"|"("|")") break ;;
+              gh|*/gh) block_cmdsub_in_gh_stream ;;
+            esac
+            if is_any_wrapper_named_token "$LOOKAHEAD_TOK"; then
+              block_cmdsub_in_gh_stream
+            fi
+            LOOKAHEAD_K=$((LOOKAHEAD_K + 1))
+          done
+          SKIP_PREFIX_VALUE=1
+          PENDING_PREFIX_FLAG=""
+          ;;
+      esac
       continue
       ;;
     sudo|eval|time|nohup|env|command|exec|nice|ionice)
@@ -2325,11 +2447,25 @@ for i in "${!TOKENS[@]}"; do
             INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
             continue
             ;;
+          --unset=MERGEPATH_AGENT|-u=MERGEPATH_AGENT|-uMERGEPATH_AGENT)
+            INLINE_MERGEPATH_AGENT=""
+            INLINE_MERGEPATH_AGENT_SET=1
+            continue
+            ;;
+          --unset=OP_PREFLIGHT_AGENT|-u=OP_PREFLIGHT_AGENT|-uOP_PREFLIGHT_AGENT)
+            INLINE_OP_PREFLIGHT_AGENT=""
+            INLINE_OP_PREFLIGHT_AGENT_SET=1
+            continue
+            ;;
           -i|--ignore-environment)
             INLINE_GH_AS_AUTHOR_IDENTITY=""
             INLINE_GH_AS_AUTHOR_IDENTITY_SET=1
             INLINE_GH_AS_REVIEWER_IDENTITY=""
             INLINE_GH_AS_REVIEWER_IDENTITY_SET=1
+            INLINE_MERGEPATH_AGENT=""
+            INLINE_MERGEPATH_AGENT_SET=1
+            INLINE_OP_PREFLIGHT_AGENT=""
+            INLINE_OP_PREFLIGHT_AGENT_SET=1
             # env -i clears EVERYTHING the wrapper would see —
             # including MERGEPATH_AGENT — so the reviewer fallback
             # must be the wrapper's bare hardcoded default, not the
@@ -2623,7 +2759,13 @@ fi
 # them, per REVIEW_POLICY.md § No-self-approve scoping. The hook
 # detects:
 #   - PR_SUBCOMMAND=review with --approve in the args
-#   - reviewer wrapper identity = nathanpayne-<agent>
+#   - reviewer wrapper identity = nathanpayne-<agent>, resolved the same
+#     way the wrapper itself will (gh_default_reviewer_identity in
+#     scripts/lib/gh-token-resolver.sh): GH_AS_REVIEWER_IDENTITY first,
+#     then nathanpayne-$MERGEPATH_AGENT, then
+#     nathanpayne-$OP_PREFLIGHT_AGENT, then the hardcoded default —
+#     preferring the inline same-segment assignment captured from this
+#     command over the hook environment at each link (#671)
 #   - PR body contains `Authoring-Agent: <agent>` matching the same
 #     agent suffix
 #   - PR is over-threshold (determined from .github/review-policy.yml
@@ -2688,7 +2830,90 @@ if [ "$PR_SUBCOMMAND" = "review" ]; then
   fi
 
   if [ "$REVIEW_APPROVE" -eq 1 ] && [ "${BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
-    REVIEWER_FOR_APPROVE="${WRAPPER_REVIEWER_IDENTITY:-}"
+    # Resolve the reviewer identity the WRAPPER will actually run under —
+    # the same chain gh_default_reviewer_identity() walks:
+    # GH_AS_REVIEWER_IDENTITY, then nathanpayne-$MERGEPATH_AGENT, then
+    # nathanpayne-$OP_PREFLIGHT_AGENT, then the hardcoded default. The
+    # previous resolution reused the consistency-loop candidate, which
+    # never honors an inline MERGEPATH_AGENT=<agent> prefix, so a
+    # legitimate cross-agent approval (MERGEPATH_AGENT=codex
+    # scripts/gh-as-reviewer.sh -- gh pr review --approve on a
+    # claude-authored PR — the Operation-to-Identity Matrix row for that
+    # case) was mis-resolved to the session default agent and blocked as
+    # self-approve (#671, observed on PR #663).
+    REVIEWER_FOR_APPROVE=""
+    if [ "$WRAPPER_KIND" = "reviewer" ]; then
+      if [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 1 ] && [ -n "$INLINE_GH_AS_REVIEWER_IDENTITY" ]; then
+        REVIEWER_FOR_APPROVE="$INLINE_GH_AS_REVIEWER_IDENTITY"
+      elif [ "$INLINE_GH_AS_REVIEWER_IDENTITY_SET" -eq 0 ] && [ -n "${GH_AS_REVIEWER_IDENTITY:-}" ] \
+           && [ "$IDENTITY_ENV_CLEARED_FOR_WRAPPER" -eq 0 ]; then
+        REVIEWER_FOR_APPROVE="$GH_AS_REVIEWER_IDENTITY"
+      elif [ "$INLINE_MERGEPATH_AGENT_SET" -eq 1 ] && [ -n "$INLINE_MERGEPATH_AGENT" ]; then
+        # Validate only when the inline value actually decides resolution:
+        # an explicit GH_AS_REVIEWER_IDENTITY above wins in the wrapper
+        # before MERGEPATH_AGENT is ever read, so a malformed agent value
+        # must not block a deterministic explicit approval (#679 review
+        # P3). Reaching this link with a value the hook cannot map to a
+        # literal identity — a command-substitution remnant or a non-slug
+        # string — fails closed: the wrapper might resolve it to ANY
+        # identity, including the authoring agent, so the sub-guard must
+        # not guess.
+        case "$INLINE_MERGEPATH_AGENT" in
+          *__MERGEPATH_CMDSUB__*|*__MERGEPATH_CMDSUB_LITERAL__*)
+            echo "BLOCKED: unverifiable inline MERGEPATH_AGENT on a gh pr review --approve." >&2
+            echo "  A \$(...) or backtick value cannot be identity-checked by the hook, and the" >&2
+            echo "  self-approve sub-guard must know which reviewer the wrapper will run under (#671)." >&2
+            echo "  Use a literal agent name: MERGEPATH_AGENT=codex scripts/gh-as-reviewer.sh -- gh pr review ..." >&2
+            exit 2
+            ;;
+          *[!A-Za-z0-9_-]*)
+            echo "BLOCKED: inline MERGEPATH_AGENT is not a plain agent slug; cannot resolve the" >&2
+            echo "  reviewer identity for the self-approve check (#671). Use a literal agent name." >&2
+            exit 2
+            ;;
+        esac
+        REVIEWER_FOR_APPROVE="nathanpayne-$INLINE_MERGEPATH_AGENT"
+      elif [ "$INLINE_MERGEPATH_AGENT_SET" -eq 0 ] && [ -n "${MERGEPATH_AGENT:-}" ] \
+           && [ "$IDENTITY_ENV_CLEARED_FOR_WRAPPER" -eq 0 ]; then
+        REVIEWER_FOR_APPROVE="nathanpayne-$MERGEPATH_AGENT"
+      elif [ "$INLINE_OP_PREFLIGHT_AGENT_SET" -eq 1 ] && [ -n "$INLINE_OP_PREFLIGHT_AGENT" ]; then
+        # Inline OP_PREFLIGHT_AGENT prefix: definitely in the wrapper's
+        # environment, same validation posture as the MERGEPATH_AGENT
+        # link above (#679 round 2).
+        case "$INLINE_OP_PREFLIGHT_AGENT" in
+          *__MERGEPATH_CMDSUB__*|*__MERGEPATH_CMDSUB_LITERAL__*)
+            echo "BLOCKED: unverifiable inline OP_PREFLIGHT_AGENT on a gh pr review --approve." >&2
+            echo "  A \$(...) or backtick value cannot be identity-checked by the hook (#671)." >&2
+            exit 2
+            ;;
+          *[!A-Za-z0-9_-]*)
+            echo "BLOCKED: inline OP_PREFLIGHT_AGENT is not a plain agent slug; cannot resolve the" >&2
+            echo "  reviewer identity for the self-approve check (#671). Use a literal agent name." >&2
+            exit 2
+            ;;
+        esac
+        REVIEWER_FOR_APPROVE="nathanpayne-$INLINE_OP_PREFLIGHT_AGENT"
+      elif [ "$INLINE_OP_PREFLIGHT_AGENT_SET" -eq 0 ] && [ -n "${OP_PREFLIGHT_AGENT:-}" ] \
+           && [ "$IDENTITY_ENV_CLEARED_FOR_WRAPPER" -eq 0 ]; then
+        # The wrapper chain's third link (#679 review P1): a session
+        # warmed with op-preflight --agent <agent> exports
+        # OP_PREFLIGHT_AGENT, and gh-as-reviewer.sh resolves
+        # nathanpayne-$OP_PREFLIGHT_AGENT when neither
+        # GH_AS_REVIEWER_IDENTITY nor MERGEPATH_AGENT is set. Skipping
+        # this link and bottoming out at the claude default would FAIL
+        # OPEN on a non-claude session: an over-threshold
+        # Authoring-Agent: cursor PR approved from a cursor-preflight
+        # session would compare cursor against claude, pass, and let the
+        # wrapper post the same-agent approval this guard exists to block.
+        # The SET=0 gate covers the converse (#679 round 2): when the
+        # command itself unsets or overrides OP_PREFLIGHT_AGENT (env -u /
+        # --unset / inline assignment), the hook environment value is
+        # stale for the wrapper and must not be trusted here.
+        REVIEWER_FOR_APPROVE="nathanpayne-$OP_PREFLIGHT_AGENT"
+      else
+        REVIEWER_FOR_APPROVE="nathanpayne-claude"
+      fi
+    fi
     REVIEWER_AGENT=""
     case "$REVIEWER_FOR_APPROVE" in
       nathanpayne-*) REVIEWER_AGENT="${REVIEWER_FOR_APPROVE#nathanpayne-}" ;;
@@ -2821,6 +3046,10 @@ if [ "$PR_SUBCOMMAND" = "review" ]; then
           echo "  a Phase 4 (over-threshold) PR from approving it. Post --comment instead, and let the" >&2
           echo "  cross-agent merge gate (Codex 👍 for Phase 4a, or external CLI APPROVED for Phase 4b)" >&2
           echo "  carry the approval." >&2
+          echo "" >&2
+          echo "  For a legitimate cross-agent approval, select the other reviewer identity the way" >&2
+          echo "  the wrapper resolves it (#671):" >&2
+          echo "    MERGEPATH_AGENT=<agent> scripts/gh-as-reviewer.sh -- gh pr review ... --approve" >&2
           echo "" >&2
           echo "  If this PR is actually under-threshold and the heuristic mis-classified it, set" >&2
           echo "  BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1 for the single call (the identity check" >&2

--- a/scripts/phase-4b-review.sh
+++ b/scripts/phase-4b-review.sh
@@ -31,6 +31,8 @@
 #   GH_TOKEN / op-preflight cache   reviewer-scoped token (auto-sourced).
 #   CODEX_BIN / CLAUDE_BIN          adapter CLI overrides (tests).
 #   P4B_GH_AS_REVIEWER              reviewer wrapper override (tests).
+#   P4B_GH_AS_AUTHOR                author wrapper override (tests) — used
+#                                   for the step-9 post-review issue writes.
 #   P4B_HANDOFF                     manual handoff renderer override (tests).
 #   P4B_ADAPTER_TIMEOUT_SECONDS     env override for the outer adapter-call
 #                                   timeout; default is resolved per-adapter
@@ -108,6 +110,10 @@ p4b_acct_mark_unposted() {
 ADAPTER_DIR="$ROOT/phase-4b/adapters"
 HANDOFF="${P4B_HANDOFF:-$ROOT/post-phase-4b-handoff.sh}"
 GH_AS_REVIEWER="${P4B_GH_AS_REVIEWER:-$ROOT/gh-as-reviewer.sh}"
+# Author wrapper for the step-9 issue writes (#672/#674): resolves AND
+# identity-verifies the author PAT before each write, replacing manual
+# token resolution (test override: P4B_GH_AS_AUTHOR).
+GH_AS_AUTHOR="${P4B_GH_AS_AUTHOR:-$ROOT/gh-as-author.sh}"
 # Outer adapter-call timeout. An explicit env override wins (tests/manual);
 # otherwise it is resolved per-adapter from policy after the reviewer is chosen
 # (see p4b_resolve_adapter_timeout). Captured here so the env override is not
@@ -362,8 +368,233 @@ TOKEN_COUNT="$(printf '%s' "$VERDICT_JSON" | jq -r '.usage.token_count // empty'
 USAGE_SOURCE="$(printf '%s' "$VERDICT_JSON" | jq -r '.usage.source // empty')"
 ADAPTER_RUNS=1
 
+# p4b_file_post_review_issues <verdict-json>
+# Policy step 9 executor (#672): one `post-review` + `observation` issue per
+# discretionary finding on an APPROVED verdict, filed in $REPO under the
+# AUTHOR identity and assigned to it. Writes go through gh-as-author.sh —
+# the wrapper resolves the author PAT (OP_PREFLIGHT_AUTHOR_PAT or keyring)
+# AND identity-verifies it before the write, which both satisfies the
+# no-bare-gh-writes contract and closes the wrong-identity risk from the
+# round-2 finding more strongly than manual token resolution did.
+# Prints TWO lines: line 1 = comma-separated `#N` references (reused +
+# created, for the review body), line 2 = the subset CREATED by this
+# invocation (for cleanup — a reused prior-run issue must never be closed
+# by this run's failure paths, #674 round-5 P2). ANY single failure —
+# wrapper/token verification, a missing label on the target repo, an API
+# error, or a DEDUP SEARCH error (#674 CodeRabbit Major: a swallowed search
+# failure would read as "no existing issue" and mint duplicates) — returns
+# non-zero so the caller refuses the approval (fail-closed: an APPROVED may
+# never post with its observations unfiled; that failure mode degrades
+# exactly to the pre-#672 refusal).
+p4b_file_post_review_issues() {
+  local vjson="$1" author_login refs="" created="" i total sev fpath fline fbody title bfile url existing
+  author_login="$(p4b_top_field author_identity)"; author_login="${author_login:-nathanjohnpayne}"
+  total="$(printf '%s' "$vjson" | jq -r '.findings | length')"
+  i=0
+  while [ "$i" -lt "$total" ]; do
+    sev="$(printf '%s' "$vjson" | jq -r --argjson i "$i" '.findings[$i].severity')"
+    fpath="$(printf '%s' "$vjson" | jq -r --argjson i "$i" '.findings[$i].path // "PR"')"
+    fline="$(printf '%s' "$vjson" | jq -r --argjson i "$i" '.findings[$i].line // empty')"
+    fbody="$(printf '%s' "$vjson" | jq -r --argjson i "$i" '.findings[$i].body')"
+    # Policy step 9 labels are `post-review` plus `observation` OR `risk`
+    # (#674 Codex P2): the verdict schema carries no risk flag, so classify
+    # by the reviewer's own wording — a finding that talks about risk files
+    # as one. Mislabels are trivially editable after the fact; the load-
+    # bearing part is that risk follow-ups stay visible to `risk`-keyed
+    # triage instead of being hard-coded observations.
+    kind="observation"
+    if printf '%s' "$fbody" | grep -qiE '(^|[^[:alpha:]])risk(s|y)?([^[:alpha:]]|$)'; then
+      kind="risk"
+    fi
+    # Rerun idempotency (#674 CodeRabbit): a mid-loop failure leaves earlier
+    # issues behind, and a straight rerun of the same verdict would file
+    # them again. Every issue body embeds a stable head-pinned marker, and
+    # the loop reuses a marker match instead of re-creating. Search-index
+    # lag can miss a JUST-created issue; the worst case is one duplicate —
+    # exactly the pre-marker status quo — never a lost filing. The marker
+    # keys on a CONTENT fingerprint, not the array index (#674 round-3 P2):
+    # a rerun that returns the same findings reordered or reworded must not
+    # bind an old issue to whatever now occupies the same slot — changed
+    # content mints a fresh issue (the superseded one stays open and
+    # visible, never silently rebound).
+    fp="$(printf '%s|%s|%s|%s' "$sev" "$fpath" "$fline" "$fbody" | cksum | cut -d' ' -f1)"
+    marker="p4b-post-review ${REPO}#${PR} head=${HEAD:-unknown} finding=${fp}"
+    if ! existing="$(gh search issues --repo "$REPO" --state open "\"$marker\"" --json url --jq '.[0].url // empty' 2>/dev/null)"; then
+      # Dedup search ERROR ≠ dedup search EMPTY (#674 CodeRabbit Major):
+      # an API/auth/rate-limit failure here must not read as "no existing
+      # issue" and mint duplicates — fail closed like any other step.
+      p4b_warn "post-review dedup search failed for fingerprint ${fp} — failing closed rather than risking duplicate issues"
+      printf '%s\n%s' "$refs" "$created"
+      return 1
+    fi
+    if [ -n "$existing" ]; then
+      refs="${refs:+$refs, }#${existing##*/}"
+      i=$((i + 1))
+      continue
+    fi
+    # Title follows the documented step-9 convention (`[Post-Review] {brief
+    # description}`, REVIEW_POLICY.md § post-merge issue creation — #674
+    # round-3 P2) so title-shape triage and searches see auto-filed
+    # follow-ups exactly like manual ones.
+    title="$(printf '%.120s' "[Post-Review] ${kind} from ${REPO}#${PR}: ${sev} ${fpath}${fline:+:$fline}")"
+    bfile="$(mktemp "${TMPDIR:-/tmp}/p4b-issue.XXXXXX")"
+    {
+      printf 'Advisory %s %s flagged by the automated Phase 4b APPROVED review of %s#%s. Filed by scripts/phase-4b-review.sh BEFORE the approval posted (policy step 9, #672).\n\n' "$sev" "$kind" "$REPO" "$PR"
+      printf 'Anchor: `%s`%s\n\n' "$fpath" "${fline:+ line $fline}"
+      printf '%s\n' "$fbody"
+      printf '\nReviewer: %s (%s adapter). Reviewed head: `%s`.\n' "$REVIEWER" "$ADAPTER" "${HEAD:-unknown}"
+      printf '\n<!-- %s -->\n' "$marker"
+    } > "$bfile"
+    url="$("$GH_AS_AUTHOR" -- gh issue create --repo "$REPO" \
+      --title "$title" --body-file "$bfile" \
+      --label post-review --label "$kind" \
+      --assignee "$author_login" 2>/dev/null)" \
+      || { rm -f "$bfile"; printf '%s\n%s' "$refs" "$created"; return 1; }
+    rm -f "$bfile"
+    [ -n "$url" ] || { printf '%s\n%s' "$refs" "$created"; return 1; }
+    refs="${refs:+$refs, }#${url##*/}"
+    created="${created:+$created, }#${url##*/}"
+    i=$((i + 1))
+  done
+  printf '%s\n%s' "$refs" "$created"
+}
+
+# p4b_close_post_review_issues <refs "#1, #2"> <reason>
+# Self-cleanup for the filing side effect (#674 round-4 P2): when an
+# approval is refused AFTER issues were filed (head drift, partial filing
+# failure), the filed issues are closed as superseded rather than left
+# orphaned — the dedup search is open-state-scoped, so a rerun files fresh
+# follow-ups instead of resurrecting closed refs. Best-effort: a close
+# failure warns with the ref so the operator can close manually; it never
+# changes the refusal outcome.
+p4b_close_post_review_issues() {
+  local refs="$1" reason="$2" n
+  for n in $(printf '%s' "$refs" | tr ',' ' '); do
+    n="${n##*#}"
+    [ -n "$n" ] || continue
+    "$GH_AS_AUTHOR" -- gh issue close "$n" --repo "$REPO" --comment "$reason" >/dev/null 2>&1 \
+      || p4b_warn "could not close superseded post-review issue #$n — close it manually"
+  done
+  return 0
+}
+
+POST_REVIEW_ISSUE_REFS=""
+P4B_CREATED_ISSUE_REFS=""
 if [ "$VERDICT" = "APPROVED" ] && [ "$FINDINGS_COUNT" -gt 0 ]; then
-  fall_back_to_manual "approved verdict included findings; post-review issue filing is required before Phase 4b clearance"
+  # Policy step 9 (#672): observations/risks from an approving external
+  # reviewer become post-review issues BEFORE the approval clears the merge
+  # gate. The validator has already rejected APPROVED carrying any
+  # policy-REQUIRED tier, so every finding here is discretionary — file the
+  # issues mechanically and post the APPROVED with the references, instead
+  # of discarding the verdict into the manual handoff (which stranded the
+  # caller without the findings it needed to comply). Opt out with
+  # phase_4b_automation.post_review_issues: false (restores the pre-#672
+  # refusal); dry-run prints intent and files nothing.
+  # Opt-out is validated fail-closed (#674 CodeRabbit): only the literal
+  # true/false (or absent ⇒ true) are accepted — a typo like `False`, `no`,
+  # or `0` must not silently fail OPEN into auto-filing issues under the
+  # author PAT.
+  _pri_knob="$(p4b_automation_field post_review_issues)"
+  case "${_pri_knob:-true}" in
+    true) : ;;
+    false)
+      fall_back_to_manual "approved verdict included findings and phase_4b_automation.post_review_issues is false; post-review issue filing is required before Phase 4b clearance"
+      ;;
+    *)
+      fall_back_to_manual "invalid phase_4b_automation.post_review_issues value '${_pri_knob}' (expected true or false) — refusing fail-closed"
+      ;;
+  esac
+  # Tiers the feedback policy marks `ignore` are never surfaced (#674 Codex
+  # P2): drop them from the FILE set. The review body still lists every
+  # verdict finding — it is the faithful record of what the reviewer said —
+  # but no follow-up issue is opened for suppressed tiers.
+  IGNORED_SEVS='[]'; _ig_first=true
+  for _tier in p0 p1 p2 p3; do
+    if [ "$(p4b_feedback_priority_value "$_tier")" = "ignore" ]; then
+      if [ "$_ig_first" = true ]; then IGNORED_SEVS='['; _ig_first=false; else IGNORED_SEVS="$IGNORED_SEVS,"; fi
+      IGNORED_SEVS="$IGNORED_SEVS\"$(printf '%s' "$_tier" | tr '[:lower:]' '[:upper:]')\""
+    fi
+  done
+  [ "$_ig_first" = true ] || IGNORED_SEVS="$IGNORED_SEVS]"
+  FILE_JSON="$(printf '%s' "$VERDICT_JSON" | jq -c --argjson ig "$IGNORED_SEVS" \
+    '{findings: [.findings[] | . as $f | select(($ig | index($f.severity)) | not)]}')"
+  FILE_COUNT="$(printf '%s' "$FILE_JSON" | jq -r '.findings | length')"
+  if [ "$FILE_COUNT" -eq 0 ]; then
+    p4b_log "all $FINDINGS_COUNT APPROVED finding(s) fall in feedback_policy ignore tiers — never surfaced, nothing to file"
+  elif [ "$DRY_RUN" = true ]; then
+    p4b_log "[dry-run] would file $FILE_COUNT post-review issue(s) in $REPO ($FINDINGS_COUNT finding(s) total; ignored tiers filtered), then post APPROVED with the references"
+    POST_REVIEW_ISSUE_REFS="(dry-run: $FILE_COUNT issue(s) would be filed)"
+  else
+    # Side-effect ordering (#674 Codex P2): re-read the live head BEFORE
+    # filing anything. post_review re-checks again at POST time, but by
+    # then the issues would already exist — a head that drifted during the
+    # adapter run must refuse here, with zero issues claiming an approval
+    # that will never post.
+    live_head_pre="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
+    [ -n "$live_head_pre" ] \
+      || fall_back_to_manual "could not re-read the live PR head before filing post-review issues"
+    if [ "$live_head_pre" != "$HEAD" ]; then
+      fall_back_to_manual "PR head changed during review (reviewed $HEAD, live $live_head_pre) — refusing to file post-review issues for an approval that will not post"
+    fi
+    # Same-head laundering gate, hoisted ahead of the side effects (#674
+    # Codex round-2 P2): the authoritative gate below still guards the
+    # POST, but by then the issues would already exist for an approval
+    # that gets refused. Same guards as the authoritative copy (module
+    # loaded; hook consults the loop log keyed to the current HEAD).
+    if [ "$P4B_ACCT_AVAILABLE" = true ] && ! p4b_acct_hook_same_head_required_block; then
+      fall_back_to_manual "an unresolved required-tier finding was recorded on the current head ($HEAD) in a prior Phase 4b loop — refusing to file post-review issues for an approval that will not post"
+    fi
+    set +e
+    _pri_out="$(p4b_file_post_review_issues "$FILE_JSON")"
+    _pri_rc=$?
+    set -e
+    POST_REVIEW_ISSUE_REFS="$(printf '%s\n' "$_pri_out" | sed -n 1p)"
+    # Cleanup operates ONLY on refs this invocation created (#674 round-5
+    # P2): a reused prior-run issue in the body refs must never be closed
+    # because a later step of THIS run failed.
+    P4B_CREATED_ISSUE_REFS="$(printf '%s\n' "$_pri_out" | sed -n 2p)"
+    if [ "$_pri_rc" -ne 0 ]; then
+      # Partial-failure orphans (#674 round-2 + round-4 P2s): surface any
+      # refs that DID file, close this run's creations as superseded
+      # (self-cleanup), and refuse. The dedup search is open-scoped, so a
+      # rerun files fresh follow-ups instead of resurrecting the closed
+      # ones.
+      if [ -n "$P4B_CREATED_ISSUE_REFS" ]; then
+        p4b_warn "post-review issue filing failed partway; closing this run's created refs as superseded: $P4B_CREATED_ISSUE_REFS"
+        p4b_close_post_review_issues "$P4B_CREATED_ISSUE_REFS" "Superseded: post-review filing for ${REPO}#${PR} failed partway and the Phase 4b approval was refused; a rerun files fresh follow-ups."
+      fi
+      fall_back_to_manual "approved verdict included findings and post-review issue filing failed${POST_REVIEW_ISSUE_REFS:+ (partial refs: $POST_REVIEW_ISSUE_REFS, created subset closed as superseded)}; refusing to post an approval with unfiled observations"
+    fi
+    [ -n "$POST_REVIEW_ISSUE_REFS" ] \
+      || fall_back_to_manual "approved verdict included findings but post-review issue filing produced no references"
+    # Post-file head recheck (#674 round-4 P2): a head that drifted DURING
+    # filing pins the just-filed issues to a head whose approval will be
+    # refused at post_review, and a new-head rerun cannot reuse the old
+    # head-pinned markers. Close this run's creations and refuse now.
+    live_head_post="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
+    if [ -z "$live_head_post" ] || [ "$live_head_post" != "$HEAD" ]; then
+      p4b_warn "PR head drifted during issue filing (reviewed $HEAD, live ${live_head_post:-unreadable}) — closing this run's filed issues as superseded"
+      p4b_close_post_review_issues "$P4B_CREATED_ISSUE_REFS" "Superseded: the PR head of ${REPO}#${PR} changed before the Phase 4b approval could post; a re-run on the new head files fresh follow-ups."
+      fall_back_to_manual "PR head changed while filing post-review issues (reviewed $HEAD, live ${live_head_post:-unreadable}); the filed issues were closed as superseded"
+    fi
+    p4b_log "filed $FILE_COUNT post-review issue(s): $POST_REVIEW_ISSUE_REFS"
+    # Enrich the accounting record (#675): the line-1 refs align 1:1 with
+    # FILE_JSON.findings (reused + created alike, in filing order). Zip them
+    # into the tuple-keyed filed-issues channel accounting.sh joins in
+    # p4b_acct_unique_findings, flipping each filed finding's record entry from
+    # unresolved/null to disposition "deferred-to-follow-up" + its issue link
+    # (advisory_issues_filed then derives), so the machine-readable record
+    # matches the prose "filed as #N" reference instead of contradicting it.
+    # Built via p4b_acct_filed_issues_from_refs (numeric, position-preserving
+    # parse — a malformed middle ref never shifts a later issue onto the wrong
+    # finding, #675 Codex round 1), and ONLY when accounting is loaded (its sole
+    # consumer). Exported BEFORE the accounting render block reads it.
+    if [ "$P4B_ACCT_AVAILABLE" = true ]; then
+      P4B_ACCT_FILED_ISSUES_JSON="$(p4b_acct_filed_issues_from_refs "$POST_REVIEW_ISSUE_REFS" "$FILE_JSON")"
+      [ -n "$P4B_ACCT_FILED_ISSUES_JSON" ] || P4B_ACCT_FILED_ISSUES_JSON='[]'
+      export P4B_ACCT_FILED_ISSUES_JSON
+    fi
+  fi
 fi
 
 # Render the PR review body (summary + findings list).
@@ -392,6 +623,20 @@ BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/p4b-body.XXXXXX")"
     printf '%s' "$VERDICT_JSON" | jq -r '
       .findings[]
       | "- **\(.severity)** \((.path // "PR") + (if .line then ":\(.line)" else "" end)): \(.body)"'
+    if [ "$VERDICT" = "APPROVED" ]; then
+      # Accurate audit trail (#674 round-3 P3): only claim filing for the
+      # subset that actually filed; ignored-tier findings are listed above
+      # as the faithful verdict record but are deliberately not surfaced
+      # as issues.
+      _ign_count=$(( FINDINGS_COUNT - ${FILE_COUNT:-$FINDINGS_COUNT} ))
+      if [ -n "$POST_REVIEW_ISSUE_REFS" ] && [ "$_ign_count" -eq 0 ]; then
+        printf '\nEach finding above is an advisory follow-up filed as a post-review issue before this approval posted (policy step 9, #672): %s\n' "$POST_REVIEW_ISSUE_REFS"
+      elif [ -n "$POST_REVIEW_ISSUE_REFS" ]; then
+        printf '\n%s of the findings above were filed as post-review issues before this approval posted (policy step 9, #672): %s. The other %s fall in feedback_policy ignore tiers and were deliberately not surfaced as issues.\n' "${FILE_COUNT:-0}" "$POST_REVIEW_ISSUE_REFS" "$_ign_count"
+      elif [ "$_ign_count" -gt 0 ]; then
+        printf '\nAll %s finding(s) above fall in feedback_policy ignore tiers — listed as the faithful verdict record, deliberately not surfaced as post-review issues.\n' "$_ign_count"
+      fi
+    fi
   fi
   printf '\n\n_Posted by scripts/phase-4b-review.sh under the reviewer identity. See plans/automated-phase-4b-handoff.md._\n'
 } > "$BODY_FILE"
@@ -573,6 +818,15 @@ post_review() {
   live_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)"
   [ -n "$live_head" ] || { p4b_acct_mark_unposted "could not re-read live PR head before posting review"; p4b_die 3 "could not re-read live PR head before posting review"; }
   if [ "$live_head" != "$HEAD" ]; then
+    # Late-window drift (#674 round-5 P2): a push landing during body or
+    # accounting rendering reaches this final check with the step-9 issues
+    # already filed — close this run's creations before refusing, same as
+    # the post-file recheck, so no orphan claims an approval that never
+    # posted.
+    if [ "$event" = "APPROVE" ] && [ -n "${P4B_CREATED_ISSUE_REFS:-}" ]; then
+      p4b_warn "PR head drifted before the approval POST — closing this run's filed post-review issues as superseded: $P4B_CREATED_ISSUE_REFS"
+      p4b_close_post_review_issues "$P4B_CREATED_ISSUE_REFS" "Superseded: the PR head of ${REPO}#${PR} changed before the Phase 4b approval could post; a re-run on the new head files fresh follow-ups."
+    fi
     fall_back_to_manual "PR head changed during review (reviewed $HEAD, live $live_head)"
   fi
   payload_file="$(mktemp "${TMPDIR:-/tmp}/p4b-review-payload.XXXXXX")"

--- a/scripts/phase-4b/README.md
+++ b/scripts/phase-4b/README.md
@@ -193,10 +193,14 @@ phase-4b-classifier.sh (is 4b needed?) ─▶ phase-4b-review.sh
   `feedback_policy` when present (#574). `APPROVED` may not carry findings in
   any policy-required severity tier; absent `feedback_policy` defaults to
   P0/P1 required and P2/P3 discretionary. `mode: address-all` makes every
-  finding block an automated approval. Separately, the orchestrator refuses to
-  post any `APPROVED` verdict that still carries findings, because repo policy
-  requires observations/risks from an approving external reviewer to become
-  post-review issues before that approval clears the merge gate.
+  finding block an automated approval. Separately, an `APPROVED` verdict that
+  carries discretionary findings triggers the policy step-9 executor (#672):
+  the orchestrator files one `post-review` + `observation` issue per finding
+  (author identity, assigned to it) and posts the approval with the issue
+  references appended — observations become issues BEFORE the approval clears
+  the merge gate. Any filing failure refuses the approval fail-closed (the
+  pre-#672 behavior); `phase_4b_automation.post_review_issues: false` opts a
+  repo back into the plain refusal.
 - **Attribution-plane auth:** the selected reviewer's PAT is resolved through
   `scripts/gh-as-reviewer.sh`. The orchestrator sets
   `GH_AS_REVIEWER_IDENTITY` and deliberately clears a stale

--- a/scripts/phase-4b/accounting.sh
+++ b/scripts/phase-4b/accounting.sh
@@ -617,7 +617,7 @@ p4b_acct_running_totals_for_post() {
 
 # --- per-approval totals ---------------------------------------------------
 
-# p4b_acct_compute_totals <loops-json-array> <price_table_version> <notional_usd|null> [unique-findings-json]
+# p4b_acct_compute_totals <loops-json-array> <price_table_version> <notional_usd|null> [unique-findings-json] [filed-issues-json]
 # Compute the per-approval `totals` object from the loop array. Token/elapsed
 # totals sum only the loops that exposed a value; when NO loop exposed one the
 # total is null (explicitly unavailable, never a fabricated 0). notional_usd
@@ -627,9 +627,14 @@ p4b_acct_running_totals_for_post() {
 # every loop with measured usage also reported a cost — a token-bearing loop
 # without one would make the sum a silent underreport (never a partial
 # figure); loops with nothing measured contribute nothing and do not block.
-# advisory_issues_filed is derived from the unique-finding issue links.
+# advisory_issues_filed is the union of the unique-finding issue links AND the
+# optional raw filed-issues list ([filed-issues-json], P4B_ACCT_FILED_ISSUES_JSON)
+# — so EVERY issue actually filed is recorded even when duplicate (identical
+# severity/path/line/body) findings collapse to one unique_findings entry whose
+# single per-finding issue holds only one of the refs (#675 Codex round 2).
 p4b_acct_compute_totals() {
-  local loops_json="$1" ptv="$2" notional="$3" uf_json="${4:-[]}"
+  local loops_json="$1" ptv="$2" notional="$3" uf_json="${4:-[]}" filed_json="${5:-[]}"
+  [ -n "$filed_json" ] || filed_json='[]'
   local ptv_json notional_json
   if [ -n "$ptv" ]; then
     ptv_json="$(jq -nc --arg v "$ptv" '$v' 2>/dev/null)" || return 1
@@ -644,7 +649,8 @@ p4b_acct_compute_totals() {
   printf '%s' "$loops_json" | jq -c \
     --argjson ptv "$ptv_json" \
     --argjson notional "$notional_json" \
-    --argjson uf "$uf_json" '
+    --argjson uf "$uf_json" \
+    --argjson filed "$filed_json" '
     {
       adapter_invocations: length,
       tokens_total: ([ .[] | .tokens.total // empty ]
@@ -675,7 +681,8 @@ p4b_acct_compute_totals() {
       ),
       price_table_version: $ptv,
       fail_closed_events: ([ .[] | select(.fail_closed.happened == true) ] | length),
-      advisory_issues_filed: ([ $uf[] | .issue | select(. != null) ] | unique)
+      advisory_issues_filed: (([ $uf[] | .issue ] + [ $filed[] | .issue ])
+                              | map(select(. != null)) | unique)
     }' 2>/dev/null
 }
 
@@ -862,7 +869,7 @@ p4b_acct_finding_details_from_verdict() {
         body: (.body // "") }' 2>/dev/null
 }
 
-# p4b_acct_unique_findings [dispositions-json]
+# p4b_acct_unique_findings [dispositions-json] [filed-issues-json]
 # Read finding-detail JSONL on stdin (the concatenated output of
 # p4b_acct_finding_details_from_verdict across loops) and emit the
 # unique_findings array: de-duplicated by (severity, path, line, body),
@@ -871,18 +878,45 @@ p4b_acct_finding_details_from_verdict() {
 # single-line title (first body line, truncated to 80 chars) — so a GitHub
 # reader can tell what was fixed/deferred from the posted record alone
 # (#615 Codex); full bodies stay in the local loop log, never in the posted
-# block. Dispositions come ONLY from the optional dispositions map
-# ({"F1":{"disposition":"fixed","fix_commit":"abc","issue":null}, ...});
-# the default is "unresolved" with null links — the accounting never GUESSES
-# a disposition.
+# block.
+#
+# Dispositions arrive on two optional channels; both default to "unresolved"
+# with null links, because the accounting never GUESSES a disposition:
+#   1. [dispositions-json] — the F-id-keyed map
+#      ({"F1":{"disposition":"fixed","fix_commit":"abc","issue":null}, ...}).
+#      Requires the caller to know each finding's first-appearance F-id.
+#   2. [filed-issues-json] — a TUPLE-keyed list the orchestrator can populate
+#      WITHOUT replaying the F-id reduce (#675):
+#      [{severity, path, line, body, issue}, ...]. Each entry is joined on the
+#      SAME collision-proof [severity, path, line, body] | tojson key computed
+#      below and sets disposition "deferred-to-follow-up" + the issue link on
+#      the matching finding.
+# On a per-finding conflict the explicit F-id map (channel 1) wins field by
+# field — its disposition/fix_commit override the filed channel's, and an
+# explicit F-id `issue` KEY (even an explicit null) wins over the filed
+# channel's issue (#675 Codex round 1: key-presence, not null-coalescing — a
+# `{"disposition":"fixed","issue":null}` override keeps issue null instead of
+# reattaching the filed follow-up). Only an ABSENT F-id issue key falls back.
 p4b_acct_unique_findings() {
-  local disp="${1:-}"
+  local disp="${1:-}" filed="${2:-}"
   [ -n "$disp" ] || disp='{}'
-  jq -cs --argjson disp "$disp" '
+  [ -n "$filed" ] || filed='[]'
+  jq -cs --argjson disp "$disp" --argjson filed "$filed" '
     def title_of: (. // "") | split("\n")[0]
       | (if length > 80 then .[0:79] + "…" else . end)
       | (if . == "" then null else . end);
-    reduce .[] as $d ( {order: [], map: {}} ;
+    # Filed-issue tuple map (#675): key each filed post-review issue by the
+    # same collision-proof [severity, path, line, body] | tojson tuple the
+    # dedupe below computes, normalized with the finding-detail defaults
+    # (severity→"unknown", path/line→null, body→"") so a caller need not
+    # reshape its list. Value: the deferred-to-follow-up disposition + issue;
+    # the explicit F-id map overrides it per field in the final build.
+    (reduce ($filed[]?) as $fi ({};
+       ( [ ($fi.severity // "unknown"), ($fi.path // null),
+           ($fi.line // null), ($fi.body // "") ] | tojson ) as $fk
+       | .[$fk] = {disposition: "deferred-to-follow-up",
+                   issue: ($fi.issue // null)} )) as $filedmap
+    | reduce .[] as $d ( {order: [], map: {}} ;
       # Collision-proof de-dupe key (#615 Codex round 9, finding 3): JSON-encode
       # the (severity, path, line, body) tuple as an ARRAY so structural
       # boundaries can never be forged by content. The prior `severity | path |
@@ -909,6 +943,7 @@ p4b_acct_unique_findings() {
         | $st.order[$i] as $k
         | ("F" + (($i + 1) | tostring)) as $id
         | ($disp[$id] // {}) as $o
+        | ($filedmap[$k] // {}) as $fo
         | { id: $id,
             severity: $st.map[$k].severity,
             path: $st.map[$k].path,
@@ -916,9 +951,49 @@ p4b_acct_unique_findings() {
             title: $st.map[$k].title,
             first_loop: $st.map[$k].first_loop,
             last_loop: $st.map[$k].last_loop,
-            disposition: ($o.disposition // "unresolved"),
+            disposition: ($o.disposition // $fo.disposition // "unresolved"),
             fix_commit: ($o.fix_commit // null),
-            issue: ($o.issue // null) } ]' 2>/dev/null
+            # Key-presence, not null-coalescing (#675 Codex round 1): an
+            # explicit F-id `issue` (even null) wins over the filed channel;
+            # only an ABSENT F-id issue key falls back to the filed issue, so a
+            # `{"disposition":"fixed","issue":null}` override is not silently
+            # re-linked to the filed follow-up.
+            issue: (if ($o | has("issue")) then $o.issue
+                    else ($fo.issue // null) end) } ]' 2>/dev/null
+}
+
+# p4b_acct_filed_issues_from_refs <refs-csv> <file-json>
+# Build the tuple-keyed filed-issues payload (P4B_ACCT_FILED_ISSUES_JSON) the
+# render hook consumes, by zipping a comma-separated "#N" ref list — line 1 of
+# scripts/phase-4b-review.sh's p4b_file_post_review_issues, aligned 1:1 with
+# <file-json>.findings in filing order (reused + created alike) — onto those
+# findings. Emits a JSON array of {severity, path, line, body, issue} with a
+# NUMERIC issue (schema: unique_finding.issue is integer|null).
+#
+# Position-preserving (#675 Codex round 1): a ref token that is not a bare
+# "#<digits>" maps to a NULL placeholder rather than being dropped, so an
+# unparseable middle ref never shifts a later issue number onto the wrong
+# finding — e.g. "#101, #bad, #103" keeps 103 on finding index 2, not index 1.
+# A finding whose ref is null/absent is then dropped (left unlinked), so the
+# enrichment never fabricates a finding→issue association. Prints "[]" on a
+# malformed <file-json> (the enrichment is advisory — never a hard failure).
+p4b_acct_filed_issues_from_refs() {
+  local refs="$1" file_json="$2" refs_json out
+  refs_json="$(printf '%s' "$refs" | jq -Rc '
+    [ splits(", *")
+      | ltrimstr("#")
+      | (if test("^[0-9]+$") then tonumber else null end) ]' 2>/dev/null)" || refs_json='[]'
+  [ -n "$refs_json" ] || refs_json='[]'
+  out="$(printf '%s' "$file_json" | jq -c --argjson refs "$refs_json" '
+    [ .findings | to_entries[]
+      | {severity: .value.severity,
+         path: (.value.path // null),
+         line: (.value.line // null),
+         body: (.value.body // ""),
+         issue: ($refs[.key] // null)}
+      | select(.issue != null) ]' 2>/dev/null)" || out=''
+  [ -n "$out" ] || out='[]'
+  printf '%s' "$out"
 }
 
 # --- record assembly -------------------------------------------------------
@@ -1959,13 +2034,13 @@ p4b_acct_hook_render_approval_block() {
   loops="$(jq -cs '[ .[] | .loop ]' "$log" 2>/dev/null)" || return 1
   [ -n "$loops" ] && [ "$loops" != "[]" ] || return 1
   details="$(jq -c '.details[]?' "$log" 2>/dev/null)" || return 1
-  uf="$(printf '%s\n' "$details" | p4b_acct_unique_findings "${P4B_ACCT_DISPOSITIONS_JSON:-}")" || return 1
+  uf="$(printf '%s\n' "$details" | p4b_acct_unique_findings "${P4B_ACCT_DISPOSITIONS_JSON:-}" "${P4B_ACCT_FILED_ISSUES_JSON:-}")" || return 1
   [ -n "$uf" ] || return 1
   ptv="$(p4b_acct_price_table_version)"
   if ! notional="$(p4b_acct_notional_for_loops "$loops")"; then
     notional="null"
   fi
-  totals="$(p4b_acct_compute_totals "$loops" "$ptv" "$notional" "$uf")" || return 1
+  totals="$(p4b_acct_compute_totals "$loops" "$ptv" "$notional" "$uf" "${P4B_ACCT_FILED_ISSUES_JSON:-[]}")" || return 1
   [ -n "$totals" ] || return 1
   # GitHub-derived prior records are fetched here (#615 Codex round 2) so
   # the rendered totals are repo-wide by default, not local-ledger-only.

--- a/scripts/phase-4b/adapters/review-via-claude.sh
+++ b/scripts/phase-4b/adapters/review-via-claude.sh
@@ -61,6 +61,10 @@
 #               are ever omitted from an over-budget diff — a non-matching
 #               oversized section fails closed to the manual handoff so an
 #               APPROVED can never post around unreviewed code (#636 P1).
+#               Omission is refused outright (exit 4) when the diff itself
+#               touches .github/review-policy.yml — the allowlist's own
+#               source of truth — so a PR cannot broaden the allowlist it
+#               is judged by (#668).
 #
 # Exit codes: identical contract to review-via-codex.sh (0/2/3/4).
 
@@ -133,7 +137,7 @@ printf '%s\n' "$DIFF" > "$DIFF_RAW"
 DIFF_BYTES="$(wc -c < "$DIFF_RAW" | tr -d '[:space:]')"
 OMIT_GLOBS="$(p4b_diff_omit_globs)"
 OMITTED="$(p4b_trim_review_diff "$DIFF_RAW" "$DIFF_FIT" "$MAX_DIFF_BYTES" "$OMIT_GLOBS")" \
-  || p4b_die 4 "diff (${DIFF_BYTES} bytes) exceeds the ${MAX_DIFF_BYTES}-byte review budget and cannot be reduced by omitting policy-allowlisted bulk sections (phase_4b_automation.diff_omit_globs) — refusing to omit unreviewed code (#636); pass a curated --diff-file or extend the allowlist; falling back to the manual handoff"
+  || p4b_die 4 "diff (${DIFF_BYTES} bytes) exceeds the ${MAX_DIFF_BYTES}-byte review budget and cannot be reduced by omitting policy-allowlisted bulk sections (phase_4b_automation.diff_omit_globs) — refusing to omit unreviewed code (#636); omission is also refused outright when the diff touches .github/review-policy.yml, because the PR may have rewritten the very allowlist this run would trust (#668); pass a curated --diff-file or extend the allowlist; falling back to the manual handoff"
 DIFF_NOTE=""
 if [ -n "$OMITTED" ]; then
   DIFF="$(cat "$DIFF_FIT")"

--- a/scripts/phase-4b/adapters/review-via-codex.sh
+++ b/scripts/phase-4b/adapters/review-via-codex.sh
@@ -55,6 +55,10 @@
 #               are ever omitted from an over-budget diff — a non-matching
 #               oversized section fails closed to the manual handoff so an
 #               APPROVED can never post around unreviewed code (#636 P1).
+#               Omission is refused outright (exit 4) when the diff itself
+#               touches .github/review-policy.yml — the allowlist's own
+#               source of truth — so a PR cannot broaden the allowlist it
+#               is judged by (#668).
 #
 # Exit codes:
 #   0  valid verdict JSON on stdout.
@@ -142,7 +146,7 @@ printf '%s\n' "$DIFF" > "$DIFF_RAW"
 DIFF_BYTES="$(wc -c < "$DIFF_RAW" | tr -d '[:space:]')"
 OMIT_GLOBS="$(p4b_diff_omit_globs)"
 OMITTED="$(p4b_trim_review_diff "$DIFF_RAW" "$DIFF_FIT" "$MAX_DIFF_BYTES" "$OMIT_GLOBS")" \
-  || p4b_die 4 "diff (${DIFF_BYTES} bytes) exceeds the ${MAX_DIFF_BYTES}-byte review budget and cannot be reduced by omitting policy-allowlisted bulk sections (phase_4b_automation.diff_omit_globs) — refusing to omit unreviewed code (#636); pass a curated --diff-file or extend the allowlist; falling back to the manual handoff"
+  || p4b_die 4 "diff (${DIFF_BYTES} bytes) exceeds the ${MAX_DIFF_BYTES}-byte review budget and cannot be reduced by omitting policy-allowlisted bulk sections (phase_4b_automation.diff_omit_globs) — refusing to omit unreviewed code (#636); omission is also refused outright when the diff touches .github/review-policy.yml, because the PR may have rewritten the very allowlist this run would trust (#668); pass a curated --diff-file or extend the allowlist; falling back to the manual handoff"
 DIFF_NOTE=""
 if [ -n "$OMITTED" ]; then
   DIFF="$(cat "$DIFF_FIT")"

--- a/scripts/phase-4b/lib.sh
+++ b/scripts/phase-4b/lib.sh
@@ -595,6 +595,14 @@ P4B_DEFAULT_DIFF_MAX_BYTES=600000   # ~150k tokens: fits every current
 P4B_MIN_DIFF_MAX_BYTES=4096
 P4B_MAX_DIFF_MAX_BYTES=10485760
 
+# The repo-relative path of the review policy file as it appears in PR
+# diffs. This is deliberately NOT derived from p4b_config():
+# MERGEPATH_REVIEW_POLICY_PATH points the CONFIG READERS at an absolute
+# (often temp) file for tests and manual runs, but the omission-provenance
+# guard below keys on the path a PR's diff sections carry, which is always
+# the canonical in-repo location.
+P4B_REVIEW_POLICY_REPO_PATH=".github/review-policy.yml"
+
 # p4b_resolve_diff_max_bytes
 # Resolve the review-diff byte budget: P4B_DIFF_MAX_BYTES env override
 # (tests/manual escape hatch — integer-validated but not range-bounded,
@@ -636,7 +644,13 @@ p4b_resolve_diff_max_bytes() {
 # no reviewer saw — only operator-declared bulk-artifact paths are ever
 # omitted. Patterns are bash `case` globs (`*` crosses `/`); a section is
 # eligible only when EVERY repo path it touches — b/-side, a/-side, and any
-# rename/copy source — matches (see p4b_trim_review_diff).
+# rename/copy source or destination — matches (see p4b_trim_review_diff).
+#
+# PROVENANCE: this reads the CURRENT CHECKOUT's policy file. The #628
+# trusted-path rule (run the orchestrator from a trusted main-ref checkout)
+# is what makes that read trustworthy operationally; the mechanical
+# backstop lives in p4b_trim_review_diff, which refuses ALL omission when
+# the diff under review itself touches the policy file (#668).
 p4b_diff_omit_globs() {
   local cfg
   if [ -n "${P4B_DIFF_OMIT_GLOBS:-}" ]; then
@@ -700,15 +714,34 @@ EOF
 # Eligible = EVERY repo path the section touches matches <omit_globs>
 # (newline-separated shell globs; see p4b_diff_omit_globs). A section touches
 # its b/-side path, its a/-side path, AND — for a rename or copy — the
-# `rename from` / `copy from` source. Checking only the b/-side (the #636
-# round-1 shape) let a large rename FROM a non-allowlisted application path
-# (`src/foo.sh`) TO an allowlisted artifact path (`docs/audits/data/foo.sh`)
-# be omitted, hiding the removal of application code while an APPROVED could
-# still post (#636 round-2 P1). Requiring the a/-side and rename source to be
-# allowlisted too fails such a section closed.
+# `rename from` / `copy from` source and `rename to` / `copy to`
+# destination. Checking only the b/-side (the #636 round-1 shape) let a
+# large rename FROM a non-allowlisted application path (`src/foo.sh`) TO an
+# allowlisted artifact path (`docs/audits/data/foo.sh`) be omitted, hiding
+# the removal of application code while an APPROVED could still post (#636
+# round-2 P1). Requiring the a/-side and rename/copy source to be
+# allowlisted too fails such a section closed; the explicit rename/copy
+# DESTINATION lines are checked as well (#668) so eligibility never rests
+# solely on the header-derived split when the section carries exact paths.
+#
+# Omission-allowlist provenance (#668, the #636 sibling): <omit_globs> is
+# read from the CURRENT CHECKOUT's .github/review-policy.yml. A PR that
+# itself edits that file could broaden the allowlist (e.g. to `src/*`),
+# pair it with an over-budget diff, and have this function omit
+# application-code sections from the reviewer input while an APPROVED still
+# posts. The #628 trusted-path rule (orchestrator runs from a trusted
+# main-ref checkout) mitigates that only operationally; the mechanical
+# guard is here: when omission is needed (the diff is over budget) and ANY
+# section touches $P4B_REVIEW_POLICY_REPO_PATH on any side, this function
+# refuses omission entirely and returns non-zero, so the run falls back to
+# the manual handoff instead of trusting an allowlist the PR under review
+# may have rewritten. Under-budget diffs are unaffected — they pass through
+# verbatim and the allowlist plays no role. The trust argument mirrors the
+# #429 head-pinned exemption: only inputs the PR author cannot influence
+# may decide what the reviewer never sees.
 p4b_trim_review_diff() {
   local in="$1" out="$2" max="$3" globs="${4:-}" total sizes omit="" projected
-  local b i bside aside rfrom plh plen
+  local b i bside aside rfrom rto p plh plen
   [ -r "$in" ] || return 1
   case "$max" in ''|*[!0-9]*) return 1 ;; esac
   total="$(wc -c < "$in" | tr -d '[:space:]')"
@@ -716,39 +749,62 @@ p4b_trim_review_diff() {
     cp "$in" "$out" || return 1
     return 0
   fi
-  # Per-section metadata as "bytes<TAB>index<TAB>bside<TAB>aside<TAB>rename_from",
+  # Per-section metadata as
+  # "bytes<TAB>index<TAB>bside<TAB>aside<TAB>rename_from<TAB>rename_to",
   # largest first. Sections are keyed by INDEX (omission never depends on path
-  # parsing); the b/-side is the display path, and a/-side + rename source are
-  # carried so the caller can require EVERY touched path to be allowlisted.
-  # a/-side is derived by stripping the parsed " b/<bside>" suffix, so it uses
-  # the same split point as the b/-side. LC_ALL=C keeps length() byte-exact.
+  # parsing); the b/-side is the display path, and a/-side + rename/copy
+  # source/destination are carried so the caller can require EVERY touched
+  # path to be allowlisted. a/-side is derived by stripping the parsed
+  # " b/<bside>" suffix, so it uses the same split point as the b/-side.
+  # LC_ALL=C keeps length() byte-exact.
   sizes="$(LC_ALL=C awk '
-    /^diff --git /{ n++; hdr[n] = $0; bytes[n] = 0; rfrom[n] = "" }
+    /^diff --git /{ n++; hdr[n] = $0; bytes[n] = 0; rfrom[n] = ""; rto[n] = "" }
     n > 0 { bytes[n] += length($0) + 1 }
     /^rename from /{ if (n > 0 && rfrom[n] == "") rfrom[n] = substr($0, 13) }
     /^copy from /  { if (n > 0 && rfrom[n] == "") rfrom[n] = substr($0, 11) }
+    /^rename to /  { if (n > 0 && rto[n]   == "") rto[n]   = substr($0, 11) }
+    /^copy to /    { if (n > 0 && rto[n]   == "") rto[n]   = substr($0, 9)  }
     END {
       for (i = 1; i <= n; i++) {
         b = hdr[i]; sub(/^diff --git a\/.* b\//, "", b)
         a = hdr[i]; sub(/^diff --git a\//, "", a)
         suf = " b/" b
         if (substr(a, length(a) - length(suf) + 1) == suf) a = substr(a, 1, length(a) - length(suf))
-        printf "%d\t%d\t%s\t%s\t%s\n", bytes[i], i, b, a, rfrom[i]
+        printf "%d\t%d\t%s\t%s\t%s\t%s\n", bytes[i], i, b, a, rfrom[i], rto[i]
       }
     }
   ' "$in" | sort -rn)"
   [ -n "$sizes" ] || return 1
+  # Omission-allowlist provenance guard (#668): omission is needed past this
+  # point, and the allowlist was read from the current checkout's policy
+  # file — the ONE repo path whose in-PR modification could have rewritten
+  # the allowlist this run is judged by. If any section touches it on any
+  # side (edit, delete, rename/copy in or out), refuse omission entirely so
+  # the caller falls back to the manual handoff. See the function comment
+  # for the trust argument.
+  while IFS=$'\t' read -r b i bside aside rfrom rto; do
+    for p in "$bside" "$aside" "$rfrom" "$rto"; do
+      if [ "$p" = "$P4B_REVIEW_POLICY_REPO_PATH" ]; then
+        return 1
+      fi
+    done
+  done <<EOF
+$sizes
+EOF
   # Omit largest-first until the PROJECTED output size fits. `projected` models
   # the exact output byte count — each omission removes the section's bytes and
   # adds its placeholder line — so a placeholder can no longer push the final
   # output back over budget after the loop stops (#636 round-2 P2).
   projected="$total"
-  while IFS=$'\t' read -r b i bside aside rfrom; do
+  while IFS=$'\t' read -r b i bside aside rfrom rto; do
     [ "$projected" -le "$max" ] && break
     p4b_path_matches_any_glob "$bside" "$globs" || continue
     p4b_path_matches_any_glob "$aside" "$globs" || continue
     if [ -n "$rfrom" ]; then
       p4b_path_matches_any_glob "$rfrom" "$globs" || continue
+    fi
+    if [ -n "$rto" ]; then
+      p4b_path_matches_any_glob "$rto" "$globs" || continue
     fi
     plh="[phase-4b diff-budget: ${bside} omitted - oversized diff section; see the prompt note]"
     plen="$(printf '%s\n' "$plh" | LC_ALL=C wc -c | tr -d '[:space:]')"

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -170,14 +170,62 @@ assert_grep "D8: daily-feedback-rollup guards dispatch to the default branch (#5
 # approval-triggered auto-merge never arms (regressing #544 / #495). Job-scoped
 # (extract the load-config block) so it cannot false-match the auto-merge gate's
 # own pull_request_review branch.
+#
+# #689: match only non-comment lines. The job's own explanatory comment
+# (right above the `if:`) also says "pull_request_review", so a plain
+# substring grep over the whole block would keep passing on that prose
+# alone even if the real `if:` condition were reverted — defeating the
+# guard. Stripping full-line comments first anchors the match on the
+# live condition.
+grep_nocomment_q() {  # <text> <fixed-string>
+  printf '%s\n' "$1" | grep -v '^[[:space:]]*#' | grep -qF -- "$2"
+}
+
 if [ -f "$W/agent-review.yml" ]; then
   _lc_block=$(awk '/^  load-config:/{f=1;print;next} /^  [A-Za-z._-]+:/{f=0} f{print}' "$W/agent-review.yml")
-  if printf '%s\n' "$_lc_block" | grep -q 'pull_request_review'; then
+  if grep_nocomment_q "$_lc_block" 'pull_request_review'; then
     pass "D9: load-config runs on pull_request_review so the arming gate sees reviewers (#557)"
   else
     fail "D9: load-config must gate on pull_request_review (#557) — direct-approval arming regressed"
   fi
 else echo "SKIP: D9 agent-review (absent)"; SKIP=$((SKIP + 1)); fi
+
+# D9 self-test (#689): prove the comment-stripping actually changes the
+# outcome, so this guard cannot quietly regress back to a bare substring
+# match without a visible test failure. A block whose COMMENT mentions
+# pull_request_review but whose `if:` does not must NOT match; a block
+# whose `if:` genuinely carries the condition must still match.
+_d9_bad_block=$(cat <<'FIXTURE'
+  load-config:
+    # Historical note: this job used to run only on pull_request_review
+    # events before an earlier refactor; kept here for context.
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'opened')
+    runs-on: ubuntu-latest
+FIXTURE
+)
+_d9_good_block=$(cat <<'FIXTURE'
+  load-config:
+    # #557: ALSO run on approved pull_request_review events.
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'opened') ||
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.state == 'approved')
+    runs-on: ubuntu-latest
+FIXTURE
+)
+if grep_nocomment_q "$_d9_bad_block" 'pull_request_review'; then
+  fail "D9 self-test: guard must not false-pass on a comment-only mention (#689)"
+else
+  pass "D9 self-test: guard ignores a comment-only mention of pull_request_review (#689)"
+fi
+if grep_nocomment_q "$_d9_good_block" 'pull_request_review'; then
+  pass "D9 self-test: guard still matches a real if: condition (#689)"
+else
+  fail "D9 self-test: guard must match a real if: condition on pull_request_review (#689)"
+fi
 
 echo ""
 echo "test_465_fail_closed: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/test_655_repo_lint_local_observed.sh
+++ b/tests/test_655_repo_lint_local_observed.sh
@@ -1,0 +1,602 @@
+#!/usr/bin/env bash
+# tests/test_655_repo_lint_local_observed.sh
+#
+# Structural regression guard for #655: a consumer's optional, never-
+# propagated repo_lint_local.yml annex (#601) produces a `repo-lint-local`
+# check run that branch protection does not require. Before this fix,
+# neither the native auto-merge path (agent-review.yml's "Require current-
+# head check success" step, hardcoded to the single `lint` check) nor the
+# needs-external-review label-clearing re-evaluation trigger
+# (auto-clear-blocking-labels.yml's workflow_run list) observed it, so a
+# consumer could auto-merge or auto-clear with local checks red. (The
+# third, deepest site — codex-review-check.sh gate (a), the script BOTH of
+# these ultimately rely on for "is CI green" — has its own execution-level
+# test in test_codex_review_check_required_checks.sh.)
+#
+# Round 6 (Codex P1/P2) rewrote how agent-review.yml enforces the annex:
+# rather than forcing its derived check name(s) into the hard-required
+# required_checks_json list (which deadlocked the wait loop forever on a
+# path-filtered or all-matrix annex that would never report under any
+# derivable name), it now captures the annex's own workflow name
+# (annex_workflow) and runs a separate workflow-wide bad/pending scan each
+# poll iteration — the same design codex-review-check.sh gate (a) already
+# uses for the identical reason.
+#
+# The workflow files here cannot be unit-executed without a full Actions
+# runner (same posture as test_465_fail_closed.sh), so this suite asserts
+# each invariant is present in source, plus a bash-syntax check on every
+# agent-review.yml `run:` block (auto-clear-blocking-labels.yml already has
+# its own equivalent syntax check in scripts/ci/check_auto_clear_workflow).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+SKIP=0
+# Propagation-safe: a consumer that does not carry a given workflow simply
+# has nothing to regress, so skip (not fail) when the file is absent.
+assert_grep() {  # <label> <file> <fixed-string>
+  if [ ! -f "$2" ]; then echo "SKIP: $1 ($2 absent)"; SKIP=$((SKIP + 1)); return; fi
+  if grep -qF -- "$3" "$2"; then pass "$1"; else fail "$1 (missing in $2: $3)"; fi
+}
+# Inverse of assert_grep: asserts a string is ABSENT, for regressions that
+# are fixed by removing a dangerous pattern rather than adding a new one.
+assert_not_grep() {  # <label> <file> <fixed-string>
+  if [ ! -f "$2" ]; then echo "SKIP: $1 ($2 absent)"; SKIP=$((SKIP + 1)); return; fi
+  if grep -qF -- "$3" "$2"; then fail "$1 (unexpectedly present in $2: $3)"; else pass "$1"; fi
+}
+
+W=.github/workflows
+
+# agent-review.yml: the required-check wait probes the PR HEAD commit for
+# the annex file via the Contents API (not the job's own checkout) and
+# conditionally scans its check run(s) alongside lint.
+assert_grep "agent-review: probes for the repo_lint_local.yml annex at the PR HEAD commit (#655)" \
+  "$W/agent-review.yml" 'repos/$REPO/contents/.github/workflows/repo_lint_local.yml?ref=$sha'
+assert_grep "agent-review: the wait loop iterates over the required_checks_json array, not one hardcoded name" \
+  "$W/agent-review.yml" 'for ((i = 0; i < check_count; i++)); do'
+
+# Codex P2 (#655 round 6, "avoid forcing path-filtered annex jobs to
+# start"): a consumer annex scoped by workflow-level paths/paths-ignore
+# legitimately never reports under ANY derived name for an out-of-scope
+# PR, so forcing one into required_checks_json (rounds 4-5's approach)
+# made this loop wait out the full deadline and refuse auto-merge forever.
+# required_checks_json must stay scoped to only the canonical check;
+# annex enforcement moves to a name-free workflow-wide scan instead.
+assert_grep "agent-review: required_checks_json stays scoped to only the canonical check (#655 round 6)" \
+  "$W/agent-review.yml" 'required_checks_json stays scoped to ONLY the canonical'
+assert_not_grep "agent-review: no longer force-injects a derived/fallback name into required_checks_json (#655 round 6)" \
+  "$W/agent-review.yml" 'repo-lint-local", workflow: ""'
+assert_grep "agent-review: captures the annex's own workflow name for the separate workflow-wide scan" \
+  "$W/agent-review.yml" 'annex_workflow=$(echo "$annex_probe_raw" | jq -r '"'"'.workflow'"'"')'
+
+# Codex P1 (#655 round 1): an indeterminate annex-probe read (token scope,
+# rate limit, transient error) must not be silently treated the same as a
+# confirmed 404 absence. Round 6 narrowed HOW this is handled (see above:
+# forcing a guessed name here would risk the same deadlock removed from
+# required_checks_json), but it must still be logged distinctly from a
+# confirmed 404, and codex-review-check.sh's gate (a) remains the
+# fail-closed backstop for this same annex on its own re-evaluation
+# schedule.
+assert_grep "agent-review: distinguishes a confirmed 404 (annex genuinely absent) from other errors" \
+  "$W/agent-review.yml" "grep -q 'HTTP 404' \"\$annex_probe_err\""
+assert_grep "agent-review: logs (but no longer force-enforces) an indeterminate non-404 annex-probe error, deferring to gate (a) (#655 round 6)" \
+  "$W/agent-review.yml" 'Could not determine whether repo_lint_local.yml exists'
+
+# Codex P2 (#655 round 1): the annex contract does not mandate the job (and
+# therefore check-run) name be literally repo-lint-local, so the probe
+# derives the actual job name(s) from the annex YAML instead of assuming
+# the filename convention.
+assert_grep "agent-review: derives the annex job name(s) from its YAML rather than assuming the filename" \
+  "$W/agent-review.yml" 'doc["jobs"].each do |id, job|'
+
+# Codex P2 (#655 round 6, "use the file path when the annex omits name"):
+# GitHub displays (and reports into statusCheckRollup .workflowName as) the
+# workflow FILE PATH when the top-level `name:` key is omitted, not an
+# empty string. An empty workflow_name would disable the workflow-wide
+# scan below entirely, even for a valid annex with reported job failures.
+assert_grep "agent-review: falls back to the workflow file path when the annex omits a top-level name: key (#655 round 6)" \
+  "$W/agent-review.yml" 'doc["name"] ? doc["name"].to_s : ".github/workflows/repo_lint_local.yml"'
+
+# Codex P2 (#655 round 2): success/skipped/neutral are all non-blocking
+# conclusions for a required check (matching codex-review-check.sh's own
+# BAD_CHECKS acceptance set) -- a conditional annex job GitHub completes as
+# skipped must not time out or abort native auto-merge. Values are the
+# GraphQL statusCheckRollup enum casing (#655 round 4 data-source switch).
+# Round 5 moved this from a per-run bash if-check to a jq computation over
+# every matched workflow group's winner (see the group-by-workflow
+# assertions below), so the acceptance set now lives in that jq filter.
+assert_grep "agent-review: accepts SUCCESS, SKIPPED, and NEUTRAL conclusions across every matched workflow group" \
+  "$W/agent-review.yml" '($r != "SUCCESS" and $r != "SKIPPED" and $r != "NEUTRAL")'
+
+# Codex P2 (#655 round 3): a matrix-strategy annex job expands into check-run
+# names this static YAML read cannot reproduce -- skip it during derivation
+# (permanently waiting on a name that will never report is worse than not
+# observing that job at all) instead of guessing the unexpanded name.
+assert_grep "agent-review: skips matrix-strategy annex jobs during derivation instead of guessing their expanded name(s)" \
+  "$W/agent-review.yml" 'job["strategy"].is_a?(Hash) && job["strategy"]["matrix"]'
+
+# Codex P1 (#655 round 6, "observe matrix annex jobs before auto-merge"): a
+# matrix job is excluded from NAME derivation above, but its annex_workflow
+# is still captured, so a reported failing matrix leg (under an expanded
+# name this static read could never predict) is still caught by the
+# workflow-wide scan matching on its workflow identity alone.
+#
+# Codex P2 (#655 round 13, "disambiguate annex workflows beyond display
+# name", found on the codex-review-check.sh copy and mirrored here): the
+# annex contract allows any top-level workflow name:, so two workflow files
+# can share the same displayed workflowName -- matching on .workflowPath
+# (derived from the GraphQL-reported resourcePath of the workflow FILE
+# itself) instead closes that collision, since the annex's file path is
+# fixed and not consumer-editable.
+assert_grep "agent-review: workflow-wide annex scan matches by the stable .workflowPath, not the collision-prone display name (#655 round 13)" \
+  "$W/agent-review.yml" '[.statusCheckRollup[] | select((.workflowPath // "") == "repo_lint_local.yml")]'
+assert_grep "agent-review: a bad conclusion reported anywhere in the annex's workflow refuses auto-merge immediately (#655 round 6)" \
+  "$W/agent-review.yml" 'non-passing reported check-run(s) after winner-selection on current HEAD $sha (conclusion=$annex_bad_summary); refusing auto-merge (#655)'
+assert_grep "agent-review: a still-in-progress annex entry is treated as pending (keeps polling), not as a failure (#655 round 6)" \
+  "$W/agent-review.yml" 'check-run(s) still in progress on current HEAD $sha; waiting for completion (#655)'
+assert_grep "agent-review: workflow query requests resourcePath alongside name to derive the stable workflowPath (#655 round 13)" \
+  "$W/agent-review.yml" 'checkSuite { workflowRun { workflow { name resourcePath } } }'
+assert_grep "agent-review: rollup_json derives workflowPath from resourcePath's final path segment (#655 round 13)" \
+  "$W/agent-review.yml" 'workflowPath: (((.checkSuite.workflowRun.workflow.resourcePath // "") | split("/") | last) // "")'
+assert_grep "agent-review: annex_bad groups by check name and keeps only the latest-completed winner per name before judging bad-ness (#655 round 13)" \
+  "$W/agent-review.yml" 'group_by(.name // .context // "?")'
+
+# Codex P2 (#655 round 4): a 403 (token lacks Contents: read) is usually
+# persistent, unlike other indeterminate errors -- forcing the synthetic
+# fallback here would permanently block native auto-merge on every future
+# PR, not just annex-having ones. Do not fail closed on a confirmed 403.
+assert_grep "agent-review: does not fail closed on a confirmed 403 (likely a persistent token-scope gap, not transient)" \
+  "$W/agent-review.yml" "grep -q 'HTTP 403' \"\$annex_probe_err\""
+
+# Codex P2 (#655 round 4): "could not parse the YAML at all" (ruby exits
+# before its `puts` line -- empty output) is a different failure mode from
+# "parsed fine but every job was matrix-strategy and skipped" (ruby emits a
+# jobs: [] with the workflow name still populated). Round 6 stopped forcing
+# a conventional-name fallback for EITHER case (see the required_checks_json
+# assertions above) -- the distinction still matters because the
+# matrix-skipped case still yields a usable annex_workflow for the
+# workflow-wide scan, while the genuine parse failure yields nothing to
+# scan at all.
+assert_grep "agent-review: distinguishes genuine YAML-parse failure from a valid parse where every job was matrix-skipped" \
+  "$W/agent-review.yml" 'every job is matrix-strategy (skipped)'
+
+# Codex P2 (#655 round 4): the annex contract does not require unique job
+# names, so matching must disambiguate by workflow (not name alone) via the
+# same statusCheckRollup data source codex-review-check.sh's gate (a) uses
+# (switched from the check-runs REST endpoint, which has no workflow-name
+# field), picking the latest run per (name, workflow) pair.
+assert_grep "agent-review: disambiguates required checks by (name, workflow) via statusCheckRollup" \
+  "$W/agent-review.yml" 'select($workflow == "" or (.workflowName // "") == $workflow)'
+
+# Codex P2 (#655 round 5, superseding round 4's plain sort_by|last): matches
+# are grouped by workflow identity before picking a winner. Within a group,
+# any NON-COMPLETED entry (e.g. a queued rerun with neither startedAt nor
+# completedAt set) takes priority over a stale completed one -- a naive
+# sort_by(startedAt // completedAt) ranked an empty-timestamp queued entry
+# BEFORE an older completed one, so `last` picked the stale result. Across
+# groups, EVERY group's winner must be green -- so a same-named annex job
+# (allowed by the annex contract, workflow=="" matches any workflow) can
+# never stand in for a failing canonical `lint`.
+assert_grep "agent-review: groups matching checks by workflow before picking a winner (not a bare sort_by | last)" \
+  "$W/agent-review.yml" 'group_by(.workflowName // "")'
+assert_grep "agent-review: picks the latest COMPLETED run within a workflow group when nothing is pending" \
+  "$W/agent-review.yml" 'sort_by(.completedAt // .startedAt // "")'
+assert_grep "agent-review: requires every matched workflow group to be green, not just one arbitrary winner" \
+  "$W/agent-review.yml" 'Every group'"'"'s winner must be green'
+
+# Codex P2 (#655 round 6, "treat successful status contexts as complete"):
+# a StatusContext entry (e.g. a legacy commit status, no .status field at
+# all -- only CheckRun has one) was treated as pending FOREVER by a bare
+# `.status != "COMPLETED"` check, since null != "COMPLETED" is true
+# regardless of .state. A StatusContext is non-terminal only when .state is
+# literally "PENDING" -- round 7 added "EXPECTED" (GitHub's "waiting for a
+# status to be reported" state, distinct from PENDING but equally
+# non-terminal): without it, a required external status context sitting in
+# EXPECTED aborted the wait loop as a failure instead of continuing to
+# poll. A CheckRun is non-terminal whenever .status is present and not
+# "COMPLETED". This predicate is shared by the winner selection, the
+# pending-count check, and the annex workflow-wide scan.
+assert_grep "agent-review: a status-context entry is pending when .state is PENDING or EXPECTED, not merely lacking .status (#655 rounds 6-7)" \
+  "$W/agent-review.yml" 'if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end'
+
+# Self-caught while porting the pending-check above into
+# codex-review-check.sh for #655 round 13: the ORIGINAL form piped a bare
+# array literal straight into `index(.state // "")`, which rebinds `.` to
+# that array literal for the rest of the pipeline -- `.state` then tries to
+# index an array with a string and jq hard-errors, but only for a
+# StatusContext (no .status field), since a CheckRun never reaches this
+# `else` branch at all. Latent since round 6/7 (never triggered here
+# because every entry observed so far has been a CheckRun), but a classic
+# Statuses-API context reaching this branch would fail the whole jq call.
+# Fixed by binding .state to a variable BEFORE the array-literal pipe;
+# guarded here so the fix cannot silently regress back to the broken form.
+assert_not_grep "agent-review: does not regress to the pre-round-13 index(.state) expression that rebinds dot inside the array-literal pipe" \
+  "$W/agent-review.yml" '(["PENDING","EXPECTED"] | index(.state // ""))'
+
+# Codex P1 (#655 round 7, "parse valid annex workflows that use YAML
+# aliases"): GitHub Actions supports YAML anchors/aliases in workflow
+# files, but Psych safe_load's aliases:false default rejected any alias
+# and treated the whole annex as unparseable. Allowing aliases outright
+# would reopen a YAML alias-expansion ("billion laughs") DoS against the
+# CI runner parsing a PR's own branch content -- guarded here with a byte-
+# size cap and a raw anchor/alias token-count cap, both checked BEFORE the
+# actual parse (the danger is in the expansion, not the input size).
+assert_grep "agent-review: allows YAML aliases when parsing the annex (#655 round 7)" \
+  "$W/agent-review.yml" 'doc = YAML.safe_load(raw, aliases: true)'
+assert_grep "agent-review: bounds annex YAML size before parsing, defending against a YAML alias-expansion DoS (#655 round 7)" \
+  "$W/agent-review.yml" 'if raw.bytesize > 100_000'
+
+# Codex P2 (#655 round 8, "avoid treating path globs as YAML aliases") and
+# round 9 ("do not count glob hyphens as YAML aliases"): the round-7
+# guard's naive `[&*]word` scan counted an ordinary glob like `**/*.ts`
+# (round 8) or a hyphenated one like `component-*.ts` (round 9, since a
+# bare trailing `-` was accepted as a structural position ANYWHERE in the
+# text) as alias tokens -- a legitimate annex with a longer or hyphenated
+# filter list could exceed the cap and be treated as too-dangerous-to-
+# parse. A real anchor/alias can only appear at a structural position:
+# start of text; a block-sequence dash anchored to the START OF ITS LINE
+# with a mandatory space before its value (round 9, excluding a mid-string
+# hyphen like a glob own); or `:`/`,`/`[`/`{` anywhere, optionally followed
+# by whitespace. A glob string value (always quoted when it starts with
+# `*`, since an unquoted one is itself a YAML syntax error) never
+# satisfies any of these.
+assert_grep "agent-review: alias token-count guard requires a line-anchored dash (or other structural position), no longer over-counting quoted or hyphenated path globs (#655 rounds 8-9)" \
+  "$W/agent-review.yml" 'if raw.scan(/(?:\A|^[ \t]*-\s+|[:,\[{]\s*)[&*][A-Za-z0-9_.-]+/).length > 40'
+
+# Codex P1 (#655 round 7, "wait for unfiltered annex workflow to appear
+# before merging"): an annex with NO restricting filter is guaranteed to
+# eventually produce a check run for this PR, so zero reported entries
+# just means Actions has not scheduled it yet -- unlike a genuinely
+# filtered annex, where zero entries is legitimately ambiguous between
+# "not yet" and "never for this diff" (Finding O, round 6, which must stay
+# non-blocking). YAML 1.1 coerces the bareword `on:` key to the boolean
+# true (the "Norway problem"), so doc["on"] is nil for the overwhelmingly
+# common unquoted `on:` and the fallback doc[true] read is required, not
+# optional.
+assert_grep "agent-review: reads the on: trigger via the true-key fallback (YAML 1.1 Norway-problem coercion) (#655 round 7)" \
+  "$W/agent-review.yml" 'on = doc.key?("on") ? doc["on"] : doc[true]'
+assert_grep "agent-review: keeps polling (does not silently pass) when an unfiltered annex has zero reported entries (#655 round 7)" \
+  "$W/agent-review.yml" 'if [ "$annex_match_count" -eq 0 ] && [ "$annex_unfiltered" = "true" ]; then'
+assert_grep "agent-review: a path-filtered annex with zero reported entries still does not block (Finding O, round 6, preserved)" \
+  "$W/agent-review.yml" 'has not reported yet (unfiltered trigger, so it is expected to)'
+
+# Codex P2 (#655 round 9, "honor non-path pull_request filters before
+# waiting") and round 11 ("evaluate base-branch filters before passing"):
+# round 8 checked only paths/paths-ignore on the pull_request config.
+# Round 9 blanket-disqualified on branches/branches-ignore presence too;
+# round 11 replaced that with an actual evaluation against the real ref
+# (below), since GitHub schedules the workflow whenever the ref matches
+# the filter, not merely when the filter is absent (types is handled
+# separately too, since round 10 found it needs different treatment).
+assert_grep "agent-review: a dedicated helper disqualifies push only when tags/tags-ignore is present AND branches/branches-ignore is entirely absent (#655 round 13)" \
+  "$W/agent-review.yml" 'def push_tag_only_excludes?(cfg)'
+assert_grep "agent-review: push_tag_only_excludes? is wired into the trigger_unfiltered lambda for the push event (#655 round 13)" \
+  "$W/agent-review.yml" 'next false if event == "push" && push_tag_only_excludes?(cfg)'
+
+# Codex P1 (#655 round 10, found on the codex-review-check.sh copy of this
+# same logic and mirrored here): round 9 disqualified "unfiltered" on the
+# MERE PRESENCE of a types key, but types selects WHICH pull_request
+# activities trigger the workflow at all (GitHub default when omitted is
+# [opened, synchronize, reopened]) rather than narrowing by path/branch.
+# An explicit `types: [opened, synchronize, reopened]` -- functionally
+# identical to omitting types -- was wrongly disqualified. Only a types
+# list that EXCLUDES synchronize should disqualify, since that is the
+# activity that fires for a resynchronized PRs current HEAD.
+assert_grep "agent-review: treats a types list that includes synchronize as unfiltered, not merely absent (#655 round 10)" \
+  "$W/agent-review.yml" 'next (cfg["types"].is_a?(Array) && cfg["types"].include?("synchronize")) if cfg.key?("types")'
+
+# Codex P2 (#655 round 16, "do not skip opened-only annex runs"),
+# REVERTED in round 17 ("do not infer opened-only runs from committer
+# date", found on the codex-review-check.sh copy and mirrored here):
+# round 16 tried to treat types: [opened] (no synchronize) as unfiltered
+# when the HEAD committer date predates PR creation. Confirmed live: a
+# genuinely-new synchronize push whose commit preserves an OLDER
+# committer date (a rebase/cherry-pick of a stale commit) still satisfies
+# that comparison, so the heuristic could say "unfiltered" for a trigger
+# that will NEVER report again on that HEAD -- a real, confirmed
+# permanent-wait risk, worse than the narrower gap being reopened. No
+# reliable, non-spoofable signal is available from data this script
+# already has, so the mechanism was removed entirely rather than patched
+# further; only a types list that explicitly includes synchronize counts
+# as unfiltered again (the simple, safe round-10 rule).
+assert_not_grep "agent-review: no longer infers an opened-only annex is unfiltered from committer date (#655 round 17)" \
+  "$W/agent-review.yml" 'head_predates_pr_creation'
+assert_not_grep "agent-review: no longer fetches PR createdAt for the reverted opened-only heuristic (#655 round 17)" \
+  "$W/agent-review.yml" ',createdAt)'
+assert_not_grep "agent-review: no longer fetches the annex HEAD's own committer date for the reverted opened-only heuristic (#655 round 17)" \
+  "$W/agent-review.yml" 'annex_head_committer_date='
+assert_grep "agent-review: types: [opened] alone (no synchronize) is unconditionally filtered again, closing the deadlock risk (#655 round 17)" \
+  "$W/agent-review.yml" 'next (cfg["types"].is_a?(Array) && cfg["types"].include?("synchronize")) if cfg.key?("types")'
+
+# Codex P2 (#655 round 11, "evaluate base-branch filters before passing",
+# found on the codex-review-check.sh copy and mirrored here):
+# `pull_request: {branches: [main]}` still runs for every PR targeting
+# main -- evaluated against the real ref (pull_request compares the PRs
+# BASE ref; push compares the ref actually pushed, which for a same-repo
+# PRs synchronize is its own HEAD ref, not base), with a conservative
+# disqualify when the relevant branch cannot be resolved. Matching itself
+# switched from File.fnmatch to a regex translator in round 13 (see the
+# branch_pattern_to_regex assertions further below).
+assert_grep "agent-review: evaluates branches/branches-ignore against the real ref instead of blanket-disqualifying on presence (#655 round 11)" \
+  "$W/agent-review.yml" 'def branch_filter_excludes?(cfg, branch)'
+assert_grep "agent-review: pull_request branches evaluation uses the PRs base ref, not head (#655 round 11)" \
+  "$W/agent-review.yml" 'trigger_unfiltered.call("pull_request", ENV["ANNEX_BASE_BRANCH"])'
+assert_grep "agent-review: push branches evaluation uses the PRs own head ref, not base (#655 round 11)" \
+  "$W/agent-review.yml" 'trigger_unfiltered.call("push", ENV["ANNEX_HEAD_BRANCH"])'
+
+# Codex P2 (#655 round 16, "wait for path-matched annex workflows",
+# narrowed in round 17 -- "use the event diff when emulating path
+# filters", found on the codex-review-check.sh copy and mirrored here): a
+# paths/paths-ignore key was previously treated as unconditionally
+# filtered on mere presence, even when the PRs actual changed files match
+# the filter. Path glob syntax documents the SAME tokens as branch/tag
+# patterns, so branch_matches_list? is reused. GitHub evaluates a push
+# triggers path filter against the two-dot diff of JUST that push, not
+# the whole-PR three-dot diff this fetch provides, so only pull_request
+# gets the real evaluation; push keeps the always-filtered default. The
+# changed-file list is also capped to GitHub own 300-file evaluation
+# limit.
+assert_grep "agent-review: evaluates paths/paths-ignore against the PRs real changed files instead of blanket-disqualifying on presence (#655 round 16)" \
+  "$W/agent-review.yml" 'def paths_filter_excludes?(event, cfg, changed_files, changed_files_known)'
+assert_grep "agent-review: push never gets the real path evaluation, avoiding a two-dot-vs-three-dot diff scope mismatch (#655 round 17)" \
+  "$W/agent-review.yml" 'return true if event == "push"'
+assert_grep "agent-review: caps the changed-file list to GitHub's own 300-file path-filter evaluation limit (#655 round 17)" \
+  "$W/agent-review.yml" 'capped_files = changed_files.first(300)'
+assert_grep "agent-review: paths requires at least one changed file to match (#655 round 16)" \
+  "$W/agent-review.yml" 'return true unless capped_files.any? { |f| branch_matches_list?(cfg["paths"], f) }'
+assert_grep "agent-review: paths-ignore excludes only when EVERY changed file matches the ignore patterns (#655 round 16)" \
+  "$W/agent-review.yml" 'return true if capped_files.all? { |f| branch_matches_list?(cfg["paths-ignore"], f) }'
+assert_grep "agent-review: fetches the PRs real changed-file list, paginated (#655 round 16)" \
+  "$W/agent-review.yml" 'annex_changed_files_raw=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files"'
+assert_grep "agent-review: paths_filter_excludes? is wired into trigger_unfiltered ahead of the tag/branch checks (#655 round 16)" \
+  "$W/agent-review.yml" 'next false if paths_filter_excludes?(event, cfg, changed_files, changed_files_known)'
+# Codex P2 (#655 round 17, "fail closed when the changed-file lookup
+# fails", Codex; "don't silently treat changed-files API failures as
+# filtered out", CodeRabbit): the round-16 fetch piped stderr into stdout
+# with no failure check, so a failed gh api call fed an error message
+# into jq, which failed too, silently collapsing to an empty list --
+# indistinguishable from "genuinely fetched, zero files", wrongly read as
+# "paths definitely does not match". An explicit success/failure branch
+# keeps a failure as an EXPLICITLY empty string, which changed_files_known
+# treats as unresolvable rather than "no files".
+assert_grep "agent-review: explicitly branches on the changed-files fetch succeeding vs failing (#655 round 17)" \
+  "$W/agent-review.yml" 'if annex_changed_files_raw=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" 2>&1); then'
+assert_grep "agent-review: a failed changed-files fetch leaves the JSON explicitly empty rather than silently valid (#655 round 17)" \
+  "$W/agent-review.yml" 'annex_changed_files_json=""'
+assert_grep "agent-review: changed_files_known distinguishes a fetch failure from a genuinely-empty changed-file list (#655 round 17)" \
+  "$W/agent-review.yml" 'changed_files_known = !(ENV["ANNEX_CHANGED_FILES_JSON"] || "").empty?'
+assert_grep "agent-review: derives base/head branch names from the same pr_view_json call, no extra API call (#655 round 11)" \
+  "$W/agent-review.yml" 'annex_base_branch=$(echo "$pr_view_json"'
+assert_grep "agent-review: gh pr view fetches baseRefName/headRefName alongside the existing fields (#655 round 11)" \
+  "$W/agent-review.yml" '--json headRefOid,isCrossRepository,baseRefName,headRefName'
+
+# Codex P2 (#655 round 11, "treat tag-only push annexes as filtered",
+# narrowed in round 13 -- "do not treat tag filters as excluding branch
+# pushes", mirrored): a push trigger scoped ONLY by tags/tags-ignore (no
+# branches/branches-ignore at all) only fires for TAG ref pushes, never an
+# ordinary branch push -- which is what a same-repo PRs synchronize always
+# is. But GitHub documents branches and tags as combinable on the SAME push
+# trigger, so a trigger with BOTH keys must still be evaluated by its
+# branches filter (already confirmed by the push_tag_only_excludes?
+# assertions above).
+
+# Codex P2 (#655 round 9, "wait for valid push-only annex workflows"):
+# check_ci_scripts_wired accepts push OR pull_request as valid annex
+# wiring, but a push-only annex (no pull_request trigger at all) was never
+# classified as unfiltered, so this wait never waited for it even though it
+# is a contractually valid annex. A push trigger only fires IN THIS REPO
+# for a same-repo PR (a fork PRs push lands in the fork, never here), so
+# this is gated on annex_same_repo_pr (derived from gh pr views own
+# isCrossRepository field, no extra API call) rather than applied
+# unconditionally.
+assert_grep "agent-review: derives same-repo-PR status via gh pr views isCrossRepository field, no extra API call (#655 round 9)" \
+  "$W/agent-review.yml" 'annex_same_repo_pr=$(echo "$pr_view_json"'
+assert_grep "agent-review: same-repo-PR determination inverts isCrossRepository (#655 round 9)" \
+  "$W/agent-review.yml" 'if .isCrossRepository then "false" else "true" end'
+assert_grep "agent-review: treats a push-only annex as unfiltered when (and only when) the PR is same-repo (#655 round 9)" \
+  "$W/agent-review.yml" 'unfiltered = pr_unfiltered || (push_unfiltered && same_repo_pr)'
+
+# Codex P2 (#655 round 11, "restrict the lint wait to the required
+# workflow"): the round-5 "group by workflow, require every group green"
+# rule closed the mask-the-canonical-check risk, but left the OPPOSITE
+# risk open for the workflow=="" (canonical) match -- a coincidentally
+# same-named but NON-required check from an unrelated workflow would ALSO
+# become a mandatory group. isRequired(pullRequestNumber:) (ground truth,
+# only resolvable via a direct graphql query -- gh pr views fixed --json
+# shape omits it) now filters the workflow=="" case to required entries
+# when any same-name entry reports required=true. If none do, the
+# configured-check wait still honors the configured check name.
+assert_grep "agent-review: fetches statusCheckRollup via a direct graphql query to access isRequired (#655 round 11)" \
+  "$W/agent-review.yml" 'isRequired(pullRequestNumber: $number)'
+assert_grep "agent-review: the canonical (workflow==\"\") match builds a required=true subset when GitHub reports one (#655 round 15)" \
+  "$W/agent-review.yml" '([$name_matches[] | select(.isRequired == true)]) as $required_matches'
+assert_grep "agent-review: the canonical (workflow==\"\") match falls back to all name matches when none report required=true (#655 round 15)" \
+  "$W/agent-review.yml" 'if $workflow == "" and ($required_matches | length) > 0'
+
+if command -v jq >/dev/null 2>&1; then
+  agent_review_winners() {
+    local rollup_json=$1 check_name=$2 check_workflow=$3
+    printf '%s' "$rollup_json" | jq -c --arg name "$check_name" --arg workflow "$check_workflow" '
+      [.statusCheckRollup[]
+        | select((.name // .context // "") == $name)
+        | select($workflow == "" or (.workflowName // "") == $workflow)
+      ] as $name_matches
+      | ([$name_matches[] | select(.isRequired == true)]) as $required_matches
+      | (if $workflow == "" and ($required_matches | length) > 0
+         then $required_matches
+         else $name_matches
+         end) as $matches
+      | ($matches | group_by(.workflowName // "")) as $groups
+      | [
+          $groups[]
+          | (map(select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end))) as $pending
+          | if ($pending | length) > 0
+            then $pending[0]
+            else (sort_by(.completedAt // .startedAt // "") | last)
+            end
+        ]'
+  }
+  ROLLUP_OPTIONAL_ONLY_LINT='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","status":"COMPLETED","conclusion":"SUCCESS","isRequired":false,"completedAt":"2026-07-01T00:00:00Z"}]}'
+  GOT=$(agent_review_winners "$ROLLUP_OPTIONAL_ONLY_LINT" "lint" "" | jq -c '[.[].workflowName]')
+  if [ "$GOT" = '["repo-lint"]' ]; then
+    pass "agent-review jq: configured lint wait still observes a same-named check when no matching entry reports isRequired=true (#655 round 15)"
+  else
+    fail "agent-review jq (no required metadata fallback): expected [\"repo-lint\"], got $GOT"
+  fi
+  ROLLUP_REQUIRED_PLUS_OPTIONAL_LINT='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","status":"COMPLETED","conclusion":"SUCCESS","isRequired":true,"completedAt":"2026-07-01T00:00:00Z"},{"name":"lint","workflowName":"optional-local","status":"COMPLETED","conclusion":"FAILURE","isRequired":false,"completedAt":"2026-07-01T00:01:00Z"}]}'
+  GOT=$(agent_review_winners "$ROLLUP_REQUIRED_PLUS_OPTIONAL_LINT" "lint" "" | jq -c '[.[].workflowName]')
+  if [ "$GOT" = '["repo-lint"]' ]; then
+    pass "agent-review jq: optional same-named collisions are dropped when a required=true lint entry is present (#655 round 15)"
+  else
+    fail "agent-review jq (required metadata narrowing): expected [\"repo-lint\"], got $GOT"
+  fi
+else
+  echo "SKIP: agent-review jq winner-selection regression fixtures (jq unavailable)"
+  SKIP=$((SKIP + 1))
+fi
+
+# Codex P1 (#655 round 12, "paginate the status check rollup"): a PR with
+# more than 100 statusCheckRollup contexts (this PR itself already had
+# 160+, confirmed live) silently hid every entry past the first page from
+# both the required-check and annex workflow-wide scans -- auto-merge
+# could arm while an unobserved check past page 1 was still red. Paged
+# through with the Relay cursor rather than a bigger fixed page size,
+# since the rollup can grow without bound on a long-lived PR.
+assert_grep "agent-review: pages through statusCheckRollup contexts via the Relay cursor instead of a single fixed-size page (#655 round 12)" \
+  "$W/agent-review.yml" 'contexts(first: 100, after: $cursor)'
+assert_grep "agent-review: passes a null GraphQL cursor on the first statusCheckRollup page (#655 round 14)" \
+  "$W/agent-review.yml" 'cursor_args=(-F cursor=null)'
+assert_grep "agent-review: passes the returned Relay cursor after the first statusCheckRollup page (#655 round 14)" \
+  "$W/agent-review.yml" 'cursor_args=(-f cursor="$cursor")'
+assert_grep "agent-review: null statusCheckRollup pages normalize to an empty contexts array (#655 round 15)" \
+  "$W/agent-review.yml" 'statusCheckRollup.contexts.nodes // []'
+assert_grep "agent-review: null statusCheckRollup pages stop pagination instead of hard-erroring (#655 round 15)" \
+  "$W/agent-review.yml" 'statusCheckRollup.contexts.pageInfo.hasNextPage // false'
+assert_grep "agent-review: null statusCheckRollup pages use an empty cursor (#655 round 15)" \
+  "$W/agent-review.yml" 'statusCheckRollup.contexts.pageInfo.endCursor // ""'
+assert_grep "agent-review: the pagination loop checks hasNextPage and accumulates entries across pages (#655 round 12)" \
+  "$W/agent-review.yml" 'pageInfo { hasNextPage endCursor }'
+assert_grep "agent-review: accumulates each page's contexts into the running rollup array (#655 round 12)" \
+  "$W/agent-review.yml" 'rollup_contexts=$(jq -c -n --argjson a "$rollup_contexts" --argjson b "$page_nodes"'
+
+# Codex P2 (#655 round 12, "honor GitHub Actions branch glob semantics",
+# found on the codex-review-check.sh copy and mirrored here): GitHub docs
+# specify a single `*` does NOT cross a `/` while `**` DOES; patterns are
+# also evaluated IN ORDER with an optional `!` prefix negating a prior
+# match, which the round-11 `any?` check ignored entirely. Round 12 used
+# File.fnmatch (with FNM_PATHNAME applied only for non-globstar patterns)
+# for the single-star/double-star distinction.
+assert_grep "agent-review: evaluates branch patterns in order with ! negation, a later pattern overriding an earlier one (#655 round 12)" \
+  "$W/agent-review.yml" 'def branch_matches_list?(patterns, branch)'
+
+# Codex P2 (#655 round 13, "use an Actions-compatible branch glob matcher",
+# found on the codex-review-check.sh copy and mirrored here): the round-12
+# fnmatch version could not represent a `+` repetition quantifier (e.g.
+# `v[12].[0-9]+.[0-9]+`, GitHub's documented semver-branch example) --
+# fnmatch always treats `+` as a literal character and returns false.
+# Replaced with a translator that converts each documented glob token into
+# an equivalent Ruby Regexp (which natively supports quantifiers and
+# character classes), matched via Regexp#match?. Round 14 added backslash
+# escaping for literal special characters in branch or tag names.
+assert_grep "agent-review: translates branch glob patterns into a Ruby Regexp instead of using File.fnmatch (#655 round 13)" \
+  "$W/agent-review.yml" 'def branch_pattern_to_regex(pattern)'
+assert_grep "agent-review: a lone * translates to a single-path-segment match, not crossing / (#655 round 13)" \
+  "$W/agent-review.yml" 'tokens << "[^/]*"'
+assert_grep "agent-review: ** translates to a cross-segment match (#655 round 13)" \
+  "$W/agent-review.yml" 'tokens << ".*"'
+assert_grep "agent-review: a + quantifier is copied through verbatim, since Ruby Regexp supports it natively (#655 round 13)" \
+  "$W/agent-review.yml" 'elsif c == "+"'
+assert_grep "agent-review: backslash escapes the next branch glob metacharacter into a literal match (#655 round 14)" \
+  "$W/agent-review.yml" 'tokens << Regexp.escape(chars[i + 1])'
+assert_grep "agent-review: branch_matches? now delegates to the regex translator instead of File.fnmatch (#655 round 13)" \
+  "$W/agent-review.yml" 'branch_pattern_to_regex(pattern).match?(branch)'
+assert_not_grep "agent-review: no longer uses File.fnmatch for branch matching (#655 round 13)" \
+  "$W/agent-review.yml" 'File.fnmatch(pattern, branch, flags)'
+
+# Codex P2 (#655 round 16, "honor ? as an optional-character filter",
+# found on the codex-review-check.sh copy and mirrored here): GitHub
+# documents `?` as matching zero or one of the PRECEDING character (e.g.
+# `release?` matches base branch `release` itself), not "exactly one
+# arbitrary character" the way POSIX glob/fnmatch define it -- the
+# round-13 translator emitted an independent [^/] token for `?` instead of
+# quantifying whatever came before it. Building a token LIST (rather than
+# one flat string) lets `?` wrap the last token in `(?:...)?`.
+assert_grep "agent-review: builds a token list instead of a flat string, so ? can quantify the preceding token (#655 round 16)" \
+  "$W/agent-review.yml" 'tokens = []'
+assert_grep "agent-review: ? wraps the preceding token in an optional non-capturing group instead of emitting an independent [^/] (#655 round 16)" \
+  "$W/agent-review.yml" 'tokens[-1] = "(?:#{tokens[-1]})?" if tokens.any?'
+assert_not_grep "agent-review: no longer treats ? as an unconditional single-character wildcard (#655 round 16)" \
+  "$W/agent-review.yml" 'result << "[^/]"'
+
+# auto-clear-blocking-labels.yml: the workflow_run trigger list observes the
+# annex's completion too (verified against a live consumer's repo_lint_local.yml
+# workflow name, per #655).
+assert_grep "auto-clear: workflow_run trigger list includes repo-lint-local (#655)" \
+  "$W/auto-clear-blocking-labels.yml" '- "repo-lint-local"'
+
+# Codex P3 (#655 round 11, "include the unnamed annex workflow trigger"):
+# workflow_run matches by the target workflow's displayed NAME, which for
+# an annex omitting a top-level `name:` is the workflow FILE PATH (round
+# 6's fallback), not the literal "repo-lint-local" string.
+assert_grep "auto-clear: workflow_run trigger list also includes the unnamed-annex file-path fallback name (#655 round 11)" \
+  "$W/auto-clear-blocking-labels.yml" '- ".github/workflows/repo_lint_local.yml"'
+
+# ── Bash syntax check on every agent-review.yml `run:` block. Catches
+#    heredoc/subshell/loop errors the grep assertions above cannot (mirrors
+#    check_auto_clear_workflow's equivalent check for its own file — no
+#    such check previously existed for agent-review.yml).
+echo
+echo "agent-review.yml bash syntax test"
+
+if [ -f "$W/agent-review.yml" ]; then
+  block_dir=$(mktemp -d)
+  awk -v outdir="$block_dir" '
+    /^[[:space:]]+run:[[:space:]]+\|[[:space:]]*$/ {
+      if (in_run) { close(outfile) }
+      n++; outfile = outdir "/block-" n ".sh"
+      match($0, /^[[:space:]]+/); base_indent = RLENGTH
+      in_run = 1; next
+    }
+    in_run && NF == 0 { print > outfile; next }
+    in_run {
+      match($0, /^[[:space:]]*/); cur_indent = RLENGTH
+      if (cur_indent <= base_indent) {
+        close(outfile); in_run = 0; next
+      }
+      sub("^[[:space:]]{" (base_indent + 2) "}", "")
+      print > outfile
+    }
+    END { if (in_run) close(outfile) }
+  ' "$W/agent-review.yml"
+
+  extracted_count=$(ls -1 "$block_dir" 2>/dev/null | wc -l | tr -d ' ')
+  syntax_errors=0
+  for f in "$block_dir"/block-*.sh; do
+    [ -f "$f" ] || continue
+    if ! err=$(bash -n "$f" 2>&1); then
+      fail "bash syntax error in $(basename "$f") (agent-review.yml)"
+      echo "$err" | sed 's/^/    /' >&2
+      syntax_errors=$((syntax_errors + 1))
+    fi
+  done
+  rm -rf "$block_dir"
+
+  if [ "$syntax_errors" -eq 0 ] && [ "$extracted_count" -gt 0 ]; then
+    pass "all $extracted_count agent-review.yml run blocks have valid bash syntax"
+  elif [ "$extracted_count" = "0" ]; then
+    fail "extracted 0 run blocks from agent-review.yml (extraction logic broken?)"
+  fi
+else
+  echo "SKIP: agent-review.yml bash syntax test (file absent)"; SKIP=$((SKIP + 1))
+fi
+
+echo ""
+echo "test_655_repo_lint_local_observed: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/tests/test_codex_record_feedback.sh
+++ b/tests/test_codex_record_feedback.sh
@@ -23,6 +23,11 @@ pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
 
 SOLICIT='Useful? React with 👍 / 👎.'
+# #682: byte-faithful fixture matching what chatgpt-codex-connector[bot]
+# actually posts -- U+00A0 (NBSP, UTF-8 c2 a0) immediately before the slash,
+# not the regular space (0x20) in $SOLICIT above.
+NBSP=$'\xc2\xa0'
+SOLICIT_NBSP="Useful? React with 👍${NBSP}/ 👎."
 
 # make_case <name> — scaffolds a temp repo with the real script + lib resolver,
 # a recording gh-as-reviewer.sh stub, and a configurable gh stub. Echoes the
@@ -264,6 +269,35 @@ EOF
     fail "no-verdict: skip reason was $(jq -r '.skipped[0].why' "$dir/out.json"), expected no-verdict"
   else
     pass "a soliciting finding with no --verdict is skipped (no blanket reaction)"
+  fi
+}
+
+test_nbsp_solicitation_is_matched() {
+  # #682: the live Codex comment uses U+00A0 (NBSP) immediately before the
+  # slash instead of a regular space. A byte-faithful fixture (not a
+  # hand-typed ASCII approximation) must still be recognized as soliciting
+  # feedback and reacted to, exactly like the plain-space form.
+  local dir rc
+  dir=$(make_case "nbsp-solicit")
+  write_gh_readonly "$dir"
+  cat >"$dir/findings.json" <<EOF
+{ "findings": [
+  { "path": "scripts/ci/check_z", "line": 7, "priority": "P1", "comment_id": 5101,
+    "body": "NBSP-solicitation finding.\n\n$SOLICIT_NBSP" }
+] }
+EOF
+  rc=$(run_case "$dir" -- 999 owner/repo --findings-json findings.json --verdict 5101=fixed)
+
+  if [ "$rc" != "0" ]; then
+    fail "nbsp-solicit: exit $rc, expected 0; stderr=$(cat "$dir/err.log")"
+  elif ! grep -q 'gh api -X POST repos/owner/repo/pulls/comments/5101/reactions -f content=+1' "$(posts_file "$dir")"; then
+    fail "nbsp-solicit: did not POST +1 for an NBSP-solicitation finding; posts=$(cat "$(posts_file "$dir")" 2>/dev/null)"
+  elif [ "$(jq -r '.skipped | length' "$dir/out.json")" != "0" ]; then
+    fail "nbsp-solicit: finding was skipped; out=$(cat "$dir/out.json")"
+  elif [ "$(ledger_lines "$dir")" != "1" ]; then
+    fail "nbsp-solicit: ledger has $(ledger_lines "$dir") lines, expected 1"
+  else
+    pass "a solicitation using U+00A0 (NBSP) before the slash is matched and reacted to, same as the plain-space form (#682)"
   fi
 }
 
@@ -643,6 +677,7 @@ test_string_id_coerced_no_double_report
 test_fixed_reacts_plus1_via_reviewer
 test_rebuttal_reacts_minus1
 test_no_solicitation_is_never_reacted
+test_nbsp_solicitation_is_matched
 test_solicits_but_no_verdict_is_skipped
 test_idempotent_existing_reviewer_reaction
 test_dry_run_posts_nothing

--- a/tests/test_codex_review_check_required_checks.sh
+++ b/tests/test_codex_review_check_required_checks.sh
@@ -1,0 +1,1259 @@
+#!/usr/bin/env bash
+# tests/test_codex_review_check_required_checks.sh
+#
+# Regression coverage for gate (a)'s annex-awareness in
+# scripts/codex-review-check.sh (#655): when branch protection lists SOME
+# required checks (the common case), gate (a) narrows its "must be green"
+# scrutiny to that list — so a consumer's optional, never-propagated #601
+# repo_lint_local.yml annex check is silently excluded, even when it is red,
+# entirely missing, or shares a name with an unrelated check. Branch
+# protection cannot require it centrally — the annex is per-consumer and
+# never propagated, so there is no canonical PR to add it fleet-wide (that
+# half is a human branch-protection change; see #655). This closes the
+# agent-doable half across thirteen rounds of Codex findings; only the
+# architecturally-significant ones are summarized here (see git history /
+# PR #687 for the full round-by-round detail):
+#
+#   Rounds 1-4: force-include the annex's check into gate (a)'s scrutiny
+#   (including when branch protection requires nothing at all), derive its
+#   real job name(s) instead of assuming the "repo-lint-local" filename
+#   convention, skip matrix-strategy jobs during name derivation (their
+#   expanded names cannot be predicted), and distinguish a persistent 403
+#   from a transient probe error.
+#
+#   Round 5 (superseding rounds 2-4's MISSING-injection approach): rounds
+#   2-4 forced a synthetic MISSING requirement for a derived check name
+#   that had not yet reported, which turns into a PERMANENT deadlock for a
+#   persistent 403, an all-matrix annex, or a path-filtered annex that
+#   legitimately never runs for a given diff. Replaced with a workflow-wide
+#   scan: any REPORTED entry belonging to the annex's own workflow (matched
+#   by workflow identity, not by a specific check name) that is non-green is
+#   unioned into BAD_CHECKS directly -- catching a matrix-leg failure
+#   without its expanded name, and never inventing a requirement for a
+#   check that may never report.
+#
+#   Rounds 6-9: fold in an omitted top-level `name:` (falls back to the
+#   workflow file path GitHub itself displays), allow YAML aliases in the
+#   annex (bounded by size/token-count DoS guards against "billion
+#   laughs", refined twice more to stop over-counting quoted and hyphenated
+#   path globs as alias tokens), and treat an annex with no restricting
+#   trigger filter (paths/paths-ignore/branches/branches-ignore, and a
+#   pull_request `types` list that still includes synchronize) as
+#   guaranteed to eventually report -- so zero reported entries blocks
+#   (not-yet-clean) instead of silently passing, including for a
+#   same-repo-gated push-only annex (a push trigger never fires in this
+#   repo for a fork PR).
+#
+#   Round 10: removed the annex-derived-name merge into REQUIRED_JSON
+#   entirely (both the empty- and non-empty-required-checks branches) --
+#   that merge was name-only, so a consumer whose annex job happened to
+#   share a bare name with an unrelated, non-required check from a
+#   DIFFERENT workflow would make that unrelated check mandatory too,
+#   wrongly blocking gate (a) with a fully green annex. The workflow-wide
+#   scan (round 5) already independently and safely enforces the annex by
+#   workflow identity, immune to this collision, so no merge is needed at
+#   all any more. Also added a conventional-name (not workflow-based, since
+#   the real identity is unknown) fallback scan for when the annex probe
+#   cannot determine a workflow identity at all (403 / unparseable /
+#   indeterminate error) -- catching a REPORTED bad conclusion under the
+#   literal name "repo-lint-local" without requiring its presence, so a
+#   persistent 403 still cannot deadlock the gate.
+#
+#   Rounds 11-12: evaluate branch/tag filters against the real base/head ref
+#   instead of blanket-disqualifying on their mere presence, add isRequired
+#   scoping for the canonical (workflow-less) required-check match, and
+#   paginate the statusCheckRollup fetch (a fixed first-100-contexts page
+#   silently hid every later entry on a long-lived PR).
+#
+#   Round 13: the branch-glob matcher switched from File.fnmatch (which
+#   cannot represent a `+` quantifier, e.g. a documented semver branch
+#   pattern) to a Ruby Regexp translator; a push trigger with BOTH branches
+#   and tags was wrongly disqualified by tags presence alone (GitHub runs it
+#   for the matching branch push too); the workflow-wide annex scan now
+#   groups by check name and picks a pending-preferred/latest-completed
+#   winner per name, so a stale failed rerun superseded by a later success
+#   no longer blocks forever; and workflow identity for the annex scan
+#   switched from the freely-editable .workflowName display string to the
+#   stable, file-derived .workflowPath, closing a collision risk when two
+#   workflow files declare the same top-level `name:`.
+#
+# The full gate (a) needs network (statusCheckRollup + branch-protection API
+# reads + the annex Contents API probe); this test pins (1) the structural
+# presence of each fix in the real script and (2) the jq logic inline — the
+# same inline-literal pattern test_codex_review_check_verdict.sh and
+# test_codex_review_check_resolution.sh use. KEEP THE INLINE FILTERS BELOW IN
+# SYNC with scripts/codex-review-check.sh's gate (a).
+#
+# Bash 3.2 portable. Runs without network (the annex-probe + ruby-yaml
+# derivation itself — including the matrix-skip and name+workflow pairing —
+# is validated by real/synthetic ruby invocations during development; see
+# the PR/issue #655 discussion — but is not re-exercised here since this
+# suite runs offline).
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/codex-review-check.sh"
+[ -r "$SCRIPT" ] || { echo "missing $SCRIPT" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not available" >&2; exit 0; }
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# ── 1. Structural: the real script probes the annex, derives (name,
+#      workflow) pairs plus the annex's own workflow name, skips
+#      matrix-strategy jobs during name derivation, and scans the annex's
+#      workflow for any reported non-green conclusion (#655 round 5,
+#      superseding the earlier MISSING-injection approach).
+if grep -q 'ANNEX_CHECKS_JSON' "$SCRIPT" \
+   && grep -q 'ANNEX_WORKFLOW_NAME' "$SCRIPT" \
+   && grep -q 'doc\["jobs"\].each do |id, job|' "$SCRIPT" \
+   && grep -q 'workflow_name = doc\["name"\] ? doc\["name"\].to_s : "\.github/workflows/repo_lint_local\.yml"' "$SCRIPT" \
+   && grep -q 'ANNEX_WORKFLOW_BAD' "$SCRIPT" \
+   && grep -q "#655" "$SCRIPT"; then
+  pass "codex-review-check.sh gate (a) probes the annex, derives (name, workflow) pairs plus the annex workflow name, and scans it for reported failures (#655)"
+else
+  fail "codex-review-check.sh gate (a) is missing the annex probe / (name, workflow) derivation / workflow-wide bad-conclusion scan (#655)"
+fi
+
+# Codex P2 (#655 round 6, "use the file path when the annex omits name"):
+# an all-matrix annex with no top-level `name:` used to yield an EMPTY
+# workflow name, disabling the workflow-wide scan entirely even though the
+# annex genuinely exists and reports real check runs under GitHub's own
+# file-path display fallback. Verify the fallback and its trigger condition
+# (doc["name"] falsy) are both present, not just a change to some other line.
+if grep -q 'doc\["name"\] ? doc\["name"\].to_s : "\.github/workflows/repo_lint_local\.yml"' "$SCRIPT"; then
+  pass "codex-review-check.sh falls back to the workflow file path when the annex omits a top-level name: key (#655 round 6)"
+else
+  fail "codex-review-check.sh does not fall back to the workflow file path when the annex's name: key is absent (#655 round 6)"
+fi
+
+# Codex P1 (#655 round 7, "keep rollup when annex only has matrix jobs"):
+# an all-matrix annex has an empty ANNEX_CHECK_NAMES_JSON but a populated
+# ANNEX_WORKFLOW_NAME. The empty-required-checks branch used to key ONLY on
+# ANNEX_CHECK_NAMES_JSON's length to decide whether to wipe ROLLUP_JSON to
+# `[]`, so an all-matrix annex took the "no annex" path and the workflow-
+# wide scan below lost its data source, hiding a reported matrix-leg
+# failure. Fixed by freezing a copy of the rollup BEFORE any
+# branch-protection-driven wiping can touch it, and pointing the
+# workflow-wide scan at that frozen copy instead of the (possibly wiped)
+# $ROLLUP_JSON -- decoupling the two consumers entirely rather than trying
+# to special-case the wiping branch.
+if grep -q 'ANNEX_SCAN_ROLLUP_JSON="\$ROLLUP_JSON"' "$SCRIPT" \
+   && grep -q 'ANNEX_WORKFLOW_MATCHES=\$(echo "\$ANNEX_SCAN_ROLLUP_JSON"' "$SCRIPT"; then
+  pass "codex-review-check.sh freezes a pristine rollup copy for the workflow-wide scan, immune to later required-checks-driven wiping (#655 round 7)"
+else
+  fail "codex-review-check.sh's workflow-wide scan is not decoupled from ROLLUP_JSON wiping (#655 round 7)"
+fi
+# The frozen copy must be taken BEFORE the empty-required-checks branch's
+# wipe, not after -- grep the line numbers to guard against a future edit
+# reordering them back into the bug.
+freeze_line=$(grep -n 'ANNEX_SCAN_ROLLUP_JSON="\$ROLLUP_JSON"' "$SCRIPT" | head -1 | cut -d: -f1)
+wipe_line=$(grep -n "ROLLUP_JSON='{\"statusCheckRollup\":\[\]}'" "$SCRIPT" | head -1 | cut -d: -f1)
+if [ -n "$freeze_line" ] && [ -n "$wipe_line" ] && [ "$freeze_line" -lt "$wipe_line" ]; then
+  pass "codex-review-check.sh freezes the annex-scan rollup copy before the empty-required-checks branch's wipe, not after (#655 round 7)"
+else
+  fail "codex-review-check.sh's frozen rollup copy is not positioned before the wipe (freeze_line=$freeze_line wipe_line=$wipe_line)"
+fi
+
+# Codex P1 (#655 round 7, "parse valid annex workflows that use YAML
+# aliases"): GitHub Actions supports YAML anchors/aliases in workflow
+# files, but Psych safe_load's aliases:false default rejected any alias
+# and treated the whole annex as unparseable. Allowing aliases outright
+# would reopen a YAML alias-expansion ("billion laughs") DoS against the
+# script parsing a PR's own branch content -- guarded here with a byte-size
+# cap and a raw anchor/alias token-count cap, both checked BEFORE the
+# actual parse (the danger is in the expansion, not the input size).
+if grep -q 'doc = YAML.safe_load(raw, aliases: true)' "$SCRIPT" \
+   && grep -q 'if raw.bytesize > 100_000' "$SCRIPT"; then
+  pass "codex-review-check.sh allows YAML aliases when parsing the annex, bounded by a byte-size DoS guard (#655 round 7)"
+else
+  fail "codex-review-check.sh does not allow YAML aliases with the expected byte-size DoS guard (#655 round 7)"
+fi
+
+# Codex P2 (#655 round 8, "avoid treating path globs as YAML aliases") and
+# round 9 ("do not count glob hyphens as YAML aliases"): the round-7
+# token-count guard's naive `[&*]word` scan counted an ordinary glob like
+# `**/*.ts` (round 8) or a hyphenated one like `component-*.ts` (round 9,
+# since a bare trailing `-` was accepted as a structural position ANYWHERE
+# in the text) as alias tokens -- a legitimate annex with a longer or
+# hyphenated filter list could exceed the cap and be treated as
+# too-dangerous-to-parse, disabling the workflow-wide scan for a real,
+# currently-failing local check. The guard now requires a structural
+# position -- start of text; a block-sequence dash anchored to the START
+# OF ITS LINE with a mandatory space before its value (round 9's fix,
+# excluding a mid-string hyphen like a glob own); or `:`/`,`/`[`/`{`
+# anywhere, optionally followed by whitespace -- before counting a token,
+# which a quoted (or otherwise validly-unquoted) glob string never
+# satisfies.
+if grep -qF 'if raw.scan(/(?:\A|^[ \t]*-\s+|[:,\[{]\s*)[&*][A-Za-z0-9_.-]+/).length > 40' "$SCRIPT"; then
+  pass "codex-review-check.sh's alias token-count guard requires a line-anchored dash (or other structural position), no longer over-counting quoted or hyphenated path globs (#655 rounds 8-9)"
+else
+  fail "codex-review-check.sh's alias token-count guard does not use the round-9 line-anchored-dash regex (#655 round 9)"
+fi
+
+# Codex P2 (#655 round 8, "wait for unreported unfiltered annex checks"):
+# gate (a)'s workflow-wide scan previously treated ANY zero-match case as
+# non-blocking, which was too lenient for an annex whose trigger is
+# guaranteed to eventually report. A synthetic PENDING entry is unioned
+# into BAD_CHECKS in that specific case, mirroring how an in-progress
+# entry already blocks (round 6).
+if grep -q 'ANNEX_UNFILTERED' "$SCRIPT" \
+   && grep -q 'ANNEX_WORKFLOW_MATCH_COUNT' "$SCRIPT" \
+   && grep -q '(not yet reported)' "$SCRIPT"; then
+  pass "codex-review-check.sh's workflow-wide scan blocks on an unfiltered annex with zero reported entries instead of silently passing (#655 round 8)"
+else
+  fail "codex-review-check.sh does not treat an unfiltered zero-match annex as not-yet-clean (#655 round 8)"
+fi
+
+# Codex P2 (#655 round 9, "honor non-path pull_request filters before
+# waiting"): round 8 checked only paths/paths-ignore on the pull_request
+# config. Round 9 blanket-disqualified on branches/branches-ignore
+# presence too; round 11 replaced that blanket disqualification with an
+# actual evaluation (below), since GitHub schedules the workflow whenever
+# the real ref matches the filter, not merely when the filter is absent.
+# Round 16 replaced the paths/paths-ignore blanket-disqualify with a real
+# evaluation too (see the paths_filter_excludes? assertions further
+# below), which is why the standalone filter-key list variables are gone.
+if grep -qF 'def paths_filter_excludes?(event, cfg, changed_files, changed_files_known)' "$SCRIPT" \
+   && ! grep -qF 'pr_filter_keys = ["paths", "paths-ignore"]' "$SCRIPT" \
+   && ! grep -qF 'push_filter_keys = ["paths", "paths-ignore"]' "$SCRIPT"; then
+  pass "codex-review-check.sh's generic filter-key lists no longer blanket-disqualify on branches/branches-ignore or paths/paths-ignore, evaluating both instead (#655 rounds 11 and 16)"
+else
+  fail "codex-review-check.sh's filter-key handling does not match the expected round-16 shape (#655 round 16)"
+fi
+
+# Codex P2 (#655 round 11, "evaluate base-branch filters before passing"):
+# `pull_request: {branches: [main]}` still runs for every PR targeting
+# main -- blanket-disqualifying "unfiltered" on mere presence (round 9-10)
+# wrongly treated a genuinely-unfiltered-for-THIS-PR annex as filtered.
+# Evaluated against the real ref instead: pull_request compares the PRs
+# BASE ref; push compares the ref actually being pushed, which for a
+# same-repo PRs synchronize is its own HEAD ref, not base -- these must
+# be genuinely different variables/inputs, not the same one reused.
+# Round 16 dropped the (by-then only paths-related) filter_keys parameter
+# from trigger_unfiltered's signature entirely, since paths/paths-ignore
+# evaluation moved into paths_filter_excludes? and no other key used it.
+if grep -qF 'def branch_filter_excludes?(cfg, branch)' "$SCRIPT" \
+   && grep -qF 'def branch_matches?(pattern, branch)' "$SCRIPT" \
+   && grep -qF 'pr_unfiltered = trigger_unfiltered.call("pull_request", ENV["ANNEX_BASE_BRANCH"])' "$SCRIPT" \
+   && grep -qF 'push_unfiltered = trigger_unfiltered.call("push", ENV["ANNEX_HEAD_BRANCH"])' "$SCRIPT"; then
+  pass "codex-review-check.sh evaluates branches/branches-ignore against the correct ref per event type (#655 round 11)"
+else
+  fail "codex-review-check.sh does not evaluate branches/branches-ignore against the real base/head ref (#655 round 11)"
+fi
+
+# Codex P2 (#655 round 12, "honor GitHub Actions branch glob semantics"):
+# GitHub docs specify a single `*` does NOT cross a `/` (feature/* excludes
+# feature/foo/bar) while `**` DOES; patterns are also evaluated IN ORDER
+# with an optional `!` prefix negating a prior match, which the round-11
+# `any?` check ignored entirely. Round 12 used File.fnmatch (FNM_PATHNAME
+# applied only for non-globstar patterns) for the star distinction.
+if grep -qF 'def branch_matches_list?(patterns, branch)' "$SCRIPT" \
+   && grep -qF 'included = false if branch_matches?(raw[1..], branch)' "$SCRIPT" \
+   && grep -qF 'included = true if branch_matches?(raw, branch)' "$SCRIPT"; then
+  pass "codex-review-check.sh evaluates branch patterns in order with ! negation, a later pattern overriding an earlier one (#655 round 12)"
+else
+  fail "codex-review-check.sh does not evaluate branch patterns in order with ! negation support (#655 round 12)"
+fi
+
+# Codex P2 (#655 round 13, "use an Actions-compatible branch glob matcher"):
+# the round-12 fnmatch version could not represent a `+` repetition
+# quantifier (e.g. `v[12].[0-9]+.[0-9]+`, GitHub's documented semver-branch
+# example) -- fnmatch always treats `+` as a literal character and returns
+# false. Replaced with a translator converting each documented glob token
+# (*, **, ?, [...], +) into an equivalent Ruby Regexp, matched via
+# Regexp#match? -- Regexp natively supports quantifiers and character
+# classes, so one mechanism now covers the full documented syntax. Round
+# 14 added backslash escaping for literal special characters in branch or
+# tag names, as GitHub documents for these same patterns.
+if grep -qF 'def branch_pattern_to_regex(pattern)' "$SCRIPT" \
+   && grep -qF 'branch_pattern_to_regex(pattern).match?(branch)' "$SCRIPT" \
+   && grep -qF 'tokens << Regexp.escape(chars[i + 1])' "$SCRIPT" \
+   && ! grep -qF 'File.fnmatch(pattern, branch, flags)' "$SCRIPT"; then
+  pass "codex-review-check.sh translates branch glob patterns into a Ruby Regexp, including escaped literal metacharacters (#655 rounds 13-14)"
+else
+  fail "codex-review-check.sh does not use the expected regex translator / escaped-literal handling for branch-pattern matching (#655 rounds 13-14)"
+fi
+# Codex P2 (#655 round 16, "honor ? as an optional-character filter"):
+# GitHub documents `?` as matching zero or one of the PRECEDING character
+# (e.g. `release?` matches base branch `release` itself), not "exactly
+# one arbitrary character" the way POSIX glob/fnmatch define it -- the
+# round-13 translator emitted an independent [^/] token instead of
+# quantifying whatever came before it.
+if grep -qF 'tokens = []' "$SCRIPT" \
+   && grep -qF 'tokens[-1] = "(?:#{tokens[-1]})?" if tokens.any?' "$SCRIPT" \
+   && ! grep -qF 'result << "[^/]"' "$SCRIPT"; then
+  pass "codex-review-check.sh builds a token list so ? can quantify the preceding token instead of matching one arbitrary character (#655 round 16)"
+else
+  fail "codex-review-check.sh does not use the round-16 token-based ? handling (#655 round 16)"
+fi
+# End-to-end: the exact semver pattern Codex cited, which fnmatch cannot
+# represent at all (it treats `+` as a literal character). KEEP THIS
+# EMBEDDED RUBY IN SYNC with scripts/codex-review-check.sh's
+# branch_pattern_to_regex -- it is a verbatim copy, not a reimplementation.
+branch_pattern_matches() {
+  local pattern=$1 branch=$2
+  ruby -e '
+    def branch_pattern_to_regex(pattern)
+      tokens = []
+      chars = pattern.chars
+      i = 0
+      while i < chars.length
+        c = chars[i]
+        if c == "\\" && chars[i + 1]
+          tokens << Regexp.escape(chars[i + 1])
+          i += 2
+        elsif c == "*" && chars[i + 1] == "*"
+          tokens << ".*"
+          i += 2
+        elsif c == "*"
+          tokens << "[^/]*"
+          i += 1
+        elsif c == "?"
+          tokens[-1] = "(?:#{tokens[-1]})?" if tokens.any?
+          i += 1
+        elsif c == "["
+          j = i + 1
+          j += 1 while j < chars.length && chars[j] != "]"
+          tokens << chars[i..j].join
+          i = j + 1
+        elsif c == "+"
+          tokens << "+"
+          i += 1
+        else
+          tokens << Regexp.escape(c)
+          i += 1
+        end
+      end
+      Regexp.new("\\A#{tokens.join}\\z")
+    end
+    def branch_matches?(pattern, branch)
+      return false unless pattern.is_a?(String) && branch.is_a?(String)
+      branch_pattern_to_regex(pattern).match?(branch)
+    rescue RegexpError, ArgumentError
+      false
+    end
+    puts branch_matches?(ARGV[0], ARGV[1])
+  ' "$pattern" "$branch"
+}
+GOT=$(branch_pattern_matches 'v[12].[0-9]+.[0-9]+' 'v1.20.3')
+if [ "$GOT" = "true" ]; then
+  pass "regex translator: the documented semver pattern v[12].[0-9]+.[0-9]+ matches v1.20.3 (#655 round 13)"
+else
+  fail "regex translator (semver match): expected true, got $GOT"
+fi
+GOT=$(branch_pattern_matches 'v[12].[0-9]+.[0-9]+' 'v3.20.3')
+if [ "$GOT" = "false" ]; then
+  pass "regex translator: the documented semver pattern v[12].[0-9]+.[0-9]+ does not match v3.20.3 (#655 round 13)"
+else
+  fail "regex translator (semver non-match): expected false, got $GOT"
+fi
+GOT=$(branch_pattern_matches 'feature/*' 'feature/foo/bar')
+if [ "$GOT" = "false" ]; then
+  pass "regex translator: a lone * still does not cross / (round-12 behavior preserved, #655 round 13)"
+else
+  fail "regex translator (single-star no-cross regression): expected false, got $GOT"
+fi
+GOT=$(branch_pattern_matches 'feature/**' 'feature/foo/bar')
+if [ "$GOT" = "true" ]; then
+  pass "regex translator: ** still crosses / (round-12 behavior preserved, #655 round 13)"
+else
+  fail "regex translator (globstar-crosses regression): expected true, got $GOT"
+fi
+GOT=$(branch_pattern_matches 'literal/\*' 'literal/*')
+if [ "$GOT" = "true" ]; then
+  pass "regex translator: escaped * matches a literal * in the branch name (#655 round 14)"
+else
+  fail "regex translator (escaped literal star): expected true, got $GOT"
+fi
+GOT=$(branch_pattern_matches 'literal/\*' 'literal/foo')
+if [ "$GOT" = "false" ]; then
+  pass "regex translator: escaped * no longer behaves as a wildcard (#655 round 14)"
+else
+  fail "regex translator (escaped star wildcard regression): expected false, got $GOT"
+fi
+# Codex P2 (#655 round 16, "honor ? as an optional-character filter"):
+# the exact example Codex cited -- release? matches base branch release
+# itself (zero of the preceding character), and also matches release1
+# (one of the preceding character), but not release12 (no room left in
+# the pattern for a second extra character).
+GOT=$(branch_pattern_matches 'release?' 'release')
+if [ "$GOT" = "true" ]; then
+  pass "regex translator: release? matches release (zero of the preceding character) (#655 round 16)"
+else
+  fail "regex translator (? zero-match): expected true, got $GOT"
+fi
+GOT=$(branch_pattern_matches 'release?' 'releas')
+if [ "$GOT" = "true" ]; then
+  pass "regex translator: release? matches releas (the preceding character e made optional) (#655 round 16)"
+else
+  fail "regex translator (? drops preceding char): expected true, got $GOT"
+fi
+GOT=$(branch_pattern_matches 'release?' 'release1')
+if [ "$GOT" = "false" ]; then
+  pass "regex translator: release? does not match release1 (? is not a stand-in for an arbitrary extra character) (#655 round 16)"
+else
+  fail "regex translator (? not a wildcard): expected false, got $GOT"
+fi
+GOT=$(branch_pattern_matches 'v[12]?' 'v')
+if [ "$GOT" = "true" ]; then
+  pass "regex translator: ? quantifies a whole preceding [...] class, not just its last character (#655 round 16)"
+else
+  fail "regex translator (? quantifies bracket class): expected true, got $GOT"
+fi
+GOT=$(branch_pattern_matches '?main' 'main')
+if [ "$GOT" = "true" ]; then
+  pass "regex translator: a leading ? with no preceding token is a no-op, not an error (#655 round 16)"
+else
+  fail "regex translator (leading ? no-op): expected true, got $GOT"
+fi
+
+# An unresolvable/unknown branch must conservatively disqualify (treat as
+# filtered) rather than guess -- verified via the ruby-level fallback
+# check_ci_scripts_wired-adjacent conservative-default philosophy applied
+# throughout #655.
+if grep -qF 'return true if (cfg.key?("branches") || cfg.key?("branches-ignore")) && !(branch.is_a?(String) && !branch.empty?)' "$SCRIPT"; then
+  pass "codex-review-check.sh conservatively disqualifies unfiltered when the relevant branch cannot be resolved (#655 round 11)"
+else
+  fail "codex-review-check.sh does not conservatively handle an unresolvable branch for branches/branches-ignore evaluation (#655 round 11)"
+fi
+
+# Codex P2 (#655 round 11, "treat tag-only push annexes as filtered",
+# narrowed in round 13 -- "do not treat tag filters as excluding branch
+# pushes"): a push trigger scoped ONLY by tags/tags-ignore (no branches/
+# branches-ignore at all) only fires for TAG ref pushes, never an ordinary
+# branch push -- which is what a same-repo PRs synchronize always is. But
+# GitHub documents branches and tags as combinable on the SAME push
+# trigger (runs for a matching branch push OR a matching tag push), so a
+# trigger with BOTH keys must still be evaluated by its branches filter --
+# round 11 put tags/tags-ignore into the generic filter_keys list checked
+# BEFORE branches ever got a chance to match, wrongly disqualifying a push
+# GitHub would actually run. push_tag_only_excludes? now only disqualifies
+# when branches/branches-ignore is entirely absent.
+if grep -qF 'def push_tag_only_excludes?(cfg)' "$SCRIPT" \
+   && grep -qF '(cfg.key?("tags") || cfg.key?("tags-ignore")) && !(cfg.key?("branches") || cfg.key?("branches-ignore"))' "$SCRIPT" \
+   && grep -qF 'next false if event == "push" && push_tag_only_excludes?(cfg)' "$SCRIPT"; then
+  pass "codex-review-check.sh disqualifies a tag-only push trigger as unfiltered via a dedicated helper, not a blanket filter-key (#655 round 13)"
+else
+  fail "codex-review-check.sh does not disqualify tag-scoped push triggers via push_tag_only_excludes? (#655 round 13)"
+fi
+# End-to-end: the exact regression Codex found -- a push trigger with BOTH
+# branches (matching) AND tags must still be treated as unfiltered, since
+# GitHub runs it for the matching branch push regardless of the tags key.
+# A direct ruby invocation is used (rather than reimplementing the
+# predicate in jq) since the real function is Ruby -- KEEP IN SYNC with
+# scripts/codex-review-check.sh's push_tag_only_excludes?.
+push_tag_only_excludes_ruby() {
+  local has_tags=$1 has_tags_ignore=$2 has_branches=$3 has_branches_ignore=$4
+  ruby -e '
+    def push_tag_only_excludes?(cfg)
+      (cfg.key?("tags") || cfg.key?("tags-ignore")) && !(cfg.key?("branches") || cfg.key?("branches-ignore"))
+    end
+    cfg = {}
+    cfg["tags"] = true if ARGV[0] == "1"
+    cfg["tags-ignore"] = true if ARGV[1] == "1"
+    cfg["branches"] = true if ARGV[2] == "1"
+    cfg["branches-ignore"] = true if ARGV[3] == "1"
+    puts push_tag_only_excludes?(cfg)
+  ' "$has_tags" "$has_tags_ignore" "$has_branches" "$has_branches_ignore"
+}
+GOT=$(push_tag_only_excludes_ruby 1 0 1 0)
+if [ "$GOT" = "false" ]; then
+  pass "push_tag_only_excludes?: tags + branches (both present) does not exclude push -- branches still gets evaluated (#655 round 13, the exact regression fixed)"
+else
+  fail "push_tag_only_excludes? (tags+branches): expected false, got $GOT"
+fi
+GOT=$(push_tag_only_excludes_ruby 1 0 0 0)
+if [ "$GOT" = "true" ]; then
+  pass "push_tag_only_excludes?: tags alone (no branches key at all) still excludes push (#655 round 11 behavior preserved)"
+else
+  fail "push_tag_only_excludes? (tags only): expected true, got $GOT"
+fi
+GOT=$(push_tag_only_excludes_ruby 0 0 1 0)
+if [ "$GOT" = "false" ]; then
+  pass "push_tag_only_excludes?: branches alone (no tags at all) does not exclude push"
+else
+  fail "push_tag_only_excludes? (branches only): expected false, got $GOT"
+fi
+
+# Codex P2 (#655 round 16, "wait for path-matched annex workflows",
+# narrowed in round 17 -- "use the event diff when emulating path
+# filters"): a paths/paths-ignore key was previously treated as
+# unconditionally filtered on mere presence, even when the PRs actual
+# changed files match the filter. Path glob syntax documents the SAME
+# tokens as branch/tag patterns, so branch_matches_list? is reused.
+# `paths` requires at least one changed file to match; `paths-ignore`
+# excludes only when EVERY changed file matches the ignore patterns.
+# GitHub evaluates a push triggers path filter against the two-dot diff
+# of JUST that push, not the whole-PR three-dot diff this fetch
+# provides, so only pull_request gets the real evaluation; push keeps
+# the always-filtered default. The changed-file list is capped to
+# GitHub's own 300-file evaluation limit.
+if grep -qF 'def paths_filter_excludes?(event, cfg, changed_files, changed_files_known)' "$SCRIPT" \
+   && grep -qF 'return true if event == "push"' "$SCRIPT" \
+   && grep -qF 'capped_files = changed_files.first(300)' "$SCRIPT" \
+   && grep -qF 'return true unless capped_files.any? { |f| branch_matches_list?(cfg["paths"], f) }' "$SCRIPT" \
+   && grep -qF 'return true if capped_files.all? { |f| branch_matches_list?(cfg["paths-ignore"], f) }' "$SCRIPT" \
+   && grep -qF 'ANNEX_CHANGED_FILES_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/files"' "$SCRIPT" \
+   && grep -qF 'next false if paths_filter_excludes?(event, cfg, changed_files, changed_files_known)' "$SCRIPT"; then
+  pass "codex-review-check.sh evaluates paths/paths-ignore against the PRs real changed files instead of blanket-disqualifying on presence (#655 round 16)"
+else
+  fail "codex-review-check.sh does not evaluate paths/paths-ignore against real changed files (#655 round 16)"
+fi
+# Codex P2 (#655 round 17, "fail closed when the changed-file lookup
+# fails", Codex; "don't silently treat changed-files API failures as
+# filtered out", CodeRabbit): codex-review-check.sh already used
+# fetch_api_array (dies on a genuine fetch failure), so this specific
+# script never actually reaches ruby with unknown data in practice -- but
+# changed_files_known still gates the evaluation for structural parity
+# with agent-review.yml, whose own ad hoc fetch (no fetch_api_array
+# available in a plain workflow YAML) DID have the silent-failure bug.
+if grep -qF 'changed_files_known = !(ENV["ANNEX_CHANGED_FILES_JSON"] || "").empty?' "$SCRIPT"; then
+  pass "codex-review-check.sh distinguishes an unknown changed-files fetch from a genuinely-empty one (#655 round 17)"
+else
+  fail "codex-review-check.sh does not track changed_files_known (#655 round 17)"
+fi
+# End-to-end: the exact scenarios the finding describes -- paths matching
+# vs not matching the actual diff, paths-ignore excluding only when ALL
+# files are covered, push never getting the real evaluation, the 300-file
+# cap, and the changed_files_known distinction.
+paths_filter_excludes_ruby() {
+  local event=$1 cfg_json=$2 changed_files_json=$3
+  ruby -rjson -e '
+    def branch_pattern_to_regex(pattern)
+      tokens = []
+      chars = pattern.chars
+      i = 0
+      while i < chars.length
+        c = chars[i]
+        if c == "*" && chars[i + 1] == "*"
+          tokens << ".*"
+          i += 2
+        elsif c == "*"
+          tokens << "[^/]*"
+          i += 1
+        else
+          tokens << Regexp.escape(c)
+          i += 1
+        end
+      end
+      Regexp.new("\\A#{tokens.join}\\z")
+    end
+    def branch_matches?(pattern, branch)
+      return false unless pattern.is_a?(String) && branch.is_a?(String)
+      branch_pattern_to_regex(pattern).match?(branch)
+    rescue RegexpError, ArgumentError
+      false
+    end
+    def branch_matches_list?(patterns, branch)
+      return false unless patterns.is_a?(Array)
+      included = false
+      patterns.each do |raw|
+        next unless raw.is_a?(String)
+        if raw.start_with?("!")
+          included = false if branch_matches?(raw[1..], branch)
+        else
+          included = true if branch_matches?(raw, branch)
+        end
+      end
+      included
+    end
+    def paths_filter_excludes?(event, cfg, changed_files, changed_files_known)
+      return false unless cfg.key?("paths") || cfg.key?("paths-ignore")
+      return true if event == "push"
+      return false unless changed_files_known
+      capped_files = changed_files.first(300)
+      if cfg.key?("paths")
+        return true unless capped_files.any? { |f| branch_matches_list?(cfg["paths"], f) }
+      end
+      if cfg.key?("paths-ignore")
+        return true if capped_files.all? { |f| branch_matches_list?(cfg["paths-ignore"], f) }
+      end
+      false
+    end
+    event = ARGV[0]
+    cfg = JSON.parse(ARGV[1])
+    changed_files_known = !ARGV[2].empty?
+    changed_files = changed_files_known ? JSON.parse(ARGV[2]) : []
+    puts paths_filter_excludes?(event, cfg, changed_files, changed_files_known)
+  ' "$event" "$cfg_json" "$changed_files_json"
+}
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths":["src/**"]}' '["src/foo.py"]')
+if [ "$GOT" = "false" ]; then
+  pass "paths_filter_excludes?: pull_request paths matches a changed file -> not excluded, gate (a) waits for it (#655 round 16)"
+else
+  fail "paths_filter_excludes? (paths matches): expected false, got $GOT"
+fi
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths":["src/**"]}' '["docs/readme.md"]')
+if [ "$GOT" = "true" ]; then
+  pass "paths_filter_excludes?: pull_request paths matches no changed file -> excluded, consistent with GitHub never scheduling the workflow (#655 round 16)"
+else
+  fail "paths_filter_excludes? (paths no match): expected true, got $GOT"
+fi
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths":["src/**"]}' '["docs/readme.md","src/foo.py"]')
+if [ "$GOT" = "false" ]; then
+  pass "paths_filter_excludes?: pull_request paths matches at least one of several changed files -> not excluded (#655 round 16)"
+else
+  fail "paths_filter_excludes? (paths partial match): expected false, got $GOT"
+fi
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths-ignore":["docs/**"]}' '["docs/readme.md"]')
+if [ "$GOT" = "true" ]; then
+  pass "paths_filter_excludes?: pull_request paths-ignore covers every changed file -> excluded (#655 round 16)"
+else
+  fail "paths_filter_excludes? (paths-ignore all covered): expected true, got $GOT"
+fi
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths-ignore":["docs/**"]}' '["docs/readme.md","src/foo.py"]')
+if [ "$GOT" = "false" ]; then
+  pass "paths_filter_excludes?: pull_request paths-ignore does not cover every changed file -> not excluded, GitHub still runs it (#655 round 16)"
+else
+  fail "paths_filter_excludes? (paths-ignore partial): expected false, got $GOT"
+fi
+GOT=$(paths_filter_excludes_ruby 'push' '{"paths":["src/**"]}' '["src/foo.py"]')
+if [ "$GOT" = "true" ]; then
+  pass "paths_filter_excludes?: push never gets the real evaluation, even when the whole-PR diff would match -- avoids the two-dot-vs-three-dot diff scope mismatch (#655 round 17)"
+else
+  fail "paths_filter_excludes? (push scoping): expected true, got $GOT"
+fi
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths":["src/**"]}' '')
+if [ "$GOT" = "false" ]; then
+  pass "paths_filter_excludes?: unknown changed-files data (fetch failed) is NOT excluded -- wait for it rather than silently pass (#655 round 17)"
+else
+  fail "paths_filter_excludes? (unknown changed files): expected false, got $GOT"
+fi
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths":["src/**"]}' '[]')
+if [ "$GOT" = "true" ]; then
+  pass "paths_filter_excludes?: a genuinely-known EMPTY changed-file list still excludes, distinct from unknown (#655 round 17)"
+else
+  fail "paths_filter_excludes? (known empty changed files): expected true, got $GOT"
+fi
+MANY_FILES=$(ruby -rjson -e 'puts JSON.generate((0...300).map { |i| "docs/file#{i}.md" } + ["src/matching.py"])')
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths":["src/**"]}' "$MANY_FILES")
+if [ "$GOT" = "true" ]; then
+  pass "paths_filter_excludes?: a matching file beyond the first 300 changed files is not counted, matching GitHub's own evaluation limit (#655 round 17)"
+else
+  fail "paths_filter_excludes? (300-file cap): expected true, got $GOT"
+fi
+MANY_FILES_WITHIN_CAP=$(ruby -rjson -e 'puts JSON.generate(["src/matching.py"] + (0...299).map { |i| "docs/file#{i}.md" })')
+GOT=$(paths_filter_excludes_ruby 'pull_request' '{"paths":["src/**"]}' "$MANY_FILES_WITHIN_CAP")
+if [ "$GOT" = "false" ]; then
+  pass "paths_filter_excludes?: a matching file within the first 300 changed files is still counted (#655 round 17)"
+else
+  fail "paths_filter_excludes? (within 300-file cap): expected false, got $GOT"
+fi
+
+# Codex P1 (#655 round 13, "page the rollup before scanning annex
+# checks"): gh pr view --json statusCheckRollup only requests the first
+# 100 contexts with no pagination -- the SAME bug already fixed in
+# agent-review.yml's wait loop (round 12), missed here when that fix
+# landed. Switched to a Relay-cursor paginated graphql query. workflowPath
+# (derived from the workflow FILE's resourcePath) is added alongside the
+# existing workflowName, since the annex contract does not guarantee a
+# unique display name across a consumer's workflows (round 13, Finding 5
+# below).
+if grep -qF 'contexts(first: 100, after: $cursor)' "$SCRIPT" \
+   && grep -qF 'pageInfo { hasNextPage endCursor }' "$SCRIPT" \
+   && grep -qF 'ROLLUP_CURSOR_ARGS=(-F cursor=null)' "$SCRIPT" \
+   && grep -qF 'ROLLUP_CURSOR_ARGS=(-f cursor="$ROLLUP_CURSOR")' "$SCRIPT" \
+   && grep -qF 'statusCheckRollup.contexts.nodes // []' "$SCRIPT" \
+   && grep -qF 'statusCheckRollup.contexts.pageInfo.hasNextPage // false' "$SCRIPT" \
+   && grep -qF 'statusCheckRollup.contexts.pageInfo.endCursor // ""' "$SCRIPT" \
+   && grep -qF 'workflow { name resourcePath }' "$SCRIPT" \
+   && grep -qF 'workflowPath: (((.checkSuite.workflowRun.workflow.resourcePath // "") | split("/") | last) // "")' "$SCRIPT"; then
+  pass "codex-review-check.sh paginates statusCheckRollup via the Relay cursor, passes null on page 1, null-coalesces empty rollup pages, and derives workflowPath from resourcePath (#655 round 13)"
+else
+  fail "codex-review-check.sh does not paginate the rollup, pass a null first-page cursor, null-coalesce empty pages, or derive workflowPath as expected (#655 round 13)"
+fi
+NULL_ROLLUP_PAGE='{"data":{"repository":{"pullRequest":{"commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]}}}}}'
+PAGE_NODES=$(printf '%s' "$NULL_ROLLUP_PAGE" | jq -c '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.nodes // [])')
+HAS_NEXT=$(printf '%s' "$NULL_ROLLUP_PAGE" | jq -r '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage // false)')
+END_CURSOR=$(printf '%s' "$NULL_ROLLUP_PAGE" | jq -r '(.data.repository.pullRequest.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.endCursor // "")')
+if [ "$PAGE_NODES" = "[]" ] && [ "$HAS_NEXT" = "false" ] && [ -z "$END_CURSOR" ]; then
+  pass "rollup pagination extraction treats a null statusCheckRollup as an empty final page"
+else
+  fail "rollup pagination extraction should normalize null statusCheckRollup to []/false/empty, got nodes=$PAGE_NODES has_next=$HAS_NEXT cursor=$END_CURSOR"
+fi
+
+# Self-caught while writing the round-13 winner-selection below: piping a
+# bare array literal straight into `index(.state // "")` rebinds `.` to
+# that array literal for the REST of the expression, so `.state` then
+# tries to index an array with a string and jq hard-errors -- but only for
+# a StatusContext entry (no .status field), since a CheckRun never reaches
+# this branch at all. This is the exact "sub-pipeline rebinds dot" hazard
+# the required-name filter above already documents and guards against for
+# $label_name. Fixed by binding .state to a variable BEFORE the
+# array-literal pipe; guarded here so it cannot silently regress.
+if grep -qF '((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state))' "$SCRIPT"; then
+  pass "codex-review-check.sh's pending-check binds .state to a variable before the array-literal pipe, avoiding the dot-rebinding jq hazard (#655 round 13)"
+else
+  fail "codex-review-check.sh's pending-check does not use the safe \$ann_state binding form (#655 round 13)"
+fi
+if grep -qF '(["PENDING","EXPECTED"] | index(.state // ""))' "$SCRIPT"; then
+  fail "codex-review-check.sh regressed to the broken index(.state) form that rebinds dot inside the array-literal pipe"
+else
+  pass "codex-review-check.sh does not regress to the broken pre-fix index(.state) expression"
+fi
+
+# Codex P1 (#655 round 10, "treat synchronize-enabled types as runnable"):
+# round 9 disqualified "unfiltered" on the MERE PRESENCE of a types key,
+# but types selects WHICH pull_request activities trigger the workflow at
+# all (GitHub own default when omitted is [opened, synchronize,
+# reopened]) rather than narrowing by path/branch. An explicit
+# `types: [opened, synchronize, reopened]` -- functionally identical to
+# omitting types -- was wrongly disqualified. Only a types list that
+# EXCLUDES synchronize should disqualify, since that is the activity that
+# fires for a resynchronized PRs current HEAD.
+if grep -qF 'next (cfg["types"].is_a?(Array) && cfg["types"].include?("synchronize")) if cfg.key?("types")' "$SCRIPT"; then
+  pass "codex-review-check.sh treats a types list that includes synchronize as unfiltered, not merely absent (#655 round 10)"
+else
+  fail "codex-review-check.sh still disqualifies unfiltered on the mere presence of a types key (#655 round 10)"
+fi
+
+# Codex P2 (#655 round 16, "don't skip opened-only annex runs"),
+# REVERTED in round 17 ("do not infer opened-only runs from committer
+# date"): round 16 tried to treat types: [opened] (no synchronize) as
+# unfiltered when the HEAD committer date predates PR creation. Confirmed
+# live: a genuinely-new synchronize push whose commit preserves an OLDER
+# committer date (a rebase/cherry-pick of a stale commit) still satisfies
+# that comparison, so the heuristic could say "unfiltered" for a trigger
+# that will NEVER report again on that HEAD -- a real, confirmed
+# permanent-wait risk, worse than the narrower gap being reopened. No
+# reliable, non-spoofable signal is available from data this script
+# already has, so the mechanism was removed entirely rather than patched
+# further.
+if ! grep -qF 'head_predates_pr_creation' "$SCRIPT" \
+   && ! grep -qF 'ANNEX_PR_CREATED_AT' "$SCRIPT" \
+   && ! grep -qF 'ANNEX_HEAD_COMMITTER_DATE' "$SCRIPT"; then
+  pass "codex-review-check.sh no longer infers an opened-only annex is unfiltered from committer date (#655 round 17)"
+else
+  fail "codex-review-check.sh still carries the reverted committer-date opened-only heuristic (#655 round 17)"
+fi
+# End-to-end: types: [opened] alone is unconditionally filtered again
+# (the deadlock scenario Codex found is empirically closed), while types
+# including synchronize is unaffected (round-10 behavior preserved).
+opened_only_unfiltered() {
+  local types_json=$1
+  ruby -rjson -e '
+    types = JSON.parse(ARGV[0])
+    cfg_has_types = true
+    result = if cfg_has_types
+      (types.is_a?(Array) && types.include?("synchronize"))
+    else
+      true
+    end
+    puts result
+  ' "$types_json"
+}
+GOT=$(opened_only_unfiltered '["opened"]')
+if [ "$GOT" = "false" ]; then
+  pass "opened-only annex: types: [opened] alone is unconditionally filtered, closing the deadlock Codex found (#655 round 17)"
+else
+  fail "opened-only annex (reverted): expected false, got $GOT"
+fi
+GOT=$(opened_only_unfiltered '["opened","synchronize","reopened"]')
+if [ "$GOT" = "true" ]; then
+  pass "opened-only annex regression guard: types including synchronize stays unfiltered (#655 round 10 behavior preserved)"
+else
+  fail "opened-only annex (synchronize regression): expected true, got $GOT"
+fi
+
+# Codex P1 (#655 round 10, "fail closed when the annex probe is
+# unauthorized"): a 403 (or genuinely-unparseable annex, or indeterminate
+# error) leaves ANNEX_WORKFLOW_NAME empty, so the workflow-wide scan above
+# cannot run at all -- silently passing gate (a) regardless of the
+# annex's real state, even for a check already reporting red under the
+# conventional name outside branch protection. A name-based (not
+# workflow-based, since the real identity is unknown) fallback scan now
+# catches a REPORTED bad conclusion under the literal name
+# "repo-lint-local" in these cases, without requiring its presence (so a
+# persistent 403 still cannot deadlock the gate).
+#
+# Codex P2 (#655 round 13): this fallback has the same stale-vs-fresh
+# rerun exposure the workflow-wide scan below fixes (a name match alone
+# doesn't dedupe multiple reported attempts under the same name), so it
+# applies the same group-by-name, pending-preferred-else-latest-completed
+# winner selection -- there is exactly one possible name group here
+# ("repo-lint-local", enforced by the select() below), but group_by still
+# resolves the zero-matches case to an empty array with no extra
+# branching, so existing single-entry fixtures are unaffected.
+annex_name_fallback_bad() {
+  local rollup_json=$1
+  printf '%s' "$rollup_json" | jq '
+    [.statusCheckRollup[] | select((.name // .context // "") == "repo-lint-local")]
+    | group_by(.name // .context // "?")
+    | [
+        .[]
+        | (map(select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end))) as $pending
+        | if ($pending | length) > 0
+          then $pending[0]
+          else (sort_by(.completedAt // .startedAt // "") | last)
+          end
+      ] as $winners
+    | [$winners[]
+        | { label: (.name // .context // "?"), workflow: (.workflowName // ""), result: (.conclusion // .state // "") }
+        | select((.result != "SUCCESS") and (.result != "SKIPPED") and (.result != "NEUTRAL"))
+      ]'
+}
+annex_name_fallback_bad_after_probe() {
+  local confirmed_absent=$1 rollup_json=$2
+  if [ "$confirmed_absent" = "1" ]; then
+    printf '[]\n'
+  else
+    annex_name_fallback_bad "$rollup_json"
+  fi
+}
+ROLLUP_403_RED_CONVENTIONAL='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"},{"name":"repo-lint-local","workflowName":"Consumer Local CI","conclusion":"FAILURE"}]}'
+GOT=$(annex_name_fallback_bad "$ROLLUP_403_RED_CONVENTIONAL" | jq -c '[.[].label]')
+if [ "$GOT" = '["repo-lint-local"]' ]; then
+  pass "conventional-name fallback scan: a red repo-lint-local is caught even when the workflow identity is unknown (#655 round 10 P1)"
+else
+  fail "conventional-name fallback scan (403 case): expected [\"repo-lint-local\"], got $GOT"
+fi
+ROLLUP_403_NO_ANNEX='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"}]}'
+GOT=$(annex_name_fallback_bad "$ROLLUP_403_NO_ANNEX")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "conventional-name fallback scan: a genuinely absent annex is not falsely flagged (no repo-lint-local entry to find)"
+else
+  fail "conventional-name fallback scan (no annex): expected 0, got $GOT"
+fi
+ROLLUP_CONFIRMED_ABSENT_OPTIONAL_RED='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"},{"name":"repo-lint-local","workflowName":"Optional Local CI","conclusion":"FAILURE"}]}'
+GOT=$(annex_name_fallback_bad_after_probe 1 "$ROLLUP_CONFIRMED_ABSENT_OPTIONAL_RED")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "conventional-name fallback scan: a confirmed-absent annex skips the repo-lint-local fallback even if an unrelated optional same-named check is red"
+else
+  fail "conventional-name fallback scan (confirmed absent): expected 0, got $GOT"
+fi
+GOT=$(annex_name_fallback_bad_after_probe 0 "$ROLLUP_CONFIRMED_ABSENT_OPTIONAL_RED" | jq -c '[.[].label]')
+if [ "$GOT" = '["repo-lint-local"]' ]; then
+  pass "conventional-name fallback scan: the same red repo-lint-local remains caught when annex identity is unknown"
+else
+  fail "conventional-name fallback scan (unknown probe state): expected [\"repo-lint-local\"], got $GOT"
+fi
+if grep -qF 'ANNEX_NAME_FALLBACK_BAD=$(echo "$ANNEX_SCAN_ROLLUP_JSON" | jq' "$SCRIPT" \
+   && grep -qF 'ANNEX_CONFIRMED_ABSENT=1' "$SCRIPT" \
+   && grep -qF 'if [ "$ANNEX_CONFIRMED_ABSENT" -eq 1 ]; then' "$SCRIPT"; then
+  pass "codex-review-check.sh's conventional-name fallback reads from the frozen rollup but skips when the annex is confirmed absent (#655)"
+else
+  fail "codex-review-check.sh's conventional-name fallback scan is missing, reads from the wrong rollup variable, or lacks the confirmed-absent guard (#655)"
+fi
+# #655 round 13: the SAME stale-vs-fresh scenario, but through the
+# conventional-name fallback specifically -- a stale FAILURE superseded by
+# a later SUCCESS under the same conventional name must not block forever.
+ROLLUP_403_STALE_RERUN='{"statusCheckRollup":[{"name":"repo-lint-local","status":"COMPLETED","conclusion":"FAILURE","completedAt":"2026-07-01T00:05:00Z"},{"name":"repo-lint-local","status":"COMPLETED","conclusion":"SUCCESS","completedAt":"2026-07-01T01:05:00Z"}]}'
+GOT=$(annex_name_fallback_bad "$ROLLUP_403_STALE_RERUN")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "conventional-name fallback scan: a stale FAILURE superseded by a later SUCCESS under the same name is not blocking (#655 round 13)"
+else
+  fail "conventional-name fallback scan (stale rerun): expected 0, got $GOT"
+fi
+
+# Codex P2 (#655 round 9, "wait for valid push-only annex workflows"):
+# check_ci_scripts_wired accepts push OR pull_request as valid annex
+# wiring, but a push-only annex (no pull_request trigger at all) was never
+# classified as unfiltered, so gate (a) never waited for it even though it
+# is a contractually valid annex. A push trigger only fires IN THIS REPO
+# for a same-repo PR (a fork PRs push lands in the fork, never here), so
+# this is gated on ANNEX_SAME_REPO_PR (derived from the PR REST object
+# head/base repo full_name, no extra API call) rather than applied
+# unconditionally.
+if grep -qF 'ANNEX_SAME_REPO_PR=$(echo "$PR_JSON" | jq -r' "$SCRIPT" \
+   && grep -qF 'push_unfiltered = trigger_unfiltered.call("push", ENV["ANNEX_HEAD_BRANCH"])' "$SCRIPT" \
+   && grep -qF 'unfiltered = pr_unfiltered || (push_unfiltered && same_repo_pr)' "$SCRIPT"; then
+  pass "codex-review-check.sh treats a push-only annex as unfiltered when (and only when) the PR is same-repo (#655 round 9)"
+else
+  fail "codex-review-check.sh does not gate push-only annex enforcement on same-repo-PR status (#655 round 9)"
+fi
+
+if grep -q 'job\["strategy"\].is_a?(Hash) && job\["strategy"\]\["matrix"\]' "$SCRIPT" \
+   && grep -q 'skipping matrix-strategy job' "$SCRIPT"; then
+  pass "codex-review-check.sh skips matrix-strategy annex jobs during NAME derivation instead of guessing their expanded name(s) (#655 round 3 P2)"
+else
+  fail "codex-review-check.sh does not guard against matrix-strategy annex jobs"
+fi
+
+# Fail-closed on an indeterminate annex-probe error (not a confirmed 404).
+if grep -q "grep -q 'HTTP 404' \"\$annex_probe_err\"" "$SCRIPT"; then
+  pass "codex-review-check.sh distinguishes a confirmed 404 (annex absent) from other annex-probe errors"
+else
+  fail "codex-review-check.sh does not distinguish a confirmed 404 from other annex-probe errors"
+fi
+
+# Codex P2 (#655 round 4): a 403 (token lacks Contents: read) is usually
+# persistent, not transient -- forcing the synthetic fallback would
+# permanently block Phase 4 label-clearing / merge-gate checks on every
+# future PR, not just annex-having ones. Do not fail closed on a confirmed
+# 403 the way the generic indeterminate-error branch does.
+if grep -q "grep -q 'HTTP 403' \"\$annex_probe_err\"" "$SCRIPT"; then
+  pass "codex-review-check.sh does not fail closed on a confirmed 403 (likely a persistent token-scope gap, not transient)"
+else
+  fail "codex-review-check.sh does not distinguish a confirmed 403 from other (plausibly transient) annex-probe errors"
+fi
+
+# Codex P2 (#655 round 4): "could not parse the YAML at all" (ruby exits
+# before its `puts` line -- empty output) is a different failure mode from
+# "parsed fine but every job was matrix-strategy and skipped" (ruby emits an
+# object with an empty jobs array) -- only the former falls back to the
+# conventional name; the latter must not, since that name will never exist
+# for a matrix-only annex and would permanently block the merge gate.
+if grep -q 'every job is matrix-strategy (skipped)' "$SCRIPT"; then
+  pass "codex-review-check.sh distinguishes genuine YAML-parse failure from a valid parse where every job was matrix-skipped"
+else
+  fail "codex-review-check.sh does not distinguish genuine parse failure from an all-matrix-jobs annex"
+fi
+
+# ── 2. Inline logic: the REQUIRED_JSON branches. Rounds 1-9 merged the
+#      annex's derived bare name(s) into REQUIRED_JSON so it would be
+#      force-checked even when branch protection required nothing (empty
+#      branch) or required only OTHER checks (non-empty branch). Round 10
+#      Codex P2 ("preserve workflow identity for annex checks") found this
+#      merge is name-only (no workflow disambiguation, unlike the
+#      workflow-wide scan in section 3), so a consumer whose annex job
+#      shares a bare name with an unrelated, non-required check from a
+#      DIFFERENT workflow would make that unrelated check mandatory too --
+#      a failing unrelated check could block gate (a) with a fully green
+#      annex. Since the workflow-wide scan already independently and
+#      safely enforces the annex (matched by workflow identity, immune to
+#      name collisions), the merge was removed entirely in both branches:
+#      the empty branch now always wipes ROLLUP_JSON (matching the
+#      pre-#655 no-annex behavior), and the non-empty branch uses branch
+#      protection's required names alone, with no annex merge.
+#      KEEP IN SYNC with scripts/codex-review-check.sh's gate (a).
+
+if grep -qF 'REQUIRED_JSON=$(echo "$REQUIRED_CHECK_NAMES" | jq -R . | jq -s .)' "$SCRIPT" \
+   && ! grep -qF '. + $annex | unique' "$SCRIPT"; then
+  pass "codex-review-check.sh's non-empty-required branch no longer merges the annex bare name into REQUIRED_JSON (#655 round 10)"
+else
+  fail "codex-review-check.sh's non-empty-required branch still merges the annex name into REQUIRED_JSON, risking a same-named unrelated-check false block (#655 round 10)"
+fi
+
+if grep -qF "gate (a) imposes no required-check filter beyond the independent annex workflow-wide scan" "$SCRIPT"; then
+  pass "codex-review-check.sh's empty-required branch always wipes the rollup now, relying on the independent workflow-wide scan for annex enforcement (#655 round 10)"
+else
+  fail "codex-review-check.sh's empty-required branch does not consistently defer to the workflow-wide scan (#655 round 10)"
+fi
+
+# End-to-end: reproduce Finding 2's exact scenario with the real
+# (post-round-10) non-empty-branch construction -- branch protection
+# already requires "lint", and the annex's OWN job is ALSO named "lint"
+# (a name collision the annex contract explicitly permits). REQUIRED_JSON
+# built the round-10 way (no annex merge) must stay ["lint"], so an
+# unrelated FAILING check sharing that name from a different workflow does
+# not matter -- only the CANONICAL lint (matched further down by BAD_CHECKS
+# using $required_names) is in scope for the name-based filter, and the
+# annex itself is separately covered by the workflow-wide scan regardless
+# of what name it happens to share.
+REQUIRED_JSON_ROUND10=$(printf 'lint' | jq -R . | jq -s .)
+if [ "$(echo "$REQUIRED_JSON_ROUND10" | jq -c 'sort')" = '["lint"]' ]; then
+  pass "non-empty branch (round 10): REQUIRED_JSON stays scoped to branch-protection names alone, even when the annex job shares one of those names"
+else
+  fail "non-empty branch (round 10): expected REQUIRED_JSON [\"lint\"] with no annex merge, got $REQUIRED_JSON_ROUND10"
+fi
+
+# End-to-end BAD_CHECKS filter (the required-name-scoped half). KEEP IN SYNC
+# with scripts/codex-review-check.sh.
+bad_checks() {
+  local rollup_json=$1 required_names_json=$2
+  printf '%s' "$rollup_json" | jq --argjson required_names "$required_names_json" '
+    [.statusCheckRollup[]
+      | { label: (.name // .context // "?"), workflow: (.workflowName // ""), result: (.conclusion // .state // "") }
+      | select((.workflow != "PR Review Policy") or (.label != "Label Gate"))
+      | (.label) as $label_name
+      | select(($required_names | length) == 0 or ($required_names | index($label_name)) != null)
+      | select((.result != "SUCCESS") and (.result != "SKIPPED") and (.result != "NEUTRAL"))
+    ]'
+}
+
+# Workflow-wide bad-conclusion scan (#655 round 5), replacing MISSING-
+# injection. Round 13 added two refinements, both mirrored here: (a)
+# matching switched from the freely-editable .workflowName display string
+# to the stable, file-derived .workflowPath (Finding 5 -- closes a
+# collision when two workflow files declare the same top-level `name:`),
+# and (b) matches are grouped by check name with a pending-preferred /
+# latest-completed winner picked per name before judging bad-ness (Finding
+# 3 -- so a stale failed rerun superseded by a later success no longer
+# blocks forever). KEEP IN SYNC with scripts/codex-review-check.sh's
+# ANNEX_WORKFLOW_MATCHES / ANNEX_WORKFLOW_BAD computation.
+annex_workflow_bad() {
+  local rollup_json=$1 workflow_path=$2
+  printf '%s' "$rollup_json" | jq --arg workflow_path "$workflow_path" '
+    [.statusCheckRollup[] | select((.workflowPath // "") == $workflow_path)]
+    | group_by(.name // .context // "?")
+    | [
+        .[]
+        | (map(select(if (.status != null) then (.status != "COMPLETED") else ((.state // "") as $ann_state | ["PENDING","EXPECTED"] | index($ann_state)) end))) as $pending
+        | if ($pending | length) > 0
+          then $pending[0]
+          else (sort_by(.completedAt // .startedAt // "") | last)
+          end
+      ] as $winners
+    | [$winners[]
+        | {
+            label: (.name // .context // "?"),
+            workflow: (.workflowName // ""),
+            result: (.conclusion // .state // "")
+          }
+        | select((.result != "SUCCESS") and (.result != "SKIPPED") and (.result != "NEUTRAL"))
+      ]'
+}
+
+# ── 3. Inline logic: the workflow-wide bad-conclusion scan (#655 round 5),
+#      now matched by .workflowPath (round 13). Fixtures set workflowPath
+#      alongside workflowName so the existing scenarios (green/red/matrix-
+#      leg/never-reported/skipped) keep exercising the same conceptual
+#      points -- workflow-scoped matching, immune to check-name collision
+#      -- through the new mechanism.
+ROLLUP_ANNEX_REPORTED_GOOD='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"},{"name":"repo-lint-local","workflowName":"repo-lint-local","workflowPath":"repo_lint_local.yml","conclusion":"SUCCESS"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_ANNEX_REPORTED_GOOD" "repo_lint_local.yml")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "workflow-wide scan: a green annex report -> no bad entries"
+else
+  fail "workflow-wide scan (green): expected 0 bad entries, got $GOT"
+fi
+
+ROLLUP_ANNEX_REPORTED_BAD='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"},{"name":"repo-lint-local","workflowName":"repo-lint-local","workflowPath":"repo_lint_local.yml","conclusion":"FAILURE"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_ANNEX_REPORTED_BAD" "repo_lint_local.yml" | jq -c '[.[].label]')
+if [ "$GOT" = '["repo-lint-local"]' ]; then
+  pass "workflow-wide scan: a red annex report blocks (round 1 scenario, now via workflow scan too)"
+else
+  fail "workflow-wide scan (red): expected [\"repo-lint-local\"], got $GOT"
+fi
+
+# #655 round 5 Codex P2: a matrix-expanded leg is invisible to the name-based
+# requirement (matrix jobs are excluded from ANNEX_CHECKS_JSON), but its
+# REPORTED failure still carries the annex's own workflow identity, so the
+# workflow-wide scan catches it regardless.
+ROLLUP_MATRIX_LEG_FAILED='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"},{"name":"checks (18)","workflowName":"consumer-annex","workflowPath":"consumer-annex.yml","conclusion":"SUCCESS"},{"name":"checks (20)","workflowName":"consumer-annex","workflowPath":"consumer-annex.yml","conclusion":"FAILURE"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_MATRIX_LEG_FAILED" "consumer-annex.yml" | jq -c '[.[].label]')
+if [ "$GOT" = '["checks (20)"]' ]; then
+  pass "workflow-wide scan: a reported matrix-leg failure is caught by workflow identity, without needing its expanded name (#655 round 5 P2)"
+else
+  fail "workflow-wide scan (matrix leg): expected [\"checks (20)\"], got $GOT"
+fi
+
+# #655 round 7 Codex P1 ("keep rollup when annex only has matrix jobs"):
+# reproduces the exact bug shape -- branch protection has NO required
+# checks (which post-round-10 always wipes ROLLUP_JSON unconditionally,
+# per the section-2 assertion above) while the annex genuinely exists as
+# all-matrix and has a REPORTED matrix-leg failure. The fixed script scans
+# a rollup frozen BEFORE that wipe (ANNEX_SCAN_ROLLUP_JSON in the real
+# script; simulated here by passing the ORIGINAL rollup straight to
+# annex_workflow_bad, exactly as the fix does) -- confirming the failure
+# is still caught even with ROLLUP_JSON wiped and REQUIRED_JSON empty.
+GOT=$(annex_workflow_bad "$ROLLUP_MATRIX_LEG_FAILED" "consumer-annex.yml" | jq -c '[.[].label]')
+if [ "$GOT" = '["checks (20)"]' ]; then
+  pass "workflow-wide scan: an all-matrix annex's reported leg failure is still caught when branch protection has no required checks (#655 round 7 P1)"
+else
+  fail "workflow-wide scan (round-7 all-matrix + no required checks): expected [\"checks (20)\"], got $GOT"
+fi
+
+# #655 round 5 Codex P2: an annex that has not reported ANYTHING for its
+# workflow (never started, or path-filtered out of this PR's diff entirely)
+# must NOT be treated as blocking -- this is the fix for the permanent
+# deadlock the removed MISSING-injection could create for a path-filtered
+# annex that legitimately never runs for a given PR.
+ROLLUP_NEVER_REPORTED='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_NEVER_REPORTED" "consumer-annex.yml")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "workflow-wide scan: an annex that never reported anything is NOT blocking (no deadlock for a path-filtered-out annex, #655 round 5 P2)"
+else
+  fail "workflow-wide scan (never reported): expected 0 (no false block), got $GOT"
+fi
+
+# Skipped/neutral reports still pass, consistent with everywhere else.
+ROLLUP_ANNEX_SKIPPED='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"},{"name":"repo-lint-local","workflowName":"repo-lint-local","workflowPath":"repo_lint_local.yml","conclusion":"SKIPPED"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_ANNEX_SKIPPED" "repo_lint_local.yml")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "workflow-wide scan: a SKIPPED annex report does not block, consistent with SUCCESS/SKIPPED/NEUTRAL elsewhere"
+else
+  fail "workflow-wide scan (skipped): expected 0, got $GOT"
+fi
+
+# #655 round 13 Codex P2 (Finding 3, "ignore stale annex runs after a green
+# rerun"): a stale FAILURE for a check name, superseded by a LATER
+# completed SUCCESS of the SAME name, must not block forever -- only the
+# latest-completed entry per name is judged.
+ROLLUP_STALE_RERUN='{"statusCheckRollup":[{"name":"lint-python","workflowPath":"repo_lint_local.yml","status":"COMPLETED","conclusion":"FAILURE","completedAt":"2026-07-01T00:05:00Z"},{"name":"lint-python","workflowPath":"repo_lint_local.yml","status":"COMPLETED","conclusion":"SUCCESS","completedAt":"2026-07-01T01:05:00Z"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_STALE_RERUN" "repo_lint_local.yml")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "workflow-wide scan: a stale FAILURE superseded by a later SUCCESS of the same name is not blocking (#655 round 13, Finding 3)"
+else
+  fail "workflow-wide scan (stale rerun): expected 0, got $GOT"
+fi
+# The reverse must still block: a stale SUCCESS followed by a LATER
+# FAILURE of the same name is genuinely currently broken.
+ROLLUP_NEWLY_BROKEN='{"statusCheckRollup":[{"name":"lint-python","workflowPath":"repo_lint_local.yml","status":"COMPLETED","conclusion":"SUCCESS","completedAt":"2026-07-01T00:05:00Z"},{"name":"lint-python","workflowPath":"repo_lint_local.yml","status":"COMPLETED","conclusion":"FAILURE","completedAt":"2026-07-01T01:05:00Z"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_NEWLY_BROKEN" "repo_lint_local.yml" | jq -c '[.[].result]')
+if [ "$GOT" = '["FAILURE"]' ]; then
+  pass "workflow-wide scan: a stale SUCCESS followed by a later FAILURE of the same name still blocks (#655 round 13, Finding 3 sanity)"
+else
+  fail "workflow-wide scan (newly broken): expected [\"FAILURE\"], got $GOT"
+fi
+# A still-non-terminal rerun (no completedAt) must outrank an older
+# COMPLETED failure of the same name -- the winner is the pending entry,
+# not the stale completed one, so gate (a) correctly waits rather than
+# either wrongly clearing or wrongly reporting the OLD conclusion.
+ROLLUP_PENDING_RERUN='{"statusCheckRollup":[{"name":"lint-python","workflowPath":"repo_lint_local.yml","status":"COMPLETED","conclusion":"FAILURE","completedAt":"2026-07-01T00:05:00Z"},{"name":"lint-python","workflowPath":"repo_lint_local.yml","status":"IN_PROGRESS","conclusion":null}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_PENDING_RERUN" "repo_lint_local.yml" | jq -c '[.[].result]')
+if [ "$GOT" = '[""]' ]; then
+  pass "workflow-wide scan: a still-in-progress rerun outranks an older completed failure of the same name (#655 round 13, Finding 3)"
+else
+  fail "workflow-wide scan (pending outranks stale): expected [\"\"] (pending, not the stale FAILURE), got $GOT"
+fi
+# A StatusContext-shaped entry (no .status field, e.g. a legacy commit
+# status) must not error out reaching this branch -- this is exactly the
+# self-caught index(.state) hazard above; confirm it evaluates cleanly.
+ROLLUP_STATUSCONTEXT_ANNEX='{"statusCheckRollup":[{"context":"legacy-ci","workflowPath":"repo_lint_local.yml","state":"SUCCESS"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_STATUSCONTEXT_ANNEX" "repo_lint_local.yml")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "workflow-wide scan: a StatusContext entry (no .status field) evaluates cleanly and a SUCCESS state is not blocking (#655 round 13, self-caught index(.state) hazard)"
+else
+  fail "workflow-wide scan (StatusContext entry): expected 0, got $GOT"
+fi
+
+# #655 round 13 Codex P2 (Finding 5, "disambiguate annex workflows beyond
+# display name"): two DIFFERENT workflow files can declare the identical
+# top-level `name:` (both display as workflowName "CI"), so matching by
+# workflowPath instead of workflowName must not be confused by the
+# collision -- only the entry whose workflowPath actually matches the
+# target is caught, regardless of a shared workflowName.
+ROLLUP_WORKFLOWNAME_COLLISION='{"statusCheckRollup":[{"name":"build","workflowName":"CI","workflowPath":"repo_lint_local.yml","conclusion":"FAILURE"},{"name":"deploy","workflowName":"CI","workflowPath":"some-other-ci.yml","conclusion":"FAILURE"}]}'
+GOT=$(annex_workflow_bad "$ROLLUP_WORKFLOWNAME_COLLISION" "repo_lint_local.yml" | jq -c '[.[].label]')
+if [ "$GOT" = '["build"]' ]; then
+  pass "workflow-wide scan: matches by workflowPath even when workflowName collides across two different workflow files (#655 round 13, Finding 5)"
+else
+  fail "workflow-wide scan (workflowName collision): expected [\"build\"] only, got $GOT"
+fi
+GOT=$(annex_workflow_bad "$ROLLUP_WORKFLOWNAME_COLLISION" "some-other-ci.yml" | jq -c '[.[].label]')
+if [ "$GOT" = '["deploy"]' ]; then
+  pass "workflow-wide scan (Finding 5 sanity): the OTHER same-workflowName workflow's own failure only surfaces when IT is the scanned path"
+else
+  fail "workflow-wide scan (Finding 5 sanity): expected [\"deploy\"] only, got $GOT"
+fi
+
+# #655 round 8 Codex P2 ("wait for unreported unfiltered annex checks"):
+# refines the round-5 "never reported -> not blocking" rule above. When
+# the annex's pull_request trigger is unfiltered (guaranteed to
+# eventually report), zero matches means "not scheduled yet", not "may
+# never run" -- a synthetic PENDING entry is unioned in instead of
+# silently passing. KEEP IN SYNC with scripts/codex-review-check.sh's
+# ANNEX_WORKFLOW_MATCHES / unfiltered-zero-match branch.
+annex_workflow_bad_or_pending() {
+  local rollup_json=$1 workflow_path=$2 unfiltered=$3
+  local match_count
+  match_count=$(printf '%s' "$rollup_json" | jq --arg workflow_path "$workflow_path" '[.statusCheckRollup[] | select((.workflowPath // "") == $workflow_path)] | length')
+  if [ "$match_count" -eq 0 ] && [ "$unfiltered" = "true" ]; then
+    jq -n --arg workflow_path "$workflow_path" '[{label: "(not yet reported)", workflow: $workflow_path, result: "PENDING"}]'
+  else
+    annex_workflow_bad "$rollup_json" "$workflow_path"
+  fi
+}
+
+GOT=$(annex_workflow_bad_or_pending "$ROLLUP_NEVER_REPORTED" "consumer-annex.yml" "true" | jq -c '[.[].result]')
+if [ "$GOT" = '["PENDING"]' ]; then
+  pass "workflow-wide scan: an unfiltered annex that never reported anything is treated as not-yet-clean, not silently passed (#655 round 8 P2)"
+else
+  fail "workflow-wide scan (unfiltered, never reported): expected [\"PENDING\"], got $GOT"
+fi
+
+GOT=$(annex_workflow_bad_or_pending "$ROLLUP_NEVER_REPORTED" "consumer-annex.yml" "false")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "workflow-wide scan: a path-filtered (unfiltered=false) annex that never reported anything is still NOT blocking, preserving round 5 (#655 round 8)"
+else
+  fail "workflow-wide scan (path-filtered, never reported): expected 0 (round-5 behavior preserved), got $GOT"
+fi
+
+GOT=$(annex_workflow_bad_or_pending "$ROLLUP_ANNEX_REPORTED_GOOD" "repo_lint_local.yml" "true")
+if [ "$(echo "$GOT" | jq 'length')" = "0" ]; then
+  pass "workflow-wide scan: an unfiltered annex that HAS reported green is not treated as pending (real reports still win)"
+else
+  fail "workflow-wide scan (unfiltered, reported green): expected 0, got $GOT"
+fi
+
+# ── 4. End-to-end: union of the required-name-scoped BAD_CHECKS and the
+#      workflow-wide scan, mirroring how the real script merges them
+#      before computing BAD_COUNT. Post-round-10, REQUIRED_JSON is JUST
+#      branch protection's own required names (BRANCH_PROTECTION_NAMES
+#      below) -- the annex is no longer merged into it, so the name-scoped
+#      filter alone can no longer see the annex AT ALL (whether
+#      conventional-named or matrix-leg); the workflow-wide scan is the
+#      SOLE annex-enforcement path now, unconditionally, regardless of
+#      REQUIRED_JSON. This is the intended fix for Finding 2's
+#      name-collision risk, not a regression: it means a same-named
+#      unrelated check (allowed by the annex contract) can never stand in
+#      for -- or be wrongly blocked by -- the annex.
+BRANCH_PROTECTION_NAMES='["lint"]'
+GOT=$(bad_checks "$ROLLUP_ANNEX_REPORTED_BAD" "$BRANCH_PROTECTION_NAMES" | jq -c '[.[].label]')
+if [ "$GOT" = '[]' ]; then
+  pass "end-to-end: the name-scoped filter alone no longer sees a red conventional-named annex check post-round-10 (workflow-wide scan is the sole path now)"
+else
+  fail "end-to-end (red conventional, name-scoped alone): expected [] (annex no longer name-merged), got $GOT"
+fi
+UNIONED_CONVENTIONAL=$(echo "$(bad_checks "$ROLLUP_ANNEX_REPORTED_BAD" "$BRANCH_PROTECTION_NAMES")" | jq -c --argjson extra "$(annex_workflow_bad "$ROLLUP_ANNEX_REPORTED_BAD" "repo_lint_local.yml")" '(. + $extra) | unique')
+GOT=$(echo "$UNIONED_CONVENTIONAL" | jq -c '[.[].label]')
+if [ "$GOT" = '["repo-lint-local"]' ]; then
+  pass "end-to-end: unioning the workflow-wide scan catches a red conventional-named annex check the name-scoped filter alone now misses (#655 round 10)"
+else
+  fail "end-to-end (red conventional, unioned): expected [\"repo-lint-local\"], got $GOT"
+fi
+
+# The matrix-leg failure was ALREADY invisible to the name-scoped filter
+# even before round 10 (its required_names never contained the expanded
+# "checks (20)"); unioning the workflow-wide scan still catches it.
+GOT=$(bad_checks "$ROLLUP_MATRIX_LEG_FAILED" "$BRANCH_PROTECTION_NAMES" | jq -c '[.[].label]')
+if [ "$GOT" = '[]' ]; then
+  pass "end-to-end: confirms the matrix-leg failure is invisible to the name-scoped filter alone"
+else
+  fail "end-to-end (matrix leg, name-scoped only): expected [] (invisible without the workflow scan), got $GOT"
+fi
+UNIONED=$(echo "$(bad_checks "$ROLLUP_MATRIX_LEG_FAILED" "$BRANCH_PROTECTION_NAMES")" | jq -c --argjson extra "$(annex_workflow_bad "$ROLLUP_MATRIX_LEG_FAILED" "consumer-annex.yml")" '(. + $extra) | unique')
+GOT=$(echo "$UNIONED" | jq -c '[.[].label]')
+if [ "$GOT" = '["checks (20)"]' ]; then
+  pass "end-to-end: unioning the workflow-wide scan catches the matrix-leg failure the name-scoped filter alone misses (#655 round 5)"
+else
+  fail "end-to-end (matrix leg, unioned): expected [\"checks (20)\"], got $GOT"
+fi
+
+ROLLUP_SKIPPED_ANNEX='{"statusCheckRollup":[{"name":"lint","conclusion":"SUCCESS"},{"name":"repo-lint-local","conclusion":"SKIPPED"}]}'
+UNIONED_SKIPPED=$(echo "$(bad_checks "$ROLLUP_SKIPPED_ANNEX" "$BRANCH_PROTECTION_NAMES")" | jq -c --argjson extra "$(annex_workflow_bad "$ROLLUP_SKIPPED_ANNEX" "repo_lint_local.yml")" '(. + $extra) | unique')
+GOT=$(echo "$UNIONED_SKIPPED" | jq -c '[.[].label]')
+if [ "$GOT" = '[]' ]; then
+  pass "end-to-end: a SKIPPED annex check (job-level conditional) does not block, consistent with SUCCESS/SKIPPED/NEUTRAL elsewhere"
+else
+  fail "end-to-end (skipped annex): expected [] (non-blocking), got $GOT"
+fi
+
+# Finding 2's EXACT scenario reproduced end-to-end: branch protection
+# requires ONLY "lint". The annex's OWN job happens to be named "test"
+# (the annex contract does not require unique job names). An UNRELATED,
+# non-required check from a completely different workflow COINCIDENTALLY
+# also happens to be named "test" and is red -- pre-round-10, merging the
+# annex's derived name ("test") into REQUIRED_JSON would have made this
+# unrelated check "required" too, wrongly blocking gate (a) with a fully
+# green annex. Post-round-10 (no merge), required_names stays ["lint"]
+# alone, so neither "test"-named check is in scope for the name-based
+# filter at all -- but the ANNEX's own "test" job is STILL correctly
+# caught if red, via the workflow-wide scan matching by workflow identity
+# (immune to the name collision the unrelated check shares).
+ROLLUP_NAME_COLLISION='{"statusCheckRollup":[{"name":"lint","workflowName":"repo-lint","conclusion":"SUCCESS"},{"name":"test","workflowName":"Consumer Annex","workflowPath":"consumer-annex.yml","conclusion":"FAILURE"},{"name":"test","workflowName":"Some Unrelated Optional Workflow","workflowPath":"some-unrelated-optional-workflow.yml","conclusion":"FAILURE"}]}'
+GOT=$(bad_checks "$ROLLUP_NAME_COLLISION" "$BRANCH_PROTECTION_NAMES" | jq -c '[.[].workflow]')
+if [ "$GOT" = '[]' ]; then
+  pass "end-to-end (Finding 2): the name-scoped filter alone does not see EITHER same-named 'test' check, since neither is in required_names post-round-10"
+else
+  fail "end-to-end (Finding 2, name-scoped alone): expected [] (no annex-name merge to widen scope), got $GOT"
+fi
+GOT=$(annex_workflow_bad "$ROLLUP_NAME_COLLISION" "consumer-annex.yml" | jq -c '[.[].workflow]')
+if [ "$GOT" = '["Consumer Annex"]' ]; then
+  pass "end-to-end (Finding 2): the workflow-wide scan still catches the annex's own red 'test' job, unconfused by the unrelated same-named check"
+else
+  fail "end-to-end (Finding 2, workflow-wide scan): expected [\"Consumer Annex\"] only (not the unrelated same-named check), got $GOT"
+fi
+GOT=$(annex_workflow_bad "$ROLLUP_NAME_COLLISION" "some-unrelated-optional-workflow.yml" | jq -c '[.[].workflow]')
+if [ "$GOT" = '["Some Unrelated Optional Workflow"]' ]; then
+  pass "end-to-end (Finding 2 sanity): the unrelated workflow's own red check would ONLY surface if IT were the scanned workflow, confirming the scan is workflow-scoped not name-scoped"
+else
+  fail "end-to-end (Finding 2 sanity): expected the unrelated workflow scan to only see its own entry, got $GOT"
+fi
+
+echo ""
+echo "test_codex_review_check_required_checks: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -93,6 +93,7 @@ run_hook() {
   STUB_PR_DELETIONS="$deletions" \
   STUB_PR_HEAD="$pr_head" \
   STUB_PR_AUTHOR="$pr_author" \
+  OP_PREFLIGHT_AGENT="${TEST_OP_PREFLIGHT_AGENT:-}" \
   GH_PR_GUARD_EXPECTED_REVIEWER="$expected_reviewer" \
     bash "$HOOK" <<<"$payload"
 }
@@ -263,6 +264,107 @@ assert_rc_contains "self-approve over-threshold blocked from wrapper identity" 2
 
 assert_rc_contains "cross-agent approve allowed" 0 "" \
   'GH_AS_REVIEWER_IDENTITY=nathanpayne-codex scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-codex" "Authoring-Agent: claude" "5000" "0"
+
+# --- #671: the self-approve sub-guard resolves the reviewer the same way
+# the wrapper will (GH_AS_REVIEWER_IDENTITY, then MERGEPATH_AGENT, then
+# the default), honoring an inline same-segment MERGEPATH_AGENT prefix.
+# Session default (expected reviewer arg) stays nathanpayne-claude in all
+# of these — exactly the PR #663 incident shape.
+assert_rc_contains "cross-agent approve via inline MERGEPATH_AGENT allowed (#671)" 0 "" \
+  'MERGEPATH_AGENT=codex scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# ...the same inline form naming the AUTHORING agent is still self-approve.
+assert_rc_contains "same-agent approve via inline MERGEPATH_AGENT still blocked (#671)" 2 "self-approve detected" \
+  'MERGEPATH_AGENT=claude scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# ...an inline value the hook cannot resolve to a literal identity fails
+# closed: a command-substitution value and a non-slug value are both
+# blocked rather than guessed at. The flattened cmdsub form arrives as an
+# empty assignment plus an adjacent placeholder token, which the capture
+# records as the placeholder so this blocks explicitly (#679 review P2).
+assert_rc_contains "cmdsub inline MERGEPATH_AGENT approve blocked (#671)" 2 "unverifiable inline MERGEPATH_AGENT" \
+  'MERGEPATH_AGENT=$(cat /tmp/agent) scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# ...including on a NON-claude-authored PR, where an empty capture falling
+# back to the claude default would have compared cursor against claude and
+# FAILED OPEN — the substitution could resolve to the authoring agent and
+# post a same-agent approval (#679 review P2 regression).
+assert_rc_contains "cmdsub inline MERGEPATH_AGENT blocked on cursor-authored PR (#679 P2)" 2 "unverifiable inline MERGEPATH_AGENT" \
+  'MERGEPATH_AGENT=$(cat /tmp/agent) scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: cursor" "5000" "0"
+
+assert_rc_contains "non-slug inline MERGEPATH_AGENT approve blocked (#671)" 2 "not a plain agent slug" \
+  'MERGEPATH_AGENT="codex or claude" scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# ...but a malformed MERGEPATH_AGENT must NOT block when an explicit
+# GH_AS_REVIEWER_IDENTITY decides resolution first — the wrapper never
+# reads MERGEPATH_AGENT in that case (#679 review P3).
+assert_rc_contains "non-slug MERGEPATH_AGENT ignored when explicit reviewer identity wins (#679 P3)" 0 "" \
+  'MERGEPATH_AGENT="codex or claude" GH_AS_REVIEWER_IDENTITY=nathanpayne-codex scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-codex" "Authoring-Agent: claude" "5000" "0"
+
+# --- #679 review P1: the wrapper chain's third link. A session warmed
+# with op-preflight --agent <agent> exports OP_PREFLIGHT_AGENT, and the
+# wrapper resolves nathanpayne-$OP_PREFLIGHT_AGENT when neither
+# GH_AS_REVIEWER_IDENTITY nor MERGEPATH_AGENT is set. Bottoming out at
+# the claude default instead would fail OPEN on a cursor-preflight
+# session approving a cursor-authored PR.
+TEST_OP_PREFLIGHT_AGENT=cursor \
+  assert_rc_contains "same-agent approve via OP_PREFLIGHT_AGENT session blocked (#679 P1)" 2 "self-approve detected" \
+  'scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: cursor" "5000" "0"
+
+TEST_OP_PREFLIGHT_AGENT=codex \
+  assert_rc_contains "cross-agent approve via OP_PREFLIGHT_AGENT session allowed (#679 P1)" 0 "" \
+  'scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# ...and an inline MERGEPATH_AGENT prefix still outranks the preflight
+# link, matching the wrapper chain order.
+TEST_OP_PREFLIGHT_AGENT=claude \
+  assert_rc_contains "inline MERGEPATH_AGENT outranks OP_PREFLIGHT_AGENT (#679 P1)" 0 "" \
+  'MERGEPATH_AGENT=codex scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# --- #679 round 2: env-unset OP_PREFLIGHT_AGENT must not be trusted from
+# the stale hook environment — the wrapper falls to its claude default, so
+# a codex-preflight session approving a claude-authored PR is same-agent.
+TEST_OP_PREFLIGHT_AGENT=codex \
+  assert_rc_contains "env -u OP_PREFLIGHT_AGENT approve resolves to default and blocks (#679 r2)" 2 "self-approve detected" \
+  'env -u OP_PREFLIGHT_AGENT -u OP_PREFLIGHT_REVIEWER_PAT scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# --- #679 round 2: a command-substitution GH_AS_REVIEWER_IDENTITY is the
+# wrapper chain FIRST link — it must fail closed (the substitution could
+# emit the authoring identity), not fall through to MERGEPATH_AGENT.
+assert_rc_contains "cmdsub GH_AS_REVIEWER_IDENTITY approve blocked (#679 r2)" 2 "not expected reviewer" \
+  'GH_AS_REVIEWER_IDENTITY=$(cat /tmp/id) MERGEPATH_AGENT=codex scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# --- #679 round 2: an EMBEDDED substitution with a literal prefix
+# (MERGEPATH_AGENT=cla$(x)e) flattens into the prefix token plus an
+# adjacent placeholder; the guard must fail closed on the whole segment,
+# never trust the literal prefix as the agent slug.
+assert_rc_contains "embedded-cmdsub MERGEPATH_AGENT approve blocked (#679 r2)" 2 "unverifiable command substitution" \
+  'MERGEPATH_AGENT=cla$(cat /tmp/a)e scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: cursor" "5000" "0"
+
+# --- same adjacency hole, bare-write form: an embedded substitution in
+# ANY prefix assignment used to derail the walk (the placeholder took
+# command position, the real gh write was classified as unrelated-command
+# args) and a BARE guarded write escaped the guard entirely.
+assert_rc_contains "bare gh pr merge behind embedded-cmdsub prefix blocked (#679 r2)" 2 "unverifiable command substitution" \
+  'FOO=a$(cat /tmp/x)b gh pr merge 123 --squash'
+
+# ...while the same embedded-cmdsub prefix on a NON-gh segment stays
+# allowed — the fail-closed scope is gh/wrapper segments only.
+assert_rc_contains "embedded-cmdsub prefix on non-gh command allowed (#679 r2)" 0 "" \
+  'FOO=a$(cat /tmp/x)b make build'
+
+# ...an inline prefix scoped to an EARLIER command does not leak across
+# the separator: the wrapper never sees it, so the sub-guard must not
+# credit it as the cross-agent identity (falls back to the default →
+# still self-approve).
+assert_rc_contains "MERGEPATH_AGENT prefix on an earlier command does not unlock approve (#671)" 2 "self-approve detected" \
+  'MERGEPATH_AGENT=codex echo ok ; scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
+
+# ...env -i strips MERGEPATH_AGENT from the wrapper environment, so an
+# earlier inline prefix must not survive it (wrapper bottoms out at its
+# hardcoded claude default → same-agent → blocked).
+assert_rc_contains "inline MERGEPATH_AGENT before env -i does not unlock approve (#671)" 2 "self-approve detected" \
+  'MERGEPATH_AGENT=codex env -i scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "lgtm"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0"
 
 ORIG_DIR="$(pwd)"
 mkdir -p "$WORKDIR/repo-with-policy/.github"

--- a/tests/test_merge_clearance_gate.sh
+++ b/tests/test_merge_clearance_gate.sh
@@ -720,8 +720,10 @@ if [ -z "${MCG_SKIP_FIX3_SELFTEST:-}" ]; then
 echo; echo "--- Test 20: check_merge_clearance_gate job-name scope (#533)"
 CHECK_BIN="$ROOT/scripts/ci/check_merge_clearance_gate"
 
-# A minimal workflow that is otherwise shape-valid (all required triggers +
-# a schedule cron) so ONLY the job-name assertion is under test.
+# A minimal workflow that is otherwise shape-valid (all required triggers, a
+# schedule cron, AND the #658 repository_dispatch trigger + dispatch-recheck
+# job) so ONLY the job-name assertion is under test. Each Case appends the job
+# under test after this header.
 write_wf_header() {
   cat <<'WF'
 name: Merge Clearance Gate
@@ -732,11 +734,24 @@ on:
     types: [submitted]
   pull_request_review_comment:
     types: [created]
+  repository_dispatch:
+    types: [merge-clearance-recheck]
   schedule:
     - cron: "*/15 * * * *"
 permissions:
   contents: read
 jobs:
+  # #658 dispatch-recheck job — present so this shape-valid header satisfies
+  # the check's repository_dispatch + dispatch-wiring assertions; each Case
+  # appends the job under test after it.
+  dispatch-recheck:
+    name: Merge clearance dispatch re-evaluation
+    if: github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          PR: ${{ github.event.client_payload.pr }}
+        run: echo "recheck $PR"
 WF
 }
 
@@ -815,6 +830,121 @@ if ! echo "$OUT" | grep -q "must define a JOB named" \
   pass "correctly-named JOB → job-name assertion passes (#533)"
 else
   fail "expected job-name assertion to pass on a correct job name (#533); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 21 (#658): the check must require the repository_dispatch marker
+# re-trigger + its dispatch wiring. The propagation-lane verified-head marker
+# is a GITHUB_TOKEN issue comment (creates no workflow run), so the lane sends
+# a merge-clearance-recheck repository_dispatch instead; without the trigger a
+# verified sync PR rides a fail-closed spurious-red gate until the */15 sweep.
+# The dispatch-recheck job must accept the merge-clearance-recheck type AND
+# resolve the PR from github.event.client_payload.pr.
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 21: check requires the repository_dispatch marker re-trigger (#658)"
+
+# Case A (negative): repository_dispatch trigger absent → check FAILS.
+WF_NO_RD="$WORKDIR/wf-no-repo-dispatch.yml"
+cat > "$WF_NO_RD" <<'WF'
+name: Merge Clearance Gate
+on:
+  pull_request:
+    types: [opened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  schedule:
+    - cron: "*/15 * * * *"
+permissions:
+  contents: read
+jobs:
+  merge-clearance-gate:
+    name: Merge clearance gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run gate
+        run: echo ok
+WF
+set +e
+OUT=$(MERGE_CLEARANCE_WORKFLOW="$WF_NO_RD" "$CHECK_BIN" 2>&1)
+RC=$?
+set -e
+if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q "missing the repository_dispatch trigger"; then
+  pass "workflow missing the repository_dispatch trigger → check FAILS (#658)"
+else
+  fail "expected check FAIL on missing repository_dispatch trigger (#658); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# Case B (negative): repository_dispatch present but the dispatch wiring absent
+# (no merge-clearance-recheck type / no client_payload.pr resolution) → the
+# re-trigger silently degrades to the sweep, so the check FAILS.
+WF_NO_WIRING="$WORKDIR/wf-no-dispatch-wiring.yml"
+cat > "$WF_NO_WIRING" <<'WF'
+name: Merge Clearance Gate
+on:
+  pull_request:
+    types: [opened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  repository_dispatch:
+    types: [some-other-event]
+  schedule:
+    - cron: "*/15 * * * *"
+permissions:
+  contents: read
+jobs:
+  merge-clearance-gate:
+    name: Merge clearance gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run gate
+        run: echo ok
+WF
+set +e
+OUT=$(MERGE_CLEARANCE_WORKFLOW="$WF_NO_WIRING" "$CHECK_BIN" 2>&1)
+RC=$?
+set -e
+if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q "not wired for the marker re-trigger"; then
+  pass "repository_dispatch without the merge-clearance-recheck wiring → check FAILS (#658)"
+else
+  fail "expected check FAIL on unwired repository_dispatch (#658); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# Case C (positive): the canonical header (repository_dispatch trigger +
+# merge-clearance-recheck type + client_payload.pr wiring) plus a correctly-
+# named job satisfies the #658 assertions — neither the missing-trigger nor the
+# unwired FAIL line is emitted.
+WF_RD_OK="$WORKDIR/wf-rd-ok.yml"
+{
+  write_wf_header
+  cat <<'WF'
+  merge-clearance-gate:
+    name: Merge clearance gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run gate
+        run: echo ok
+WF
+} > "$WF_RD_OK"
+set +e
+OUT=$(MCG_SKIP_FIX3_SELFTEST=1 MERGE_CLEARANCE_WORKFLOW="$WF_RD_OK" "$CHECK_BIN" 2>&1)
+RC=$?
+set -e
+# Assert the check RAN to completion AND its pre-flight PASSED. A pre-flight
+# failure for ANY reason (the #658 assertions or otherwise) emits
+# "FAIL (pre-flight)", so this catches a checker that fails for a different
+# reason (CodeRabbit) — stronger than only checking the two #658 lines are
+# absent. RC is deliberately NOT asserted: the check also runs the nested
+# fixture suite, whose unrelated failures must not couple this positive control
+# (#556, same rationale as the job-name Case C above).
+if echo "$OUT" | grep -q "check_merge_clearance_gate:" \
+   && ! echo "$OUT" | grep -q "FAIL (pre-flight)"; then
+  pass "repository_dispatch trigger + merge-clearance-recheck wiring present → check pre-flight (incl. #658 assertions) passes"
+else
+  fail "expected the check pre-flight to pass on the wired header; got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
 fi
 fi  # end re-entrancy guard (MCG_SKIP_FIX3_SELFTEST)
 

--- a/tests/test_phase_4b_accounting.sh
+++ b/tests/test_phase_4b_accounting.sh
@@ -544,6 +544,135 @@ if printf '%s' "$uf" | jq -e 'length == 1
   pass "an identical finding (pipe-bearing content) across loops still dedupes to one lifecycle entry (finding 3)"
 else fail "pipe-bearing repeat dedup: $uf"; fi
 
+# ---------------------------------------------------------------------------
+# Filed-issues tuple-keyed injection channel (#675). The step-9 executor files
+# post-review issues for an APPROVED-with-advisories verdict, then injects the
+# filed list WITHOUT knowing F-ids; unique_findings joins it on the SAME
+# collision-proof [severity, path, line, body] tuple and records
+# disposition=deferred-to-follow-up + the issue link on the matched finding.
+FILED='[{"severity":"P2","path":"a.js","line":3,"body":"dup","issue":701}]'
+uf="$(printf '%s\n%s\n' \
+  '{"loop":1,"severity":"P2","path":"a.js","line":3,"body":"dup"}' \
+  '{"loop":2,"severity":"P3","path":null,"line":null,"body":"solo"}' \
+  | p4b_acct_unique_findings '' "$FILED")"
+if printf '%s' "$uf" | jq -e '
+    (.[0].id == "F1" and .[0].disposition == "deferred-to-follow-up" and .[0].issue == 701)
+    and (.[1].id == "F2" and .[1].disposition == "unresolved" and .[1].issue == null)' >/dev/null; then
+  pass "filed-issues tuple join sets deferred-to-follow-up + issue on the matched finding only (#675)"
+else fail "filed-issues tuple join: $uf"; fi
+
+# A filed entry matching no recorded finding is ignored — the join only
+# enriches existing dedup entries, never mints a phantom unique finding.
+uf="$(printf '%s\n' '{"loop":1,"severity":"P2","path":"a.js","line":3,"body":"dup"}' \
+  | p4b_acct_unique_findings '' '[{"severity":"P1","path":"z.js","line":9,"body":"never-recorded","issue":702}]')"
+if printf '%s' "$uf" | jq -e 'length == 1
+    and .[0].disposition == "unresolved" and .[0].issue == null' >/dev/null; then
+  pass "filed entry matching no recorded finding is ignored — no phantom entry (#675)"
+else fail "filed no-match phantom: $uf"; fi
+
+# The filed join keys on the collision-proof tuple, not a '|'-joined string, so
+# a body containing '|' cannot cross-match a different finding's issue link.
+uf="$(printf '%s\n%s\n' \
+  '{"loop":1,"severity":"P2","path":"a","line":1,"body":"b|2|c"}' \
+  '{"loop":2,"severity":"P2","path":"a|1|b","line":2,"body":"c"}' \
+  | p4b_acct_unique_findings '' '[{"severity":"P2","path":"a","line":1,"body":"b|2|c","issue":703}]')"
+if printf '%s' "$uf" | jq -e '
+    (.[0].issue == 703 and .[0].disposition == "deferred-to-follow-up")
+    and (.[1].issue == null and .[1].disposition == "unresolved")' >/dev/null; then
+  pass "filed join respects the collision-proof tuple key ('|'-bearing content) (#675)"
+else fail "filed join collision: $uf"; fi
+
+# Explicit F-id dispositions map wins per finding over the filed channel: a
+# fully specified F-id entry overrides disposition, fix_commit, AND issue.
+uf="$(printf '%s\n' '{"loop":1,"severity":"P2","path":"a.js","line":3,"body":"dup"}' \
+  | p4b_acct_unique_findings \
+      '{"F1":{"disposition":"fixed","fix_commit":"abc123","issue":999}}' \
+      '[{"severity":"P2","path":"a.js","line":3,"body":"dup","issue":701}]')"
+if printf '%s' "$uf" | jq -e '
+    .[0].disposition == "fixed" and .[0].fix_commit == "abc123" and .[0].issue == 999' >/dev/null; then
+  pass "explicit F-id dispositions map wins per finding over the filed-issues channel (#675)"
+else fail "F-id precedence over filed channel: $uf"; fi
+
+# advisory_issues_filed derives automatically from the filed-enriched unique
+# findings — no explicit F-id map, just the tuple-keyed filed channel (#675).
+UF_FILED="$(printf '%s\n%s\n' \
+  '{"loop":1,"severity":"P2","path":"a.js","line":3,"body":"one"}' \
+  '{"loop":1,"severity":"P3","path":"b.js","line":9,"body":"two"}' \
+  | p4b_acct_unique_findings '' \
+      '[{"severity":"P2","path":"a.js","line":3,"body":"one","issue":701},{"severity":"P3","path":"b.js","line":9,"body":"two","issue":702}]')"
+tt_filed="$(p4b_acct_compute_totals '[{"loop":1,"reviewer":"nathanpayne-codex","adapter":"a","direction":"claude->codex","elapsed_seconds":null,"tokens":{"total":null,"input":null,"output":null,"cache_creation":null,"cache_read":null,"reasoning":null,"cost_usd":null,"source":"unavailable"},"fail_closed":{"happened":false,"reason":null,"duration_seconds":null}}]' "" "null" "$UF_FILED")"
+if printf '%s' "$tt_filed" | jq -e '.advisory_issues_filed == [701,702]' >/dev/null; then
+  pass "advisory_issues_filed derives from the filed-issues-enriched unique findings (#675)"
+else fail "advisory_issues_filed derivation: $tt_filed"; fi
+
+# Explicit F-id issue override respects an explicit null (#675 Codex round 1):
+# key-presence, not null-coalescing — a {"disposition":"fixed","issue":null}
+# override keeps issue null instead of reattaching the filed follow-up.
+uf="$(printf '%s\n' '{"loop":1,"severity":"P2","path":"a.js","line":3,"body":"dup"}' \
+  | p4b_acct_unique_findings \
+      '{"F1":{"disposition":"fixed","fix_commit":"abc123","issue":null}}' \
+      '[{"severity":"P2","path":"a.js","line":3,"body":"dup","issue":585}]')"
+if printf '%s' "$uf" | jq -e '.[0].disposition == "fixed" and .[0].fix_commit == "abc123" and .[0].issue == null' >/dev/null; then
+  pass "explicit F-id issue:null wins over the filed channel (key-presence, not null-coalescing) (#675)"
+else fail "explicit-null issue override: $uf"; fi
+# An F-id entry that OMITS the issue key still inherits the filed issue link.
+uf="$(printf '%s\n' '{"loop":1,"severity":"P2","path":"a.js","line":3,"body":"dup"}' \
+  | p4b_acct_unique_findings '{"F1":{"disposition":"rebutted"}}' \
+      '[{"severity":"P2","path":"a.js","line":3,"body":"dup","issue":585}]')"
+if printf '%s' "$uf" | jq -e '.[0].disposition == "rebutted" and .[0].issue == 585' >/dev/null; then
+  pass "an F-id entry that omits issue still inherits the filed issue link (#675)"
+else fail "F-id omits issue fallback: $uf"; fi
+
+# p4b_acct_filed_issues_from_refs — the orchestrator's ref→filed-issues zip,
+# extracted for testability (#675 Codex round 1). Numeric issues, 1:1 with
+# FILE_JSON.findings in filing order.
+FILE3='{"findings":[{"severity":"P2","path":"a","line":1,"body":"one"},{"severity":"P3","path":"b","line":2,"body":"two"},{"severity":"P2","path":"c","line":3,"body":"three"}]}'
+fi_out="$(p4b_acct_filed_issues_from_refs "#901, #902, #903" "$FILE3")"
+if printf '%s' "$fi_out" | jq -e '
+    length == 3
+    and .[0] == {severity:"P2",path:"a",line:1,body:"one",issue:901}
+    and .[1] == {severity:"P3",path:"b",line:2,body:"two",issue:902}
+    and .[2] == {severity:"P2",path:"c",line:3,body:"three",issue:903}' >/dev/null; then
+  pass "filed_issues_from_refs zips numeric refs onto findings in filing order (#675)"
+else fail "filed_issues_from_refs normal: $fi_out"; fi
+# Position preservation: a malformed MIDDLE ref maps to a null placeholder so a
+# later issue number never shifts onto the wrong finding — the malformed one is
+# dropped (unlinked), the others keep their correct issue.
+fi_out="$(p4b_acct_filed_issues_from_refs "#101, #bad, #103" "$FILE3")"
+if printf '%s' "$fi_out" | jq -e '
+    length == 2
+    and (.[0] | .path == "a" and .issue == 101)
+    and (.[1] | .path == "c" and .issue == 103)' >/dev/null; then
+  pass "filed_issues_from_refs preserves ref positions (malformed middle ref dropped, not compacted) (#675)"
+else fail "filed_issues_from_refs position preservation: $fi_out"; fi
+# Empty ref list → empty filed-issues array (nothing linked).
+fi_out="$(p4b_acct_filed_issues_from_refs "" "$FILE3")"
+[ "$fi_out" = "[]" ] && pass "filed_issues_from_refs with no refs → [] (#675)" || fail "filed_issues_from_refs empty: $fi_out"
+
+# advisory_issues_filed captures EVERY filed issue even when duplicate findings
+# collapse (#675 Codex round 2): two identical-tuple findings can get two
+# DIFFERENT filed refs (a search-lag duplicate in p4b_file_post_review_issues);
+# the tuple-keyed filed map keeps only the last ref on the single collapsed
+# unique finding, so compute_totals unions the unique-finding issues with the
+# raw filed list to record both — matching the review prose.
+DUP_LOOP='[{"loop":1,"reviewer":"nathanpayne-codex","adapter":"a","direction":"claude->codex","elapsed_seconds":null,"tokens":{"total":null,"input":null,"output":null,"cache_creation":null,"cache_read":null,"reasoning":null,"cost_usd":null,"source":"unavailable"},"fail_closed":{"happened":false,"reason":null,"duration_seconds":null}}]'
+DUP_FILED='[{"severity":"P2","path":"x.js","line":2,"body":"dup","issue":901},{"severity":"P2","path":"x.js","line":2,"body":"dup","issue":902}]'
+UF_DUP="$(printf '%s\n%s\n' \
+  '{"loop":1,"severity":"P2","path":"x.js","line":2,"body":"dup"}' \
+  '{"loop":1,"severity":"P2","path":"x.js","line":2,"body":"dup"}' \
+  | p4b_acct_unique_findings '' "$DUP_FILED")"
+tt_dup="$(p4b_acct_compute_totals "$DUP_LOOP" "" "null" "$UF_DUP" "$DUP_FILED")"
+if printf '%s' "$UF_DUP" | jq -e 'length == 1' >/dev/null \
+   && printf '%s' "$tt_dup" | jq -e '.advisory_issues_filed == [901,902]' >/dev/null; then
+  pass "advisory_issues_filed unions the filed list so duplicate-collapsed findings keep every filed ref (#675 Codex round 2)"
+else fail "dup-collapse advisory union: uf=$UF_DUP tt=$tt_dup"; fi
+# Without a filed list, advisory_issues_filed still derives from the unique
+# findings (the F-id-map / golden path is unchanged).
+tt_nofiled="$(p4b_acct_compute_totals "$DUP_LOOP" "" "null" '[{"id":"F1","issue":701},{"id":"F2","issue":702}]')"
+if printf '%s' "$tt_nofiled" | jq -e '.advisory_issues_filed == [701,702]' >/dev/null; then
+  pass "advisory_issues_filed without a filed list derives from the unique findings (unchanged) (#675)"
+else fail "no-filed advisory derivation: $tt_nofiled"; fi
+
 # ===========================================================================
 echo "accounting.sh — notional-cost math (versioned price table)"
 # ===========================================================================

--- a/tests/test_phase_4b_automation.sh
+++ b/tests/test_phase_4b_automation.sh
@@ -172,6 +172,14 @@ mk_fake fake-codex-approve \
   "printf '%s' '{\"verdict\":\"APPROVED\",\"summary\":\"looks good\",\"findings\":[]}'"
 mk_fake fake-codex-approve-p2 \
   "printf '%s' '{\"verdict\":\"APPROVED\",\"summary\":\"advisory only\",\"findings\":[{\"severity\":\"P2\",\"path\":\"x.js\",\"line\":2,\"body\":\"should be handled under stricter policy\"}]}'"
+mk_fake fake-codex-approve-risk \
+  "printf '%s' '{\"verdict\":\"APPROVED\",\"summary\":\"advisory only\",\"findings\":[{\"severity\":\"P2\",\"path\":\"x.js\",\"line\":2,\"body\":\"residual risk of stale cache reads after failover\"}]}'"
+mk_fake fake-codex-approve-p3 \
+  "printf '%s' '{\"verdict\":\"APPROVED\",\"summary\":\"advisory only\",\"findings\":[{\"severity\":\"P3\",\"path\":\"x.js\",\"line\":2,\"body\":\"cosmetic nit only\"}]}'"
+mk_fake fake-codex-approve-2p2 \
+  "printf '%s' '{\"verdict\":\"APPROVED\",\"summary\":\"advisory only\",\"findings\":[{\"severity\":\"P2\",\"path\":\"x.js\",\"line\":2,\"body\":\"first advisory\"},{\"severity\":\"P2\",\"path\":\"y.js\",\"line\":9,\"body\":\"second advisory\"}]}'"
+mk_fake fake-codex-approve-p2p3 \
+  "printf '%s' '{\"verdict\":\"APPROVED\",\"summary\":\"advisory only\",\"findings\":[{\"severity\":\"P2\",\"path\":\"x.js\",\"line\":2,\"body\":\"filed advisory\"},{\"severity\":\"P3\",\"path\":\"y.js\",\"line\":9,\"body\":\"suppressed nit\"}]}'"
 mk_fake fake-codex-junk \
   "printf '%s' 'this is not json at all'"
 mk_fake fake-codex-usage \
@@ -311,11 +319,38 @@ cat > "$BIN/gh" <<'SH'
 if [ "${1:-}" = "api" ]; then
   case "${2:-}" in
     repos/o/r/pulls/*)
-      printf '%s\n' "${P4B_FAKE_LIVE_HEAD:-abc123}"
+      # #674 round 4: P4B_FAKE_LIVE_HEAD2 simulates a head that drifts
+      # between reads — served from the SECOND live-head read on.
+      cnt_file="${P4B_ISSUE_LOG:-${TMPDIR:-/tmp}/p4b-fake}.headreads"
+      cnt=$(( $( [ -f "$cnt_file" ] && cat "$cnt_file" || echo 0 ) + 1 ))
+      printf '%s\n' "$cnt" > "$cnt_file"
+      if [ -n "${P4B_FAKE_LIVE_HEAD2:-}" ] && [ "$cnt" -ge "${P4B_FAKE_LIVE_HEAD2_FROM:-2}" ]; then
+        printf '%s\n' "$P4B_FAKE_LIVE_HEAD2"
+      else
+        printf '%s\n' "${P4B_FAKE_LIVE_HEAD:-abc123}"
+      fi
       exit 0
       ;;
   esac
 fi
+
+
+# dedup lookup (#674 CodeRabbit): empty by default; P4B_FAKE_EXISTING_ISSUE
+# simulates a marker match from a prior partially-failed run.
+if [ "${1:-}" = "search" ] && [ "${2:-}" = "issues" ]; then
+  # #674 CodeRabbit Major: a search ERROR must fail the filing closed.
+  [ -n "${P4B_FAKE_SEARCH_FAIL:-}" ] && exit 1
+  if [ -n "${P4B_FAKE_EXISTING_ISSUE_ONCE:-}" ]; then
+    scnt_file="${P4B_ISSUE_LOG:-${TMPDIR:-/tmp}/p4b-fake}.searches"
+    scnt=$(( $( [ -f "$scnt_file" ] && cat "$scnt_file" || echo 0 ) + 1 ))
+    printf '%s\n' "$scnt" > "$scnt_file"
+    [ "$scnt" -eq 1 ] && printf 'https://github.com/o/r/issues/777\n'
+    exit 0
+  fi
+  [ -n "${P4B_FAKE_EXISTING_ISSUE:-}" ] && printf 'https://github.com/o/r/issues/777\n'
+  exit 0
+fi
+
 echo "unexpected fake gh invocation: $*" >&2
 exit 127
 SH
@@ -350,6 +385,42 @@ done
 printf '{"id":1,"commit_id":"%s"}\n' "${P4B_FAKE_CREATED_REVIEW_HEAD:-abc123}"
 SH
 chmod +x "$BIN/fake-gh-as-reviewer"
+
+# Author wrapper fake (#674): the step-9 issue writes route through
+# gh-as-author.sh. Logs to P4B_ISSUE_LOG with the same record shapes the
+# assertions key on (VIA / ARGV / CLOSE / body copies), mints incrementing
+# issue URLs, honors the failure knobs.
+cat > "$BIN/fake-gh-as-author" <<'SH'
+#!/usr/bin/env bash
+[ "${1:-}" = "--" ] || { echo "expected wrapper separator" >&2; exit 64; }
+shift
+[ "${1:-}" = "gh" ] || { echo "expected gh command" >&2; exit 64; }
+shift
+log="${P4B_ISSUE_LOG:-/dev/null}"
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "create" ]; then
+  { printf 'VIA gh-as-author\n'; printf 'ARGV gh %s\n' "$*"; } >> "$log"
+  prev=""
+  for a in "$@"; do
+    if [ "$prev" = "--body-file" ] && [ -n "${P4B_ISSUE_LOG:-}" ]; then
+      cp "$a" "${log}.body.$(grep -c '^ARGV ' "$log")"
+    fi
+    prev="$a"
+  done
+  [ -n "${P4B_FAKE_ISSUE_FAIL:-}" ] && exit 1
+  if [ -n "${P4B_FAKE_ISSUE_FAIL_AFTER_1:-}" ] && [ "$(grep -c '^ARGV ' "$log")" -ge 2 ]; then
+    exit 1
+  fi
+  printf 'https://github.com/o/r/issues/%s\n' "$((900 + $(grep -c '^ARGV ' "$log")))"
+  exit 0
+fi
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "close" ]; then
+  printf 'CLOSE #%s\n' "${3:-}" >> "$log"
+  exit 0
+fi
+echo "unexpected fake gh-as-author invocation: $*" >&2
+exit 64
+SH
+chmod +x "$BIN/fake-gh-as-author"
 
 # ===========================================================================
 echo "lib.sh — reviewer selection"
@@ -820,6 +891,67 @@ if [ "$rc" = 0 ] \
   pass "trim: rename within the allowlist stays eligible (omitted with placeholder)"
 else fail "trim rename-within-allowlist (rc=$rc, report='${rep:-}')"; fi
 
+# #668 finding 2 hardening: a crafted section whose explicit `rename to`
+# destination disagrees with the header-derived b/-side must fail closed —
+# eligibility may never rest solely on the header split when the section
+# carries exact rename/copy path lines.
+TRIM_RTO_IN="$WORK/trim-rto-in.diff"
+{
+  printf 'diff --git a/small.js b/small.js\n+ok\n'
+  printf 'diff --git a/data/old.jsonl b/data/new.jsonl\n'
+  printf 'similarity index 40%%\nrename from data/old.jsonl\nrename to src/evil.sh\n'
+  awk 'BEGIN { for (i = 0; i < 200; i++) printf "+RTO-CODE-%06d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n", i }'
+} > "$TRIM_RTO_IN"
+set +e
+p4b_trim_review_diff "$TRIM_RTO_IN" "$TRIM_OUT" 2000 'data/*' >/dev/null; rc=$?
+set -e
+[ "$rc" != 0 ] \
+  && pass "trim: rename-to destination outside the allowlist fails closed even when the header b/-side matches (#668)" \
+  || fail "trim rename-to-outside-allowlist should fail closed (rc=$rc)"
+
+# #668 finding 1: omission-allowlist provenance. When the over-budget diff
+# ITSELF touches .github/review-policy.yml, the allowlist read from the
+# checkout is untrusted for this run — omission must be refused entirely
+# (fail closed to the manual handoff), even though the bulk section is
+# allowlisted and the budget would otherwise be met.
+TRIM_POLICY_IN="$WORK/trim-policy-in.diff"
+{
+  printf 'diff --git a/.github/review-policy.yml b/.github/review-policy.yml\n'
+  printf '+  diff_omit_globs:\n+    - "src/*"\n'
+  printf 'diff --git a/data/huge.jsonl b/data/huge.jsonl\n'
+  awk 'BEGIN { for (i = 0; i < 200; i++) printf "+POLICY-BULK-%06d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n", i }'
+} > "$TRIM_POLICY_IN"
+set +e
+p4b_trim_review_diff "$TRIM_POLICY_IN" "$TRIM_OUT" 2000 'data/*' >/dev/null; rc=$?
+set -e
+[ "$rc" != 0 ] \
+  && pass "trim: refuses ALL omission when the diff touches .github/review-policy.yml (#668 provenance)" \
+  || fail "trim policy-touching diff should fail closed (rc=$rc)"
+
+# ...including when the policy file is only the SOURCE of a rename (the
+# a/-side / rename-from path) — moving it away still rewrites the policy.
+TRIM_POLICY_MV="$WORK/trim-policy-mv.diff"
+{
+  printf 'diff --git a/.github/review-policy.yml b/docs/old-policy.yml\n'
+  printf 'similarity index 90%%\nrename from .github/review-policy.yml\nrename to docs/old-policy.yml\n'
+  printf 'diff --git a/data/huge.jsonl b/data/huge.jsonl\n'
+  awk 'BEGIN { for (i = 0; i < 200; i++) printf "+POLICY-MV-%06d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n", i }'
+} > "$TRIM_POLICY_MV"
+set +e
+p4b_trim_review_diff "$TRIM_POLICY_MV" "$TRIM_OUT" 2000 'data/*' >/dev/null; rc=$?
+set -e
+[ "$rc" != 0 ] \
+  && pass "trim: policy file as a rename SOURCE also refuses omission (#668 provenance)" \
+  || fail "trim policy-rename-away diff should fail closed (rc=$rc)"
+
+# ...but an UNDER-budget diff touching the policy file passes through
+# verbatim: no omission happens, so the allowlist plays no role and the
+# provenance guard must not over-block ordinary policy PRs.
+rep="$(p4b_trim_review_diff "$TRIM_POLICY_IN" "$TRIM_OUT" 1000000 'data/*')" \
+  && cmp -s "$TRIM_POLICY_IN" "$TRIM_OUT" && [ -z "$rep" ] \
+  && pass "trim: under-budget policy-touching diff still passes through verbatim (#668)" \
+  || fail "trim under-budget policy-touching passthrough"
+
 # #636 round-2 P2: the omission loop must account for placeholder bytes.
 # Construct two allowlisted sections so that omitting only the largest gets
 # input-minus-omitted under budget, but the placeholder it adds pushes the
@@ -1040,6 +1172,30 @@ P4B_DIFF_MAX_BYTES=200 P4B_DIFF_OMIT_GLOBS='data/*' CLAUDE_BIN="$BIN/fake-claude
 set -e
 [ "$rc" = 4 ] && pass "claude adapter fails closed (exit 4) when nothing reviewable survives the budget" \
   || fail "claude adapter untrimmable diff should exit 4 (got $rc)"
+
+# #668 provenance: an over-budget diff that ALSO touches
+# .github/review-policy.yml must exit 4 (manual fallback) instead of
+# trusting the checkout's allowlist — the adapters inherit the mechanical
+# guard from p4b_trim_review_diff.
+HUGE_POLICY_DIFF="$WORK/huge-policy.diff"
+{
+  printf 'diff --git a/.github/review-policy.yml b/.github/review-policy.yml\n'
+  printf '+  diff_omit_globs:\n+    - "src/*"\n'
+  cat "$HUGE_DIFF"
+} > "$HUGE_POLICY_DIFF"
+set +e
+errout="$(P4B_DIFF_MAX_BYTES=2000 P4B_DIFF_OMIT_GLOBS='data/*' CODEX_BIN="$BIN/fake-codex-approve" bash "$AD_CODEX" --pr 1 --repo o/r --diff-file "$HUGE_POLICY_DIFF" 2>&1 >/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] && printf '%s' "$errout" | grep -q 'review-policy.yml'; then
+  pass "codex adapter refuses omission on a policy-touching over-budget diff (exit 4, cause named) (#668)"
+else fail "codex adapter policy-touching diff should exit 4 naming the policy file (rc=$rc, err=$errout)"; fi
+
+set +e
+errout="$(P4B_DIFF_MAX_BYTES=2000 P4B_DIFF_OMIT_GLOBS='data/*' CLAUDE_BIN="$BIN/fake-claude-approve-usage" bash "$AD_CLAUDE" --pr 1 --repo o/r --diff-file "$HUGE_POLICY_DIFF" 2>&1 >/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] && printf '%s' "$errout" | grep -q 'review-policy.yml'; then
+  pass "claude adapter refuses omission on a policy-touching over-budget diff (exit 4, cause named) (#668)"
+else fail "claude adapter policy-touching diff should exit 4 naming the policy file (rc=$rc, err=$errout)"; fi
 
 # CLI stderr must reach the failure message (#635: every nonzero rc used to
 # be reported as a plan-login problem; a context-overflow rc=1 read as an
@@ -1287,25 +1443,337 @@ if [ "$rc" = 4 ] && [ "$(printf '%s' "$out" | jq -r '.fell_back_to_manual')" = "
   pass "policy-required finding in APPROVED verdict → manual fallback, no auto-approve"
 else fail "policy-required finding fallback (rc=$rc): $out"; fi
 
-# Repo policy requires post-review issues for observations/risks flagged while
-# approving. The schema can carry advisory findings, but the automated poster
-# cannot clear the merge gate until that follow-up path has been handled.
+# Policy step 9 executor (#672): an APPROVED carrying discretionary findings
+# now FILES the post-review issues and posts, instead of discarding the
+# verdict into the manual handoff. Dry-run prints intent, files nothing, and
+# still reports a dry-run APPROVED.
 set +e
 out="$(MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
   bash "$ORCH" 133 --repo o/r --author claude --head abc123 --diff-file "$DIFF" --dry-run 2>/dev/null)"; rc=$?
 set -e
+if [ "$rc" = 0 ] \
+   && [ "$(printf '%s' "$out" | jq -r '.verdict')" = "APPROVED" ] \
+   && [ "$(printf '%s' "$out" | jq -r '.dry_run')" = "true" ]; then
+  pass "APPROVED with advisory findings dry-run → would file issues, no fallback (#672)"
+else fail "approved-with-advisory dry-run (rc=$rc): $out"; fi
+
+# #672 happy path: issues filed under the author token with the step-9 labels
+# and assignee, references appended to the posted APPROVED body.
+ISSUE_LOG="$WORK/issue-create.log"; : > "$ISSUE_LOG"
+P4B672_BODY="$WORK/p4b672-body.txt"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$ISSUE_LOG" \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b672-wrapper.log" \
+  P4B_WRAPPER_BODY="$P4B672_BODY" P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_CREATED_REVIEW_HEAD=abc123 \
+  bash "$ORCH" 134 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 0 ] && [ "$(printf '%s' "$out" | jq -r '.review_posted')" = "true" ]; then
+  pass "#672: APPROVED with advisory findings posts after filing issues"
+else fail "#672 happy path (rc=$rc): $out"; fi
+grep -q -- "--label post-review" "$ISSUE_LOG" && grep -q -- "--label observation" "$ISSUE_LOG" \
+  && pass "#672: filed issue carries the step-9 labels" || fail "#672: labels missing from issue create argv"
+grep -q -- "--assignee nathanjohnpayne" "$ISSUE_LOG" \
+  && pass "#672: filed issue assigned to the author identity" || fail "#672: assignee missing"
+grep -q "^VIA gh-as-author$" "$ISSUE_LOG" \
+  && pass "#672: issue writes routed through the author wrapper" || fail "#672: issue create not wrapper-routed"
+grep -q "post-review issue" "$P4B672_BODY" && grep -q "#901" "$P4B672_BODY" \
+  && pass "#672: posted APPROVED body carries the issue reference" || fail "#672: issue reference missing from review body"
+P2_FP="$(printf '%s|%s|%s|%s' P2 x.js 2 "should be handled under stricter policy" | cksum | cut -d' ' -f1)"
+grep -q "p4b-post-review o/r#134 head=abc123 finding=${P2_FP}" "${ISSUE_LOG}.body.1" \
+  && pass "#674: filed issue body embeds the content-fingerprinted dedup marker" || fail "#674: content-fingerprint marker missing from issue body"
+grep -q -- "--title \[Post-Review\]" "$ISSUE_LOG" || grep -q "\[Post-Review\]" "$ISSUE_LOG" \
+  && pass "#674: issue title follows the documented Post-Review convention" || fail "#674: Post-Review title prefix missing"
+# #675: the posted APPROVED body's accounting block records the filed advisory
+# with disposition=deferred-to-follow-up + its issue link (not unresolved/null),
+# and totals.advisory_issues_filed derives from it — so the machine-readable
+# record matches the prose "filed as #901" reference instead of contradicting
+# it. Extract the embedded p4b-accounting:v1 record and assert the enrichment.
+P4B675_REC="$(awk '/<!-- p4b-accounting:v1/{f=1;next} /^-->/{f=0} f' "$P4B672_BODY")"
+if [ -n "$P4B675_REC" ] && printf '%s' "$P4B675_REC" | jq -e '
+    (.totals.advisory_issues_filed == [901])
+    and ([ .unique_findings[]
+           | select(.disposition == "deferred-to-follow-up" and .issue == 901) ]
+         | length) == 1' >/dev/null 2>&1; then
+  pass "#675: filed advisory enriches the posted accounting record (deferred-to-follow-up + #901)"
+else fail "#675: accounting record not enriched with the filed issue (rec=$P4B675_REC)"; fi
+
+# #674 CodeRabbit: a marker match from a prior partially-failed run is
+# REUSED — no duplicate issue is created and the reference still lands.
+DEDUP_ISSUE_LOG="$WORK/issue-dedup.log"; : > "$DEDUP_ISSUE_LOG"
+DEDUP_BODY="$WORK/p4b674-dedup-body.txt"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$DEDUP_ISSUE_LOG" P4B_FAKE_EXISTING_ISSUE=1 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-dedup-wrapper.log" \
+  P4B_WRAPPER_BODY="$DEDUP_BODY" P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_CREATED_REVIEW_HEAD=abc123 \
+  bash "$ORCH" 140 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 0 ] && [ ! -s "$DEDUP_ISSUE_LOG" ] && grep -q "#777" "$DEDUP_BODY"; then
+  pass "#674: existing marker match reused (no duplicate issue; reference carried)"
+else fail "#674 dedup reuse (rc=$rc)"; fi
+
+# #674 CodeRabbit: an unrecognized post_review_issues value fails CLOSED
+# instead of silently failing open into auto-filing.
+POLICY_BAD_KNOB="$WORK/policy-bad-knob.yml"
+cat > "$POLICY_BAD_KNOB" <<'YAML'
+available_reviewers:
+  - nathanpayne-claude
+  - nathanpayne-cursor
+  - nathanpayne-codex
+default_external_reviewer: nathanpayne-codex
+author_identity: nathanjohnpayne
+phase_4b_automation:
+  enabled: true
+  mode: local
+  post_review_issues: nope
+YAML
+set +e
+out="$(MERGEPATH_REVIEW_POLICY_PATH="$POLICY_BAD_KNOB" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  bash "$ORCH" 141 --repo o/r --author claude --head abc123 --diff-file "$DIFF" --dry-run 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] \
+   && printf '%s' "$out" | jq -r '.reason' | grep -q "invalid phase_4b_automation.post_review_issues"; then
+  pass "#674: invalid post_review_issues value fails closed"
+else fail "#674 bad-knob fail-closed (rc=$rc): $out"; fi
+
+# #672 fail-closed: an issue-create failure refuses the approval (no review
+# POST is attempted) and falls back to the manual handoff.
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$WORK/issue-fail.log" P4B_FAKE_ISSUE_FAIL=1 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b672-fail-wrapper.log" \
+  P4B_FAKE_LIVE_HEAD=abc123 \
+  bash "$ORCH" 135 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
 if [ "$rc" = 4 ] \
    && [ "$(printf '%s' "$out" | jq -r '.fell_back_to_manual')" = "true" ] \
-   && [ "$(printf '%s' "$out" | jq -r '.reason')" = "approved verdict included findings; post-review issue filing is required before Phase 4b clearance" ]; then
-  pass "APPROVED with advisory findings → manual fallback until post-review issues exist"
-else fail "approved-with-advisory fallback (rc=$rc): $out"; fi
+   && printf '%s' "$out" | jq -r '.reason' | grep -q "issue filing failed"; then
+  pass "#672: issue-create failure refuses the approval (fail-closed)"
+else fail "#672 fail-closed (rc=$rc): $out"; fi
+[ ! -s "$WORK/p4b672-fail-wrapper.log" ] \
+  && pass "#672: no review POST attempted after filing failure" || fail "#672: review POST attempted despite filing failure"
+
+# #674 round 1: a head that drifted during the adapter run must refuse
+# BEFORE any side-effecting issue creation (post_review would refuse the
+# POST later, but by then the issues would already exist).
+DRIFT_ISSUE_LOG="$WORK/issue-drift.log"; : > "$DRIFT_ISSUE_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$DRIFT_ISSUE_LOG" \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-drift-wrapper.log" \
+  P4B_FAKE_LIVE_HEAD=def456 \
+  bash "$ORCH" 137 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] \
+   && printf '%s' "$out" | jq -r '.reason' | grep -q "refusing to file post-review issues"; then
+  pass "#674: head drift refuses BEFORE issue filing"
+else fail "#674 head-drift pre-check (rc=$rc): $out"; fi
+[ ! -s "$DRIFT_ISSUE_LOG" ] \
+  && pass "#674: no issues created for a drifted head" || fail "#674: issues created despite head drift"
+
+# #674 round 1: a finding whose wording flags a RISK files under the `risk`
+# label per policy step 9, not a hard-coded `observation`.
+RISK_ISSUE_LOG="$WORK/issue-risk.log"; : > "$RISK_ISSUE_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-risk" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$RISK_ISSUE_LOG" \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-risk-wrapper.log" \
+  P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_CREATED_REVIEW_HEAD=abc123 \
+  bash "$ORCH" 138 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 0 ] && grep -q -- "--label risk" "$RISK_ISSUE_LOG" && ! grep -q -- "--label observation" "$RISK_ISSUE_LOG"; then
+  pass "#674: risk-worded finding files under the risk label"
+else fail "#674 risk classification (rc=$rc)"; fi
+
+# #674 round 1: feedback_policy `ignore` tiers are never surfaced — no issue
+# is filed for them, and the approval still posts.
+POLICY_P3_IGNORE="$WORK/policy-p3-ignore.yml"
+cat > "$POLICY_P3_IGNORE" <<'YAML'
+available_reviewers:
+  - nathanpayne-claude
+  - nathanpayne-cursor
+  - nathanpayne-codex
+default_external_reviewer: nathanpayne-codex
+author_identity: nathanjohnpayne
+feedback_policy:
+  mode: by-priority
+  priorities:
+    p0: required
+    p1: required
+    p2: discretionary
+    p3: ignore
+phase_4b_automation:
+  enabled: true
+  mode: local
+YAML
+IGNORE_ISSUE_LOG="$WORK/issue-ignore.log"; : > "$IGNORE_ISSUE_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_P3_IGNORE" CODEX_BIN="$BIN/fake-codex-approve-p3" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$IGNORE_ISSUE_LOG" \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-ignore-wrapper.log" \
+  P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_CREATED_REVIEW_HEAD=abc123 \
+  bash "$ORCH" 139 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 0 ] && [ "$(printf '%s' "$out" | jq -r '.review_posted')" = "true" ] && [ ! -s "$IGNORE_ISSUE_LOG" ]; then
+  pass "#674: ignore-tier findings file nothing and the approval still posts"
+else fail "#674 ignore-tier filter (rc=$rc): $out"; fi
+
+# #674: token ownership lives in the identity-verifying author wrapper —
+# filing succeeds with an ambient reviewer token in the environment and no
+# preflight author PAT, and every write routes through gh-as-author.
+KEYRING_ISSUE_LOG="$WORK/issue-keyring.log"; : > "$KEYRING_ISSUE_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  GH_TOKEN=ambient-reviewer-token P4B_ISSUE_LOG="$KEYRING_ISSUE_LOG" \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" \
+  P4B_WRAPPER_LOG="$WORK/p4b674-keyring-wrapper.log" \
+  P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_CREATED_REVIEW_HEAD=abc123 \
+  bash "$ORCH" 142 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 0 ] \
+   && grep -q "^VIA gh-as-author$" "$KEYRING_ISSUE_LOG" \
+   && [ "$(printf '%s' "$out" | jq -r '.review_posted')" = "true" ]; then
+  pass "#674: filing under an ambient reviewer token routes through the author wrapper"
+else fail "#674 wrapper token ownership (rc=$rc)"; fi
+
+# #674 CodeRabbit Major: a dedup search ERROR fails the filing closed —
+# never read as "no existing issue".
+SEARCHFAIL_LOG="$WORK/issue-searchfail.log"; : > "$SEARCHFAIL_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$SEARCHFAIL_LOG" P4B_FAKE_SEARCH_FAIL=1 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" \
+  P4B_WRAPPER_LOG="$WORK/p4b674-searchfail-wrapper.log" P4B_FAKE_LIVE_HEAD=abc123 \
+  bash "$ORCH" 148 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] \
+   && printf '%s' "$out" | jq -r '.reason' | grep -q "issue filing failed" \
+   && ! grep -q "^ARGV " "$SEARCHFAIL_LOG"; then
+  pass "#674: dedup search error fails closed with no issue created"
+else fail "#674 search-error fail-closed (rc=$rc): $out"; fi
+[ ! -s "$WORK/p4b674-searchfail-wrapper.log" ] \
+  && pass "#674: no review POST after a search error" || fail "#674: review POST attempted after search error"
+
+# #674 round 2: a partial filing failure surfaces the already-filed refs in
+# the fallback reason (the dedup marker makes a rerun reuse them).
+PARTIAL_ISSUE_LOG="$WORK/issue-partial.log"; : > "$PARTIAL_ISSUE_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-2p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$PARTIAL_ISSUE_LOG" P4B_FAKE_ISSUE_FAIL_AFTER_1=1 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-partial-wrapper.log" \
+  P4B_FAKE_LIVE_HEAD=abc123 \
+  bash "$ORCH" 143 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] \
+   && printf '%s' "$out" | jq -r '.reason' | grep -q "partial refs: #901"; then
+  pass "#674: partial filing failure surfaces the orphan refs in the fallback"
+else fail "#674 partial-orphan surfacing (rc=$rc): $out"; fi
+grep -q "^CLOSE #901$" "$PARTIAL_ISSUE_LOG" \
+  && pass "#674: partial orphans closed as superseded (round-4 self-cleanup)" || fail "#674: partial orphan not closed"
+[ ! -s "$WORK/p4b674-partial-wrapper.log" ] \
+  && pass "#674: no review POST after a partial filing failure" || fail "#674: review POST attempted after partial failure"
+
+# #674 round 4: a head that drifts DURING filing refuses at the post-file
+# recheck, and the just-filed issues are closed as superseded.
+DRIFT2_ISSUE_LOG="$WORK/issue-drift2.log"; : > "$DRIFT2_ISSUE_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$DRIFT2_ISSUE_LOG" \
+  P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_LIVE_HEAD2=def456 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-drift2-wrapper.log" \
+  bash "$ORCH" 145 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] \
+   && printf '%s' "$out" | jq -r '.reason' | grep -q "changed while filing post-review issues" \
+   && grep -q "^ARGV " "$DRIFT2_ISSUE_LOG" \
+   && grep -q "^CLOSE #901$" "$DRIFT2_ISSUE_LOG"; then
+  pass "#674: mid-filing head drift refuses and closes the filed issues"
+else fail "#674 mid-filing drift cleanup (rc=$rc): $out"; fi
+[ ! -s "$WORK/p4b674-drift2-wrapper.log" ] \
+  && pass "#674: no review POST after mid-filing drift" || fail "#674: review POST attempted after mid-filing drift"
+
+# #674 round 3: a mixed filed+ignored approval body claims filing only for
+# the filed subset and names the suppressed remainder.
+MIXED_ISSUE_LOG="$WORK/issue-mixed.log"; : > "$MIXED_ISSUE_LOG"
+MIXED_BODY="$WORK/p4b674-mixed-body.txt"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_P3_IGNORE" CODEX_BIN="$BIN/fake-codex-approve-p2p3" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$MIXED_ISSUE_LOG" \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-mixed-wrapper.log" \
+  P4B_WRAPPER_BODY="$MIXED_BODY" P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_CREATED_REVIEW_HEAD=abc123 \
+  bash "$ORCH" 144 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 0 ] \
+   && [ "$(grep -c '^ARGV ' "$MIXED_ISSUE_LOG")" = "1" ] \
+   && grep -q "1 of the findings above were filed" "$MIXED_BODY" \
+   && grep -q "ignore tiers and were deliberately not surfaced" "$MIXED_BODY"; then
+  pass "#674: mixed approval body claims filing only for the filed subset"
+else fail "#674 mixed filed/ignored body wording (rc=$rc)"; fi
+
+# #674 round 5: a REUSED prior-run issue is never closed by this run's
+# failure cleanup — only refs this invocation created are.
+REUSE_ISSUE_LOG="$WORK/issue-reuse-fail.log"; : > "$REUSE_ISSUE_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-2p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$REUSE_ISSUE_LOG" \
+  P4B_FAKE_EXISTING_ISSUE_ONCE=1 P4B_FAKE_ISSUE_FAIL=1 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-reuse-wrapper.log" \
+  P4B_FAKE_LIVE_HEAD=abc123 \
+  bash "$ORCH" 146 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] && ! grep -q "^CLOSE #777$" "$REUSE_ISSUE_LOG"; then
+  pass "#674: reused prior-run issue is NOT closed by this run's failure cleanup"
+else fail "#674 reused-ref protection (rc=$rc)"; fi
+
+# #674 round 5: drift landing in the render window (after the post-file
+# recheck, before the POST) still closes this run's filed issues.
+LATE_ISSUE_LOG="$WORK/issue-late-drift.log"; : > "$LATE_ISSUE_LOG"
+set +e
+out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  OP_PREFLIGHT_AUTHOR_PAT=fake-author-pat P4B_ISSUE_LOG="$LATE_ISSUE_LOG" \
+  P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_LIVE_HEAD2=def456 P4B_FAKE_LIVE_HEAD2_FROM=3 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/p4b674-late-wrapper.log" \
+  bash "$ORCH" 147 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] \
+   && printf '%s' "$out" | jq -r '.reason' | grep -q "changed during review" \
+   && grep -q "^CLOSE #901$" "$LATE_ISSUE_LOG"; then
+  pass "#674: render-window drift closes this run's filed issues before refusing"
+else fail "#674 late-drift cleanup (rc=$rc): $out"; fi
+[ ! -s "$WORK/p4b674-late-wrapper.log" ] \
+  && pass "#674: no review POST after render-window drift" || fail "#674: review POST attempted after late drift"
+
+# #672 opt-out: post_review_issues: false restores the pre-#672 refusal.
+POLICY_NO_ISSUES="$WORK/policy-no-issues.yml"
+cat > "$POLICY_NO_ISSUES" <<'YAML'
+available_reviewers:
+  - nathanpayne-claude
+  - nathanpayne-cursor
+  - nathanpayne-codex
+default_external_reviewer: nathanpayne-codex
+author_identity: nathanjohnpayne
+phase_4b_automation:
+  enabled: true
+  mode: local
+  post_review_issues: false
+YAML
+set +e
+out="$(MERGEPATH_REVIEW_POLICY_PATH="$POLICY_NO_ISSUES" CODEX_BIN="$BIN/fake-codex-approve-p2" \
+  bash "$ORCH" 136 --repo o/r --author claude --head abc123 --diff-file "$DIFF" --dry-run 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" = 4 ] \
+   && [ "$(printf '%s' "$out" | jq -r '.fell_back_to_manual')" = "true" ] \
+   && printf '%s' "$out" | jq -r '.reason' | grep -q "post_review_issues is false"; then
+  pass "#672: post_review_issues: false restores the refusal"
+else fail "#672 opt-out (rc=$rc): $out"; fi
 
 # Stale-head guard: a non-dry-run APPROVED must re-read the live head and
 # fall back before the wrapper writes if the reviewed SHA is no longer live.
 WRAPPER_LOG="$WORK/wrapper.log"
 set +e
 out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve" \
-  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_WRAPPER_LOG="$WRAPPER_LOG" P4B_FAKE_LIVE_HEAD=def456 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WRAPPER_LOG" P4B_FAKE_LIVE_HEAD=def456 \
   bash "$ORCH" 127 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
 set -e
 if [ "$rc" = 4 ] \
@@ -1320,7 +1788,7 @@ WRAPPER_BODY="$WORK/wrapper-success-body.md"
 WRAPPER_PAYLOAD="$WORK/wrapper-success-payload.json"
 set +e
 out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve" \
-  OP_PREFLIGHT_REVIEWER_PAT=wrong-current-agent-token P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_WRAPPER_LOG="$WRAPPER_LOG" P4B_WRAPPER_BODY="$WRAPPER_BODY" P4B_WRAPPER_PAYLOAD="$WRAPPER_PAYLOAD" P4B_FAKE_LIVE_HEAD=abc123 \
+  OP_PREFLIGHT_REVIEWER_PAT=wrong-current-agent-token P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WRAPPER_LOG" P4B_WRAPPER_BODY="$WRAPPER_BODY" P4B_WRAPPER_PAYLOAD="$WRAPPER_PAYLOAD" P4B_FAKE_LIVE_HEAD=abc123 \
   bash "$ORCH" 129 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
 set -e
 if [ "$rc" = 0 ] \
@@ -1341,7 +1809,7 @@ WRAPPER_BODY="$WORK/wrapper-mismatch-body.md"
 WRAPPER_PAYLOAD="$WORK/wrapper-mismatch-payload.json"
 set +e
 out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CODEX_BIN="$BIN/fake-codex-approve" \
-  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_WRAPPER_LOG="$WRAPPER_LOG" P4B_WRAPPER_BODY="$WRAPPER_BODY" P4B_WRAPPER_PAYLOAD="$WRAPPER_PAYLOAD" P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_CREATED_REVIEW_HEAD=def456 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WRAPPER_LOG" P4B_WRAPPER_BODY="$WRAPPER_BODY" P4B_WRAPPER_PAYLOAD="$WRAPPER_PAYLOAD" P4B_FAKE_LIVE_HEAD=abc123 P4B_FAKE_CREATED_REVIEW_HEAD=def456 \
   bash "$ORCH" 132 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
 set -e
 if [ "$rc" = 3 ] && jq -e '.commit_id == "abc123" and .event == "APPROVE"' "$WRAPPER_PAYLOAD" >/dev/null; then
@@ -1353,7 +1821,7 @@ WRAPPER_BODY="$WORK/wrapper-usage-body.md"
 WRAPPER_PAYLOAD="$WORK/wrapper-usage-payload.json"
 set +e
 out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$POLICY_ON" CLAUDE_BIN="$BIN/fake-claude-approve-usage" \
-  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_WRAPPER_LOG="$WRAPPER_LOG" P4B_WRAPPER_BODY="$WRAPPER_BODY" P4B_WRAPPER_PAYLOAD="$WRAPPER_PAYLOAD" P4B_FAKE_LIVE_HEAD=abc123 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WRAPPER_LOG" P4B_WRAPPER_BODY="$WRAPPER_BODY" P4B_WRAPPER_PAYLOAD="$WRAPPER_PAYLOAD" P4B_FAKE_LIVE_HEAD=abc123 \
   bash "$ORCH" 130 --repo o/r --author codex --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
 set -e
 if [ "$rc" = 0 ] \
@@ -1543,7 +2011,7 @@ echo "orchestrator — policy-driven timeout/effort (#589)"
 EFFORT_BODY="$WORK/orch-effort-body.md"
 set +e
 out="$(PATH="$BIN:$PATH" MERGEPATH_REVIEW_POLICY_PATH="$WORK/policy-te.yml" CODEX_BIN="$BIN/fake-codex-effort" \
-  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_WRAPPER_LOG="$WORK/orch-effort-wrapper.log" P4B_WRAPPER_BODY="$EFFORT_BODY" P4B_FAKE_LIVE_HEAD=abc123 \
+  P4B_GH_AS_REVIEWER="$BIN/fake-gh-as-reviewer" P4B_GH_AS_AUTHOR="$BIN/fake-gh-as-author" P4B_WRAPPER_LOG="$WORK/orch-effort-wrapper.log" P4B_WRAPPER_BODY="$EFFORT_BODY" P4B_FAKE_LIVE_HEAD=abc123 \
   bash "$ORCH" 140 --repo o/r --author claude --head abc123 --diff-file "$DIFF" 2>/dev/null)"; rc=$?
 set -e
 if [ "$rc" = 0 ] \


### PR DESCRIPTION
Bulk sync to [mergepath@fd103f8](https://github.com/nathanjohnpayne/mergepath/commit/fd103f8a098b3c183aa7905c91de6a2e753516b3) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

@coderabbitai ignore

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/lib/gh-retry-helpers.sh
  - scripts/lib/gh-token-resolver.sh
  - scripts/lib/manifest-fact-helpers.sh
  - scripts/lib/template-substitution.sh
  - scripts/lib/reviewers-helpers.sh
  - scripts/lib/ensure-yq.sh
  - scripts/coderabbit-wait.sh
  - scripts/coderabbit-automerge-rate-limit-gate.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/codex-record-feedback.sh
  - scripts/phase-4b-classifier.sh
  - scripts/phase-4b-review.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/coderabbit-severity-gate.sh
  - scripts/coderabbit-record-feedback.sh
  - scripts/lib/feedback-policy-helpers.sh
  - scripts/lib/lint-tooling.sh
  - scripts/audit-propagation-lane.sh
  - tests/test_audit_propagation_lane.sh
  - scripts/merge-clearance-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_gh_wrapper_parallel.sh
  - tests/test_check_no_bare_gh_writes.sh
  - tests/test_identity_check.sh
  - tests/test_coderabbit_wait_identity_derivation.sh
  - tests/test_coderabbit_wait_status_probe.sh
  - tests/test_coderabbit_wait_paused.sh
  - tests/test_coderabbit_wait_codex_failover.sh
  - tests/test_coderabbit_automerge_rate_limit_gate.sh
  - tests/test_coderabbit_wait_statuscontext_ratelimit.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_match_protected_paths.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_coderabbit_severity_gate.sh
  - tests/test_feedback_policy_helpers.sh
  - tests/test_lint_tooling.sh
  - tests/test_codex_review_request_ack.sh
  - tests/test_codex_review_request_trigger_only.sh
  - tests/test_codex_review_request_entry.sh
  - tests/test_codex_review_request_verdict.sh
  - tests/test_codex_review_check_resolution.sh
  - tests/test_codex_review_check_verdict.sh
  - tests/test_codex_review_check_required_checks.sh
  - tests/test_465_fail_closed.sh
  - tests/test_655_repo_lint_local_observed.sh
  - tests/test_codex_record_feedback.sh
  - tests/test_coderabbit_record_feedback.sh
  - tests/test_merge_clearance_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_phase_4b_automation.sh
  - tests/test_phase_4b_accounting.sh
  - tests/fixtures/phase_4b_verdicts.jsonl
  - tests/test_op_preflight_check.sh
  - tests/test_op_preflight_token_mode.sh
  - tests/test_helper_autosource.sh
  - tests/test_preflight_agent_name.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_resolve_pr_threads_staleness_pagination.sh
  - tests/test_resolve_pr_threads_verified_propagation.sh
  - tests/test_daily_feedback_rollup.sh
  - tests/test_template_substitution.sh
  - tests/test_export_consumer_facts.sh
  - tests/test_check_coderabbit_config.sh
  - tests/test_check_propagation_closure.sh
  - .github/pull_request_template.md
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/coderabbit-severity-gate.yml
  - .github/workflows/merge-clearance-gate.yml
  - .github/workflows/daily-feedback-rollup.yml
  - .github/workflows/repo_lint.yml

## Kit paths synced
  - .github/ISSUE_TEMPLATE/ (kit, allow-extras)
  - scripts/phase-4b/ (kit, allow-extras)
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.cjs.js)


Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@fd103f8 HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.