### PR TITLE
fix(share-view): use semantic section for payment summary landmark

### DIFF
--- a/src/app/views/ShareView.jsx
+++ b/src/app/views/ShareView.jsx
@@ -543,7 +543,7 @@ function PaymentSummarySection({ ps }) {
     // two that still matter (share, annual); owed/unpaid keeps annual, paid, and
     // the outstanding balance plus the progress bar.
     return (
-        <div className="share-section share-summary-stats" role="region" aria-label="Payment summary">
+        <section className="share-section share-summary-stats" aria-label="Payment summary">
             <div className="share-stat-grid">
                 {isSettled ? (
                     <>
@@ -567,7 +567,7 @@ function PaymentSummarySection({ ps }) {
                     <div className="share-progress-label">{pctPaid}% paid</div>
                 </>
             )}
-        </div>
+        </section>
     );
 }
 


### PR DESCRIPTION
Authoring-Agent: claude

Closes #385

## Changes

- #385: PaymentSummarySection in src/app/views/ShareView.jsx swaps the div role=region wrapper for a native section element that provides the region landmark implicitly via aria-label. No visual or behavioral change. Existing role-based test queries pass unchanged.

## Verification

- npx vitest run tests/react/views/ShareView.test.jsx - 73 passed.
- npx eslint src/app/views/ShareView.jsx - clean.
- node_modules symlinked from main checkout locally to run checks only, removed before commit.

## Self-Review

Minimal 2-line diff, verified finding against current code before editing, no .github changes, existing tests pass unmodified.