### PR TITLE
fix(charge-notice): hoist chargeNoticeId guard before share-link side effects (#386)

### DIFF
--- a/src/lib/ChargeNoticeService.js
+++ b/src/lib/ChargeNoticeService.js
@@ -52,6 +52,16 @@ export async function issueChargeNotice(opts, deps = {}) {
         activeYear, settings,
     } = opts;
 
+    // Guard the id first, before any side effect: an absent/blank chargeNoticeId would
+    // otherwise stringify to a shared key like "undefined" and silently overwrite an
+    // unrelated dispute doc (CodeRabbit #369). Validate up front so invalid input fails
+    // fast — before we mint (and prune) the member's share links or build the doc — and
+    // reuse the validated noticeId at the setDoc call site below.
+    const noticeId = String(chargeNoticeId ?? '').trim();
+    if (!noticeId || noticeId === 'undefined' || noticeId === 'null') {
+        throw new Error('issueChargeNotice requires a valid chargeNoticeId to key the notice doc.');
+    }
+
     // 1. Best-effort: mint a member share link carrying usageCharges:read so the
     //    member can review the charge on their share page. If it fails, the notice
     //    is still recorded and emailed (the member can use an existing link).
@@ -88,17 +98,11 @@ export async function issueChargeNotice(opts, deps = {}) {
         charges,
         ...(tokenHash ? { tokenHash } : {}),
     });
-    // Deterministic id keyed to the chargeNoticeId so a retry overwrites the same
-    // dispute doc instead of appending a duplicate (and re-triggering the member
-    // notification) — PR #328 review r3447513514. billDeferredCharges() stamps a
-    // unique chargeNoticeId per Charge Notice, so one notice maps to exactly one doc.
-    // Guard the id first: an absent/blank chargeNoticeId would otherwise stringify to
-    // a shared key like "undefined" and silently overwrite an unrelated dispute doc
-    // (CodeRabbit #369). Fail loudly instead of corrupting the subcollection.
-    const noticeId = String(chargeNoticeId ?? '').trim();
-    if (!noticeId || noticeId === 'undefined' || noticeId === 'null') {
-        throw new Error('issueChargeNotice requires a valid chargeNoticeId to key the notice doc.');
-    }
+    // Deterministic id keyed to the chargeNoticeId (validated above) so a retry
+    // overwrites the same dispute doc instead of appending a duplicate (and
+    // re-triggering the member notification) — PR #328 review r3447513514.
+    // billDeferredCharges() stamps a unique chargeNoticeId per Charge Notice, so one
+    // notice maps to exactly one doc.
     const col = collection(db, 'users', userId, 'billingYears', billingYearId, 'disputes');
     await setDoc(doc(col, noticeId), { ...noticeDoc, createdAt: serverTimestamp() });
 

--- a/tests/react/lib/ChargeNoticeService.test.js
+++ b/tests/react/lib/ChargeNoticeService.test.js
@@ -86,6 +86,10 @@ describe('issueChargeNotice', () => {
         const opts = { ...baseOpts(), chargeNoticeId: badId };
         await expect(issueChargeNotice(opts, { createShareLink, queueEmailFn })).rejects.toThrow(/valid chargeNoticeId/);
         expect(mockSetDoc).not.toHaveBeenCalled();
+        // The guard must fire BEFORE any side effect (#386): an invalid id must not mint
+        // (and prune) the member's share links, nor queue an email, before it throws.
+        expect(createShareLink).not.toHaveBeenCalled();
+        expect(queueEmailFn).not.toHaveBeenCalled();
     });
 
     it('mints a share link with the usageCharges:read scope and stamps its tokenHash on the doc', async () => {


### PR DESCRIPTION
Authoring-Agent: claude

Fixes a guard-ordering correctness bug in the charge-notice issuance path surfaced by a review-thread sweep.

Closes #386

## Changes

- **#386 — `issueChargeNotice`: `chargeNoticeId` guard fired after share-link side effects.** The validation that rejects an invalid/blank `chargeNoticeId` (added in PR #369) ran only after `createShareLink` had already minted a new member share link and pruned the member's existing share links, and after the notice doc was built. An invalid input therefore revoked existing share links before the function threw. Hoisted the `noticeId` validation to the very top of `issueChargeNotice` — before any side effect — so invalid input fails fast with no share-link churn, then reused the single validated `noticeId` at the `setDoc` call site (dropping the now-redundant later derivation). Extended the existing regression test to assert `createShareLink` and `queueEmailFn` are never invoked when the guard fires.

## Verification

- `npx vitest run tests/react/lib/ChargeNoticeService.test.js` — 1 file, 12 tests passing (includes the strengthened rejection cases).
- `npx eslint src/lib/ChargeNoticeService.js tests/react/lib/ChargeNoticeService.test.js` — clean (exit 0).
- Dependencies were installed with `--legacy-peer-deps` to work around a pre-existing `@eslint/js`/`eslint` peer-dependency conflict on `main` (unrelated to this change); the resulting `package-lock.json` churn was reverted and is not part of this PR. The full `npm test` suite (functions + secrets + e2e) was not run — those need Node functions/Playwright infra outside this change's scope; the changed unit and lint checks are green.

## Self-Review

- Verified the finding against current `main` before changing: the guard at the old location ran after `createShareLink` (mint + prune) and `buildChargeNoticeDoc`, confirming the reported ordering bug.
- The hoisted guard preserves identical validation semantics (same `String(chargeNoticeId ?? '').trim()` normalization and the same empty/`'undefined'`/`'null'` rejection set and error message) — only the position changed, so the existing passing cases are unaffected.
- `noticeId` is now derived once and reused; no behavioral change to the happy path (idempotent-key and tokenHash tests still pass).
- Scope is one file plus its test; no `.github/` or protected paths touched; diff is ~19 lines.
